### PR TITLE
runner: imxrt106x: add loading tests using plo

### DIFF
--- a/psh/test.yaml
+++ b/psh/test.yaml
@@ -4,13 +4,9 @@ test:
     tests:
         - name: prompt
           harness: test-prompt.py
-          targets:
-              include: [armv7m7-imxrt106x]
 
         - name: ps
           harness: test-ps.py
-          targets:
-              include: [armv7m7-imxrt106x]
 
         - name: mkdir
           harness: test-mkdir.py

--- a/runner.py
+++ b/runner.py
@@ -69,6 +69,10 @@ def parse_args():
                         help="Specify serial to communicate with device board. "
                              "By default uses %(default)s.")
 
+    parser.add_argument("--no-flash",
+                        default=False, action='store_true',
+                        help="Board will not be flashed by runner.")
+
     args = parser.parse_args()
 
     args.log_level = logging_level[args.log_level]
@@ -91,7 +95,8 @@ def main():
 
     runner = TestsRunner(targets=args.target,
                          test_paths=args.test,
-                         build=args.build)
+                         build=args.build,
+                         flash=not args.no_flash)
 
     passed, failed, skipped = runner.run()
 

--- a/sample/helloworld/test.yaml
+++ b/sample/helloworld/test.yaml
@@ -4,4 +4,4 @@ test:
           harness: test.py
           exec: test-helloworld
           targets:
-              include: [host-pc]
+              include: [host-pc, armv7m7-imxrt106x]

--- a/sample/test/test.yaml
+++ b/sample/test/test.yaml
@@ -4,11 +4,11 @@ test:
           exec: test-echo
           harness: test-echo.py
           targets:
-              include: [host-pc]
+              include: [host-pc, armv7m7-imxrt106x]
 
         - name: unity
           exec: test-unity
           type: unit
           targets:
-              include: [host-pc]
+              include: [host-pc, armv7m7-imxrt106x]
 

--- a/trunner/device.py
+++ b/trunner/device.py
@@ -2,6 +2,8 @@ import logging
 import os
 import signal
 import subprocess
+import sys
+import threading
 import time
 
 import pexpect
@@ -11,9 +13,10 @@ import serial
 try:
     import RPi.GPIO
 except ImportError:
-    print("RPi.GPIO module can't be imported!")
+    pass
 
 from .config import PHRTOS_PROJECT_DIR, DEVICE_SERIAL
+from .tools.color import Color
 
 
 _BOOT_DIR = PHRTOS_PROJECT_DIR / '_boot'
@@ -30,13 +33,225 @@ QEMU_CMD = {
 }
 
 
-def proccess_log_output(proc):
-    while True:
-        output = proc.stdout.readline().decode('utf-8')
-        if proc.poll() is not None and output == '':
-            break
-        if output:
-            logging.info(output)
+def is_github_actions():
+    return os.getenv('GITHUB_ACTIONS', False)
+
+
+class Psu:
+    """Wrapper for psu program"""
+
+    def __init__(self, script, cwd=_BOOT_DIR):
+        self.script = script
+        self.cwd = cwd
+        self.proc = None
+
+    def read_output(self):
+        if is_github_actions():
+            logging.info('::group::psu\n')
+
+        while True:
+            line = self.proc.stdout.readline().decode('utf-8')
+            if not line:
+                break
+
+            logging.info(line)
+
+        if is_github_actions():
+            logging.info('::endgroup::\n')
+
+    def run(self):
+        self.proc = subprocess.Popen(
+            ['psu', f'{self.script}'],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            cwd=self.cwd
+        )
+
+        self.read_output()
+        self.proc.wait()
+        if self.proc.returncode != 0:
+            logging.error(f'Command {" ".join(self.proc.args)} with pid {self.proc.pid} failed!\n')
+            raise Exception('Flashing IMXRT106x failed')
+
+
+class PhoenixdError(Exception):
+    pass
+
+
+class Phoenixd:
+    """ Wrapper for phoenixd program"""
+
+    def __init__(
+        self,
+        port,
+        baudrate=460800,
+        dir='.',
+        cwd=_BOOT_DIR,
+        wait_dispatcher=True
+    ):
+        self.port = port
+        self.baudrate = baudrate
+        self.dir = dir
+        self.cwd = cwd
+        self.proc = None
+        self.reader_thread = None
+        self.wait_dispatcher = wait_dispatcher
+        self.dispatcher_event = None
+        self.output_buffer = ''
+
+    def _reader(self):
+        """ This method is intended to be run as a separated thread. It reads output of proc
+            line by line and saves it in the output_buffer. Additionally, if wait_dispatcher is true,
+            it searches for a line stating that message dispatcher has started """
+
+        while True:
+            line = self.proc.readline()
+            if not line:
+                break
+
+            if self.wait_dispatcher and not self.dispatcher_event.is_set():
+                msg = f'Starting message dispatcher on [{self.port}] (speed={self.baudrate})'
+                if msg in line:
+                    self.dispatcher_event.set()
+
+            self.output_buffer += line
+
+    def run(self):
+        # Use pexpect.spawn to run a process as PTY, so it will flush on a new line
+        self.proc = pexpect.spawn(
+            'phoenixd',
+            ['-p', self.port,
+             '-b', str(self.baudrate),
+             '-s', self.dir],
+            cwd=self.cwd,
+            encoding='utf-8'
+        )
+
+        self.dispatcher_event = threading.Event()
+        self.reader_thread = threading.Thread(target=self._reader)
+        self.reader_thread.start()
+
+        if self.wait_dispatcher:
+            # Reader thread will notify us that message dispatcher has just started
+            dispatcher_ready = self.dispatcher_event.wait(timeout=10)
+            if not dispatcher_ready:
+                self.kill()
+                msg = f'message dispatcher did not start! Phoenixd output:\n{self.output()}'
+                raise PhoenixdError(msg)
+
+        return self.proc
+
+    def output(self):
+        output = self.output_buffer
+        if is_github_actions():
+            output = '::group::Pheonixd\n' + output + '::endgroup::\n'
+
+        return output
+
+    def kill(self):
+        os.killpg(os.getpgid(self.proc.pid), signal.SIGTERM)
+        self.reader_thread.join(timeout=10)
+        if self.reader_thread.is_alive():
+            os.killpg(os.getpgid(self.proc.pid), signal.SIGKILL)
+
+    def __enter__(self):
+        self.run()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.kill()
+
+
+class PloError(Exception):
+    def __init__(self, message, expected):
+        msg = Color.colorify("PLO ERROR:\n", Color.BOLD)
+        msg += str(message) + '\n'
+        if expected:
+            msg += Color.colorify("EXPECTED:\n", Color.BOLD)
+            msg += str(expected) + '\n'
+
+        super().__init__(msg)
+
+
+class PloTalker:
+    """Interface to communicate with plo"""
+
+    def __init__(self, port, baudrate=115200):
+        self.port = port
+        self.baudrate = baudrate
+        self.serial = None
+        self.plo = None
+
+    @classmethod
+    def from_pexpect(cls, pexpect_fd):
+        """ PloTalker can be created by passing pexpect spawn object directly.
+            User should handle port and process by himself. """
+
+        obj = cls(port=None)
+        obj.plo = pexpect_fd
+        return obj
+
+    def open(self):
+        try:
+            self.serial = serial.Serial(self.port, baudrate=self.baudrate)
+        except serial.SerialException:
+            logging.error(f'Port {self.port} not available\n')
+            raise
+
+        try:
+            self.plo = pexpect.fdpexpect.fdspawn(self.serial, timeout=8)
+        except Exception:
+            self.serial.close()
+            raise
+
+        return self
+
+    def close(self):
+        self.serial.close()
+
+    def __enter__(self):
+        return self.open()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def wait_prompt(self, timeout=8):
+        self.plo.expect_exact("(plo)% ", timeout=timeout)
+
+    def expect_prompt(self, timeout=8):
+        idx = self.plo.expect([r"\(plo\)% ", r"(.*?)\n"], timeout=timeout)
+        if idx == 1:
+            # Something else than prompt was printed, raise error
+            line = self.plo.match.group(0)
+            raise PloError(line, expected="(plo)% ")
+
+    def cmd(self, cmd, timeout=8):
+        self.plo.send(cmd + '\r\n')
+        # Wait for an eoched command
+        self.plo.expect_exact(cmd)
+        # There might be some ASCII escape characters, we wait only for a new line
+        self.plo.expect_exact('\n', timeout=timeout)
+
+    def app(self, device, file, imap, dmap, exec=False):
+        exec = '-x' if exec else ''
+        self.cmd(f'app {device} {exec} {file} {imap} {dmap}', timeout=30)
+        self.expect_prompt()
+
+    def copy(self, src, src_obj, dst, dst_obj, src_size='', dst_size=''):
+        self.cmd(f'copy {src} {src_obj} {src_size} {dst} {dst_obj} {dst_size}', timeout=60)
+        self.expect_prompt()
+
+    def copy_file2mem(self, src, file, dst='flash1', off=0, size=0):
+        self.copy(
+            src=src,
+            src_obj=file,
+            dst=dst,
+            dst_obj=off,
+            dst_size=size
+        )
+
+    def go(self):
+        self.plo.send('go!\r\n')
 
 
 class Runner:
@@ -71,13 +286,14 @@ class DeviceRunner(Runner):
         proc = pexpect.fdpexpect.fdspawn(self.serial, encoding='utf-8', timeout=test.timeout)
 
         try:
+            PloTalker.from_pexpect(proc).go()
             test.handle(proc)
         finally:
             self.serial.close()
 
 
 class GPIO:
-    """Wrappee around the RPi.GPIO module. It represents a single OUT pin"""
+    """Wrapper around the RPi.GPIO module. It represents a single OUT pin"""
 
     def __init__(self, pin):
         self.pin = pin
@@ -101,7 +317,11 @@ class IMXRT106xRunner(DeviceRunner):
     SDP = 'plo-ram-armv7m7-imxrt106x.sdp'
     IMAGE = 'phoenix-armv7m7-imxrt106x.disk'
 
-    def __init__(self, port, phoenixd_port='/dev/ttyUSB0'):
+    def __init__(
+        self,
+        port,
+        phoenixd_port='/dev/serial/by-id/usb-Phoenix_Systems_plo_CDC_ACM-if00'
+    ):
         super().__init__(port)
         self.phoenixd_port = phoenixd_port
         self.reset_gpio = GPIO(17)
@@ -124,61 +344,63 @@ class IMXRT106xRunner(DeviceRunner):
     def flash(self):
         self.boot(serial_downloader=True)
 
-        logging.info("psu run!\n")
+        Psu(script=self.SDP).run()
 
-        psu = subprocess.Popen(
-            ['psu', f'{self.SDP}'],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            cwd=_BOOT_DIR
-        )
-
-        proccess_log_output(psu)
-        psu.wait()
-        if psu.returncode != 0:
-            logging.error(f'Command {" ".join(psu.args)} with pid {psu.pid} failed!\n')
-            raise Exception('Flashing IMXRT106x failed\n')
-
-        phoenixd = subprocess.Popen([
-            'phoenixd',
-            '-p', self.phoenixd_port,
-            '-b', '115200',
-            '-s', '.'],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.STDOUT,
-            cwd=_BOOT_DIR,
-            preexec_fn=os.setpgrp
-        )
-
-        logging.info("phoenixd run!\n")
-
+        phd = None
         try:
-            target_serial = serial.Serial(self.port, baudrate=115200)
-        except serial.SerialException:
-            logging.error(f'Port {self.port} not available\n')
-            raise
-
-        plo = pexpect.fdpexpect.fdspawn(target_serial)
-
-        try:
-            plo.expect_exact("(plo)% ")
-            logging.info(f"Copying {self.IMAGE} to target\n")
-            plo.send(f"copy com1 {self.IMAGE} flash0 0 0\r\n")
-            plo.expect_exact("Finished copying", timeout=60)
-            logging.info(f"Finished copying {self.IMAGE} to target\n")
-            plo.expect_exact("(plo)% ")
-        except pexpect.exceptions.TIMEOUT:
-            target_serial.close()
-            os.killpg(os.getpgid(phoenixd.pid), signal.SIGTERM)
-            raise
+            with PloTalker(self.port) as plo:
+                plo.wait_prompt()
+                with Phoenixd(self.phoenixd_port) as phd:
+                    plo.copy_file2mem(
+                        src='usb0',
+                        file=self.IMAGE,
+                        dst='flash1',
+                        off=0
+                    )
+        except (pexpect.exceptions.TIMEOUT, pexpect.exceptions.EOF, PloError) as exc:
+            exception = f'{exc}\n'
+            if phd:
+                exception += Color.colorify('\nPHOENIXD OUTPUT:\n', Color.BOLD)
+                exception += phd.output()
+            logging.info(exception)
+            sys.exit(1)
 
         self.boot()
 
-        target_serial.close()
-        os.killpg(os.getpgid(phoenixd.pid), signal.SIGTERM)
+    def load(self, test):
+        """Loads test ELF into syspage using plo"""
+
+        phd = None
+        load_dir = 'test/armv7m7-imxrt106x'
+        try:
+            with PloTalker(self.port) as plo:
+                self.boot()
+                plo.wait_prompt()
+                with Phoenixd(self.phoenixd_port, dir=load_dir) as phd:
+                    plo.app('usb0', test.exec_bin, 'ocram2', 'ocram2')
+        except (pexpect.exceptions.TIMEOUT, pexpect.exceptions.EOF, PloError) as exc:
+            if isinstance(exc, PloError):
+                test.exception = str(exc)
+                test.fail()
+            else:  # TIMEOUT or EOF
+                test.exception = Color.colorify('EXCEPTION PLO\n', Color.BOLD)
+                test.handle_pyexpect_error(plo.plo, exc)
+
+            if phd:
+                test.exception += Color.colorify('\nPHOENIXD OUTPUT:\n', Color.BOLD)
+                test.exception += phd.output()
+
+            return False
+
+        return True
 
     def run(self, test):
-        self.boot()
+        if test.skipped():
+            return
+
+        if not self.load(test):
+            return
+
         super().run(test)
 
 

--- a/trunner/testcase.py
+++ b/trunner/testcase.py
@@ -39,6 +39,9 @@ class TestCase:
         self.harness = None
         self.exception = ''
 
+    def fail(self):
+        self.status = TestCase.FAILED
+
     def skipped(self):
         return self.status == TestCase.SKIPPED
 
@@ -92,14 +95,15 @@ class TestCase:
         # Look for searched pattern
         # pexpect searcher object is cleared when timeout exception is raised
         # parse patterns directly from the exception message
-        r_searched = r"[\d+]: (?:re.compile\()?'(.*)'\)?"
+        r_searched = r"[\d+]: (?:re.compile\()?b?'(.*)'\)?"
         searched_patterns = re.findall(r_searched, exc.value)
 
         self.exception += Color.colorify('EXPECTED:\n', Color.BOLD)
         for idx, pattern in enumerate(searched_patterns):
             self.exception += f'\t{idx}: {pattern}\n'
 
-        got = proc.before.replace("\r", "")
+        got = str(proc.before)
+        got = got.replace("\r", "")
         self.exception += Color.colorify('GOT:\n', Color.BOLD)
         self.exception += f'{got}\n'
 
@@ -140,7 +144,7 @@ class TestCase:
             try:
                 self.exec_test(proc)
             except pexpect.exceptions.TIMEOUT as exc:
-                self.exception = Color.colorify('Executing {self.exec_bin} failed!\n', Color.BOLD)
+                self.exception = Color.colorify(f'Executing {self.exec_bin} failed!\n', Color.BOLD)
                 self.handle_pyexpect_error(proc, exc)
                 return
 


### PR DESCRIPTION
These changes add possibility of running tests automatically. Runner uses new plo to load test ELF (from _boot/test) to the syspage.

Some remarks:
1.  usb0 is not ready when the plo prompt is printed first time. Normally in the initscript there is some wait (like wait 2000), so end user is not affected by this. Unfortunately, plo occasionally crashes executing this command. Therefore, for now, tests will be build without wait in the preinit script and runner will wait 1 second for usb initialization (but maybe is possible to make some lookup for /dev).
2. `phoenixd` needs ~1 second to be ready to handle requests from plo. Here we could parse output from phoenixd and look for the "dispatcher ready" string but `phoenixd` doesn't flush too often. Setting small buffers in `Popen` doesn't help. I would like to handle this in the next PR (and also how to log `phoenixd` output in the GA and to the user in case of failure -- in general logging).
3. Im going to think of how to handle the `psh` case because we can't copy it directly to the syspage.