### PR TITLE
Add assertion handling

### DIFF
--- a/initfini/test.py
+++ b/initfini/test.py
@@ -1,17 +1,12 @@
 def harness(p):
-    if 'Constructor 0' not in p.readline():
-        return False
+    scenario = [
+        'Constructor 0',
+        'Constructor 1',
+        'Main function',
+        'Destructor 1',
+        'Destructor 0'
+    ]
 
-    if 'Constructor 1' not in p.readline():
-        return False
-
-    if 'Main function' not in p.readline():
-        return False
-
-    if 'Destructor 1' not in p.readline():
-        return False
-
-    if 'Destructor 0' not in p.readline():
-        return False
-
-    return True
+    for expect in scenario:
+        line = p.readline().rstrip()
+        assert expect == line, f'Expected: {expect}, got: {line}'

--- a/psh/test-prompt.py
+++ b/psh/test-prompt.py
@@ -1,10 +1,5 @@
 def harness(p):
     # Expect erase in display ascii escape sequence and prompt sign
-    expect = '\r\x1b[0J' + '(psh)% '
-    got = p.read(len(expect))
-
-    if got != expect:
-        print(f'Expected:\n\t{expect}\nGot:\n\t{got}')
-        return False
-
-    return True
+    prompt = '\r\x1b[0J' + '(psh)% '
+    got = p.read(len(prompt))
+    assert got == prompt, f'Expected:\n{prompt}\nGot:\n{got}'

--- a/sample/helloworld/test.py
+++ b/sample/helloworld/test.py
@@ -1,5 +1,2 @@
 def harness(p):
-    if 'Hello world!' not in p.readline():
-        return False
-
-    return True
+    assert 'Hello world!' in p.readline()

--- a/sample/test/fails/test-fail-output-2.py
+++ b/sample/test/fails/test-fail-output-2.py
@@ -6,7 +6,5 @@ def harness(p):
         val = int(p.match.group(0))
         unique_numbers.append(val)
 
-    if len(unique_numbers) != len(set(unique_numbers)):
-        return False
-
-    return True
+    assert len(unique_numbers) == len(set(unique_numbers)), \
+           f'expected unique sequence! Got: {unique_numbers}'

--- a/trunner/config.py
+++ b/trunner/config.py
@@ -2,9 +2,9 @@ import logging
 import os
 import pathlib
 
-
 import yaml
 
+from .tools.text import remove_prefix
 
 PHRTOS_PROJECT_DIR = pathlib.Path(os.getcwd())
 PHRTOS_TEST_DIR = PHRTOS_PROJECT_DIR / 'phoenix-rtos-tests'
@@ -17,13 +17,6 @@ ALL_TARGETS = ['ia32-generic', 'host-pc']
 
 # Default targets used by parser if 'target' value is absent
 DEFAULT_TARGETS = [target for target in ALL_TARGETS if target != 'host-pc']
-
-
-def remove_prefix(string, prefix):
-    if string.startswith(prefix):
-        return string[len(prefix):]
-
-    return string
 
 
 class YAMLParserError(Exception):

--- a/trunner/harness.py
+++ b/trunner/harness.py
@@ -79,7 +79,9 @@ class UnitTestHarness:
                 # Make sure if parsed infos are as expected
                 fail_no = len([t for t in test_results if t.status == UnitTestResult.FAIL])
                 ignore_no = len([t for t in test_results if t.status == UnitTestResult.IGNORE])
-                if (fail_no != fail or ignore_no != ignore or len(test_results) != total):
-                    raise ValueError("Unit test harness: results do not match")
+
+                assert fail_no == fail
+                assert ignore_no == ignore
+                assert len(test_results) == total
 
                 return test_results

--- a/trunner/test/test_exceptions.py
+++ b/trunner/test/test_exceptions.py
@@ -1,0 +1,65 @@
+import re
+
+import pytest
+
+from trunner.config import ALL_TARGETS
+from trunner.testcase import TestCase
+
+
+# Pytest tries to collect TestCase as a class to test
+# Mark TestCase as not testable
+TestCase.__test__ = False
+
+
+class TestExceptionHandler:
+    @staticmethod
+    def assert_exc_msg(testcase, function_names):
+        for func in function_names:
+            pattern = rf'File "{__file__}", line \d+, in {func}'
+            assert re.search(pattern, testcase.exception), \
+                   f"pattern '{pattern}' not found in exception msg"
+
+    @staticmethod
+    def fake_harness(function):
+        def harness(p):
+            function()
+
+        return harness
+
+    @pytest.fixture
+    def testcase(self):
+        return TestCase(
+            name='xyz',
+            target=ALL_TARGETS[0],
+            timeout=3,
+            exec_bin='xyz'
+        )
+
+    def test_assert(self, testcase):
+        def foo():
+            assert False
+
+        testcase.harness = TestExceptionHandler.fake_harness(foo)
+        testcase.handle(proc=None, psh=False)
+
+        TestExceptionHandler.assert_exc_msg(testcase, ('harness', 'foo'))
+
+    def test_assert_msg(self, testcase):
+        def foo():
+            assert False, "boo has failed!"
+
+        testcase.harness = TestExceptionHandler.fake_harness(foo)
+        testcase.handle(proc=None, psh=False)
+
+        TestExceptionHandler.assert_exc_msg(testcase, ('harness', 'foo'))
+        assert "boo has failed!" in testcase.exception
+
+    def test_exception(self, testcase):
+        def foo():
+            raise Exception("boo has failed!")
+
+        testcase.harness = TestExceptionHandler.fake_harness(foo)
+        testcase.handle(proc=None, psh=False)
+
+        TestExceptionHandler.assert_exc_msg(testcase, ('harness', 'foo'))
+        assert 'Exception: boo has failed!' in testcase.exception

--- a/trunner/tools/color.py
+++ b/trunner/tools/color.py
@@ -4,6 +4,7 @@ class Color:
     FAIL = '\033[91m'
     OK = '\033[92m'
     SKIP = '\033[93m'
+    BOLD = '\033[1m'
     END = '\033[0m'
 
     @staticmethod

--- a/trunner/tools/text.py
+++ b/trunner/tools/text.py
@@ -1,0 +1,5 @@
+def remove_prefix(string, prefix):
+    if string.startswith(prefix):
+        return string[len(prefix):]
+
+    return string


### PR DESCRIPTION
Now we do not have to return error value from harnesses. Test interrupted by assertion produces following exception message:
![image](https://user-images.githubusercontent.com/22961277/116402725-0bce5b80-a82d-11eb-9ea1-3e7563fac766.png)

Test interrupted by python exception other than assertion/pyexpect are handled and marked as failed.