### PR TITLE
Add CI for runner. Fix warnings from GCC and flake

### DIFF
--- a/.github/workflows/runner-ci.yaml
+++ b/.github/workflows/runner-ci.yaml
@@ -1,0 +1,44 @@
+name: Runner CI
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '**.py'
+      - 'trunner/**'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '**.py'
+      - 'trunner/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest
+        pip install -r requirements.txt
+
+    - name: Lint with flake8
+      run: |
+        flake8 . --max-line-length 120 --exclude ./net
+
+    - name: Test with pytest
+      run: |
+        pytest trunner/test

--- a/psh/test-mkdir.py
+++ b/psh/test-mkdir.py
@@ -5,6 +5,7 @@ from collections import namedtuple
 
 File = namedtuple('File', ['name', 'owner', 'is_dir'])
 
+
 def ls(p, dir=''):
     files = []
 
@@ -25,7 +26,7 @@ def ls(p, dir=''):
         try:
             permissions, _, owner, _, _, _, _, _, name = line.split()
         except ValueError:
-            print(f'psh mkdir: wrong ls output')
+            print('psh mkdir: wrong ls output')
             return []
 
         # Name is printed with ascii escaped characters - remove them
@@ -39,18 +40,20 @@ def ls(p, dir=''):
 
     return files
 
+
 def mkdir(p, dir):
     p.sendline(f'mkdir {dir}')
     p.expect_exact(f'mkdir {dir}')
     p.expect_exact('\n')
 
-    idx = p.expect(['\(psh\)\% ', 'mkdir: failed to create (.*) directory'])
+    idx = p.expect([r'\(psh\)\% ', r'mkdir: failed to create (.*) directory'])
 
     if idx == 1:
         # Failed, read one more time (psh)%
         p.expect_exact('(psh)% ')
 
     return idx != 1
+
 
 def dir_present(dir, files):
     for file in files:
@@ -68,6 +71,7 @@ def dir_present(dir, files):
         return False
 
     return True
+
 
 def assert_dir_created(p, dir):
     if not mkdir(p, dir):
@@ -87,9 +91,10 @@ def assert_dir_created(p, dir):
 
     return dir_present(dir, files)
 
+
 def random_dirs(p, pool, count=20):
     if not mkdir(p, '/random_dirs'):
-        print(f'psh mkdir: failed to create /random_dirs')
+        print('psh mkdir: failed to create /random_dirs')
         return False
 
     dirs = {''.join(random.choices(pool, k=random.randint(8, 16))) for _ in range(count)}
@@ -103,7 +108,7 @@ def random_dirs(p, pool, count=20):
         return False
 
     if len(files) > len(dirs) + 2:      # +2 because of . and ..
-        print(f'psh ls: too many dirs')
+        print('psh ls: too many dirs')
         return False
 
     for dir in dirs:
@@ -111,6 +116,7 @@ def random_dirs(p, pool, count=20):
             return False
 
     return True
+
 
 def get_first_prompt(p):
     prompt = '\r\x1b[0J' + '(psh)% '
@@ -121,6 +127,7 @@ def get_first_prompt(p):
         return False
 
     return True
+
 
 def harness(p):
     chars = list(set(string.printable) - set(string.whitespace) - set('/'))

--- a/psh/test-ps.py
+++ b/psh/test-ps.py
@@ -8,6 +8,7 @@
     1     0  4 sleep   0.0   3ms    0:00      0   1 init
 """
 
+
 def harness(p):
     header_seen = False
     expected_tasks = ['[idle]', 'init', 'psh']
@@ -20,11 +21,11 @@ def harness(p):
         return False
 
     p.sendline('ps')
-    p.expect('ps(\r+)\n')
+    p.expect(r'ps(\r+)\n')
 
     while True:
         # Get prompt or new line
-        idx = p.expect(['\(psh\)\% ', '(.*)(\r+)\n'])
+        idx = p.expect([r'\(psh\)\% ', r'(.*)(\r+)\n'])
         if idx == 0:
             break
 
@@ -36,14 +37,14 @@ def harness(p):
             try:
                 pid, ppid, pr, state, cpu, wait, time, vmem, thr, task = line.split()
             except ValueError:
-                print(f'psh ps: wrong ps output')
+                print('psh ps: wrong ps output')
                 return False
 
             if task in expected_tasks:
                 expected_tasks.remove(task)
 
     if not header_seen:
-        print(f'psh ps: wrong header')
+        print('psh ps: wrong header')
 
     if expected_tasks:
         print(f'psh ps: not seen expected task: {", ".join(expected_tasks)}')

--- a/sample/test/fails/test-fail-output-1.py
+++ b/sample/test/fails/test-fail-output-1.py
@@ -1,4 +1,4 @@
 def harness(p):
-    p.expect_exact("[Test FAIL TIMEOUT started]");
+    p.expect_exact("[Test FAIL TIMEOUT started]")
     # We expect "1", should trigger timeout
     p.expect_exact("2")

--- a/sample/test/fails/test-fail-output-2.py
+++ b/sample/test/fails/test-fail-output-2.py
@@ -2,7 +2,7 @@ def harness(p):
     p.expect_exact("Unique number sequence")
 
     unique_numbers = []
-    while p.expect(["(\d+) ", "That's all what I got!"]) != 1:
+    while p.expect([r"(\d+) ", "That's all what I got!"]) != 1:
         val = int(p.match.group(0))
         unique_numbers.append(val)
 

--- a/sample/test/test-echo.c
+++ b/sample/test/test-echo.c
@@ -8,7 +8,9 @@ int main(int argc, char** argv)
 	printf("[Start test-1 example]\n");
 
 	while (c != '\n') {
-		read(STDIN_FILENO, &c, 1);
+		if (read(STDIN_FILENO, &c, 1) != 1)
+			return -1;
+
 		putchar(c);
 	}
 

--- a/trunner/builder.py
+++ b/trunner/builder.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import pathlib
 import shutil
 import subprocess
 import sys

--- a/trunner/test/test_config.py
+++ b/trunner/test/test_config.py
@@ -59,7 +59,6 @@ class TestTarget:
         tests = parser.parse_test_config()
         assert not tests
 
-
     @pytest.mark.parametrize('target, expect_target', [
         (
             {},


### PR DESCRIPTION
Comments to some other warnings:
1. Build on riscv64-virt produces the following warning:
```
unity/unity_internals.h:903:121: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
[omitted output]
sample/test/test-unity.c:26:2: note: in expansion of macro 'TEST_ASSERT_EQUAL_PTR'
   26 |  TEST_ASSERT_EQUAL_PTR(p, NULL);
      |  ^~~~~~~~~~~~~~~~~~~~~
```
Unity uses `UINTPTR_MAX` to detect pointer size. Then it casts it to int of the right size. In libphoenix `UINTPTR_MAX` is defined as `UINT32_MAX` but `sizeof(void*)` is 8. Also `uintptr_t` is defined as `uint64_t` so it might some inconsistency.  

2. No return warning mentioned in https://github.com/phoenix-rtos/phoenix-rtos-tests/issues/10
It might be triggered because of lack `noreturn` attribute in `longjmp` definition in libphoenix.

Changes fixe https://github.com/phoenix-rtos/phoenix-rtos-tests/issues/7.