### PR TITLE
runner: add 'install' target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ TARGET ?= ia32-generic
 include ../phoenix-rtos-build/Makefile.common
 include ../phoenix-rtos-build/Makefile.$(TARGET_SUFF)
 
+INSTALL_PROGS :=
 
 .PHONY: clean
 clean:
@@ -32,7 +33,7 @@ ifneq ($(filter clean,$(MAKECMDGOALS)),)
 	$(shell rm -rf $(BUILD_DIR))
 endif
 
-T1 := $(filter-out clean all,$(MAKECMDGOALS))
+T1 := $(filter-out clean all install,$(MAKECMDGOALS))
 ifneq ($(T1),)
 	include $(T1)/Makefile
 .PHONY: $(T1)
@@ -46,9 +47,16 @@ else
 	include fs/Makefile
 	include disk/Makefile
 	#include virtio/Makefile
-	include sample/helloworld/Makefile
-	include sample/test/Makefile
-	include sample/test/fails/Makefile
+	include sample/Makefile
 	include setjmp/Makefile
 
 endif
+
+PREFIX_INSTALL = $(PREFIX_FS)bin/
+
+$(addprefix $(PREFIX_INSTALL), $(INSTALL_PROGS)): $(PREFIX_INSTALL)% : $(PREFIX_PROG_STRIPPED)%
+	$(INSTALL_FS)
+
+all: $(addprefix $(PREFIX_PROG), $(INSTALL_PROGS))
+
+install: $(addprefix $(PREFIX_INSTALL), $(INSTALL_PROGS))

--- a/runner.py
+++ b/runner.py
@@ -56,9 +56,9 @@ def parse_args():
                              "If flag is not used then runner searches for tests in "
                              "phoenix-rtos-tests directory. Flag can be used multiple times.")
 
-    parser.add_argument("--no-build",
+    parser.add_argument("--build",
                         default=False, action='store_true',
-                        help="Omit building step.")
+                        help="Runner will build all tests.")
 
     parser.add_argument("-l", "--log-level",
                         default='info',
@@ -85,7 +85,7 @@ def main():
 
     runner = TestsRunner(targets=args.target,
                          test_paths=args.test,
-                         build=not args.no_build)
+                         build=args.build)
 
     passed, failed, skipped = runner.run()
 

--- a/sample/Makefile
+++ b/sample/Makefile
@@ -1,0 +1,2 @@
+include sample/test/Makefile
+include sample/helloworld/Makefile

--- a/sample/helloworld/Makefile
+++ b/sample/helloworld/Makefile
@@ -1,4 +1,4 @@
-$(PREFIX_PROG)helloworld: $(PREFIX_O)sample/helloworld/main.o
+$(PREFIX_PROG)test-helloworld: $(PREFIX_O)sample/helloworld/main.o
 	$(LINK)
 
-all: $(addprefix $(PREFIX_PROG_STRIPPED), helloworld)
+INSTALL_PROGS += test-helloworld

--- a/sample/helloworld/test.yaml
+++ b/sample/helloworld/test.yaml
@@ -1,5 +1,5 @@
 test:
-    syspage: test-helloworld
     tests:
         - name: main
           harness: test.py
+          exec: test-helloworld

--- a/sample/helloworld/test.yaml
+++ b/sample/helloworld/test.yaml
@@ -1,5 +1,5 @@
 test:
-    syspage: helloworld
+    syspage: test-helloworld
     tests:
-        - name: helloworld
+        - name: main
           harness: test.py

--- a/sample/test/Makefile
+++ b/sample/test/Makefile
@@ -1,8 +1,15 @@
-$(PREFIX_PROG)sample_echo: $(PREFIX_O)sample/test/test-echo.o
+include sample/test/fails/Makefile
+
+HARNESS_PROGS := test-echo
+
+UNITY_PROGS := test-unity
+
+CURR_DIR := sample/test/
+
+INSTALL_PROGS += $(HARNESS_PROGS) $(UNITY_PROGS)
+
+$(addprefix $(PREFIX_PROG), $(HARNESS_PROGS)): $(PREFIX_PROG)%: $(PREFIX_O)$(CURR_DIR)%.o
 	$(LINK)
 
-$(PREFIX_PROG)sample_unity: $(PREFIX_O)sample/test/test-unity.o $(PREFIX_A)unity.a
+$(addprefix $(PREFIX_PROG), $(UNITY_PROGS)): $(PREFIX_PROG)%: $(PREFIX_O)$(CURR_DIR)%.o $(PREFIX_A)unity.a
 	$(LINK)
-
-all: $(addprefix $(PREFIX_PROG_STRIPPED), sample_echo sample_unity)
-

--- a/sample/test/fails/Makefile
+++ b/sample/test/fails/Makefile
@@ -1,18 +1,13 @@
-$(PREFIX_PROG)fail_output_1: $(PREFIX_O)sample/test/fails/test-fail-output-1.o
+HARNESS_PROGS := test-fail-output-1 test-fail-output-2 test-fail-exception
+
+UNITY_PROGS := test-fail-unity test-fail-unity-exc
+
+CURR_DIR := sample/test/fails/
+
+INSTALL_PROGS += $(HARNESS_PROGS) $(UNITY_PROGS)
+
+$(addprefix $(PREFIX_PROG), $(HARNESS_PROGS)): $(PREFIX_PROG)%: $(PREFIX_O)$(CURR_DIR)%.o
 	$(LINK)
 
-$(PREFIX_PROG)fail_output_2: $(PREFIX_O)sample/test/fails/test-fail-output-2.o
+$(addprefix $(PREFIX_PROG), $(UNITY_PROGS)): $(PREFIX_PROG)%: $(PREFIX_O)$(CURR_DIR)%.o $(PREFIX_A)unity.a
 	$(LINK)
-
-$(PREFIX_PROG)fail_exception: $(PREFIX_O)sample/test/fails/test-fail-exception.o
-	$(LINK)
-
-$(PREFIX_PROG)fail_unity: $(PREFIX_O)sample/test/fails/test-fail-unity.o $(PREFIX_A)unity.a
-	$(LINK)
-
-$(PREFIX_PROG)fail_unity_exception: $(PREFIX_O)sample/test/fails/test-fail-unity-exc.o $(PREFIX_A)unity.a
-	$(LINK)
-
-all: $(addprefix $(PREFIX_PROG_STRIPPED), fail_output_1 fail_output_2 fail_unity fail_exception \
-					fail_unity_exception)
-

--- a/sample/test/fails/test.yaml
+++ b/sample/test/fails/test.yaml
@@ -2,22 +2,22 @@ test:
     ignore: true
     tests:
         - name: fail-output-1
-          syspage: test-fail-output-1
+          exec: test-fail-output-1
           harness: test-fail-output-1.py
 
         - name: fail-output-2
-          syspage: test-fail-output-2
+          exec: test-fail-output-2
           harness: test-fail-output-2.py
 
         - name: fail-exception
-          syspage: test-fail-exception
+          exec: test-fail-exception
           harness: test-fail-exception.py
 
         - name: fail-unity
-          syspage: test-fail-unity
+          exec: test-fail-unity
           type: unit
 
         - name: fail-unity-exception
-          syspage: test-fail-unity-exc
+          exec: test-fail-unity-exc
           type: unit
 

--- a/sample/test/fails/test.yaml
+++ b/sample/test/fails/test.yaml
@@ -2,22 +2,22 @@ test:
     ignore: true
     tests:
         - name: fail-output-1
-          syspage: fail_output_1
+          syspage: test-fail-output-1
           harness: test-fail-output-1.py
 
         - name: fail-output-2
-          syspage: fail_output_2
+          syspage: test-fail-output-2
           harness: test-fail-output-2.py
 
         - name: fail-exception
-          syspage: fail_exception
+          syspage: test-fail-exception
           harness: test-fail-exception.py
 
         - name: fail-unity
-          syspage: fail_unity
+          syspage: test-fail-unity
           type: unit
 
         - name: fail-unity-exception
-          syspage: fail_unity_exception
+          syspage: test-fail-unity-exc
           type: unit
 

--- a/sample/test/test.yaml
+++ b/sample/test/test.yaml
@@ -1,10 +1,10 @@
 test:
     tests:
         - name: echo
-          syspage: test-echo
+          exec: test-echo
           harness: test-echo.py
 
         - name: unity
-          syspage: test-unity
+          exec: test-unity
           type: unit
 

--- a/sample/test/test.yaml
+++ b/sample/test/test.yaml
@@ -1,10 +1,10 @@
 test:
     tests:
         - name: echo
-          syspage: sample_echo
+          syspage: test-echo
           harness: test-echo.py
 
         - name: unity
-          syspage: sample_unity
+          syspage: test-unity
           type: unit
 

--- a/setjmp/Makefile
+++ b/setjmp/Makefile
@@ -1,4 +1,4 @@
-$(PREFIX_PROG)test_setjmp: $(PREFIX_O)setjmp/setjmp.o $(PREFIX_A)unity.a
+$(PREFIX_PROG)test-setjmp: $(PREFIX_O)setjmp/setjmp.o $(PREFIX_A)unity.a
 	$(LINK)
 
-all: $(addprefix $(PREFIX_PROG_STRIPPED), test_setjmp)
+INSTALL_PROGS += test-setjmp

--- a/setjmp/test.yaml
+++ b/setjmp/test.yaml
@@ -2,5 +2,5 @@ test:
     type: unit
     tests:
         - name: unit
-          syspage: test-setjmp
+          exec: test-setjmp
 

--- a/setjmp/test.yaml
+++ b/setjmp/test.yaml
@@ -2,5 +2,5 @@ test:
     type: unit
     tests:
         - name: unit
-          syspage: test_setjmp
+          syspage: test-setjmp
 

--- a/trunner/builder.py
+++ b/trunner/builder.py
@@ -96,6 +96,7 @@ class TargetBuilder:
                           'clean',
                           'core',
                           'fs',
+                          'test',
                           'image',
                           'project'])
 
@@ -111,20 +112,6 @@ class IA32Builder(TargetBuilder):
     def prebuild_action(self, user_syspage=None, **kwargs):
         # We run test binaries from filesystem, set only default syspage
         self.env['SYSPAGE'] = " ".join(self.SYSPAGE[self.target])
-
-    def postbuild_action(self, user_syspage=None, **kwargs):
-        if not user_syspage:
-            return
-
-        logging.info(f"Installing {' '.join(user_syspage)} to filesystem for {self.target}\n")
-        build_dir = PHRTOS_PROJECT_DIR / f"_build/{self.target}/prog.stripped"
-        syspage_dir = pathlib.Path("/root/bin")
-
-        self.fs_mkdir(syspage_dir)
-        for prog in user_syspage:
-            self.fs_install(syspage_dir, build_dir / prog, 0o755)
-
-        self.run_command(['./phoenix-rtos-build/build.sh', 'image'])
 
 
 class TargetBuilderFactory:

--- a/trunner/config.py
+++ b/trunner/config.py
@@ -9,6 +9,9 @@ import yaml
 PHRTOS_PROJECT_DIR = pathlib.Path(os.getcwd())
 PHRTOS_TEST_DIR = PHRTOS_PROJECT_DIR / 'phoenix-rtos-tests'
 
+# Default time after pexpect will raise TIEMOUT exception if nothing matches an expected pattern
+PYEXPECT_TIMEOUT = 8
+
 def remove_prefix(string, prefix):
     if string.startswith(prefix):
         return string[len(prefix):]
@@ -40,7 +43,7 @@ class YAMLParser:
         self.parsed_tests = []
 
     def parse_test_case(self, config):
-        allowed_keys = ('exec', 'type', 'harness', 'name', 'ignore')
+        allowed_keys = ('exec', 'type', 'harness', 'name', 'ignore', 'timeout')
         mandatory_keys = ('exec', 'name')
 
         unnecessary_keys = set(config) - set(allowed_keys)
@@ -61,6 +64,7 @@ class YAMLParser:
         # If type is not known assume that it's a unit test
         config.setdefault('type', 'unit')
         config.setdefault('ignore', False)
+        config.setdefault('timeout', PYEXPECT_TIMEOUT)
 
         if not isinstance(config['ignore'], bool):
             config['ignore'] = False

--- a/trunner/config.py
+++ b/trunner/config.py
@@ -40,8 +40,8 @@ class YAMLParser:
         self.parsed_tests = []
 
     def parse_test_case(self, config):
-        allowed_keys = ('syspage', 'type', 'harness', 'name', 'ignore')
-        mandatory_keys = ('syspage', 'name')
+        allowed_keys = ('exec', 'type', 'harness', 'name', 'ignore')
+        mandatory_keys = ('exec', 'name')
 
         unnecessary_keys = set(config) - set(allowed_keys)
         if unnecessary_keys:

--- a/trunner/device.py
+++ b/trunner/device.py
@@ -35,7 +35,7 @@ class DeviceRunner:
         except serial.SerialException as exc:
             raise exc
 
-        proc = pexpect.fdpexpect.fdspawn(self.serial, encoding='utf-8')
+        proc = pexpect.fdpexpect.fdspawn(self.serial, encoding='utf-8', timeout=test.timeout)
 
         try:
             test.handle(proc)
@@ -54,7 +54,7 @@ class QemuRunner:
         if test.skipped():
             return
 
-        proc = pexpect.spawn(self.qemu, args=self.args, encoding='utf-8')
+        proc = pexpect.spawn(self.qemu, args=self.args, encoding='utf-8', timeout=test.timeout)
 
         res = False
         try:

--- a/trunner/test_runner.py
+++ b/trunner/test_runner.py
@@ -1,6 +1,6 @@
 import logging
 
-from .builder import TargetBuilderFactory
+from .builder import TargetBuilder
 from .config import YAMLParser
 from .device import QemuRunner, QEMU_CMD
 from .testcase import TestCaseFactory
@@ -48,12 +48,8 @@ class TestsRunner:
                 tests.append(test_case)
 
         if self.build:
-            for target, tests in self.tests_per_target.items():
-                target_builder = TargetBuilderFactory.create(target)
-
-                test_binaries = [test_case.exec_bin for test_case in tests]
-                test_binaries = list(set(test_binaries))
-                target_builder.build(test_binaries)
+            for target in self.tests_per_target:
+                TargetBuilder(target).build()
 
         for target, tests in self.tests_per_target.items():
             for test_case in tests:

--- a/trunner/testcase.py
+++ b/trunner/testcase.py
@@ -176,7 +176,7 @@ class TestCaseFactory:
             return TestCaseUnit(
                     name=test['name'],
                     target=test['target'],
-                    exec_bin=test['syspage'],
+                    exec_bin=test['exec'],
                     status=status
             )
         if test['type'] == 'harness':
@@ -184,7 +184,7 @@ class TestCaseFactory:
                     name=test['name'],
                     target=test['target'],
                     harness_path=test['harness'],
-                    exec_bin=test['syspage'],
+                    exec_bin=test['exec'],
                     status=status
             )
 

--- a/trunner/testcase.py
+++ b/trunner/testcase.py
@@ -16,9 +16,10 @@ class TestCase:
     FAILED_TIMEOUT = "FAILED TIMEOUT"
     SKIPPED = "SKIPPED"
 
-    def __init__(self, name, target, exec_bin=None, status=None):
+    def __init__(self, name, target, timeout, exec_bin=None, status=None):
         self.name = name
         self.target = target
+        self.timeout = timeout
         self.exec_bin = exec_bin
         if not status:
             status = TestCase.FAILED
@@ -119,8 +120,8 @@ class TestCase:
 class TestCaseCustomHarness(TestCase):
     """The test case with user harness loaded from .py file"""
 
-    def __init__(self, name, target, harness_path, exec_bin=None, status=TestCase.FAILED):
-        super().__init__(name, target, exec_bin, status)
+    def __init__(self, name, target, timeout, harness_path, exec_bin=None, status=TestCase.FAILED):
+        super().__init__(name, target, timeout, exec_bin, status)
         self.load_module(harness_path)
 
     def load_module(self, path):
@@ -137,8 +138,8 @@ class TestCaseCustomHarness(TestCase):
 class TestCaseUnit(TestCase):
     """The test case representing Unity unit tests."""
 
-    def __init__(self, name, target, exec_bin, status=TestCase.FAILED):
-        super().__init__(name, target, exec_bin, status)
+    def __init__(self, name, target, timeout, exec_bin, status=TestCase.FAILED):
+        super().__init__(name, target, timeout, exec_bin, status)
         self.harness = UnitTestHarness.harness
         self.unit_test_results = []
 
@@ -176,6 +177,7 @@ class TestCaseFactory:
             return TestCaseUnit(
                     name=test['name'],
                     target=test['target'],
+                    timeout=test['timeout'],
                     exec_bin=test['exec'],
                     status=status
             )
@@ -183,6 +185,7 @@ class TestCaseFactory:
             return TestCaseCustomHarness(
                     name=test['name'],
                     target=test['target'],
+                    timeout=test['timeout'],
                     harness_path=test['harness'],
                     exec_bin=test['exec'],
                     status=status


### PR DESCRIPTION
- Add 'dir' keyword for config which specifies where test are placed on phoenix-rtos. By default if our path is `/home/user/phoenix-rtos-project/myproject/path/to/test/test.yaml` then test are run from `/bin/myproject/path/to/test/{syspage}`. Using 'dir' keyword we can change default path and run tests from wherever we want.
- Add `install_fs` target to Makefile.
- Decrease pyexpect timeout to 8 seconds

Needed by [ci: add test runner job #61](https://github.com/phoenix-rtos/phoenix-rtos-project/pull/61)

