### PR TITLE
Unify use of the rid parameter of msgRecv, msgRespond functions

### DIFF
--- a/proc/test_msg.c
+++ b/proc/test_msg.c
@@ -127,7 +127,7 @@ int test_ping(unsigned seed, unsigned port, unsigned count)
 int test_pong(unsigned port)
 {
 	msg_t msg;
-	unsigned rid;
+	unsigned long rid;
 
 	printf("test_msg/pong: starting\n");
 


### PR DESCRIPTION
Accordingly to phoenix-rtos/libphoenix#70 (comment)