### PR TITLE
tests: initfini: change constructor priority

### DIFF
--- a/initfini/main.c
+++ b/initfini/main.c
@@ -15,13 +15,13 @@
 #include <stdio.h>
 
 
-__attribute__((constructor(0))) static void test_constr0(void)
+__attribute__((constructor(101))) static void test_constr0(void)
 {
 	printf("Constructor 0\n");
 }
 
 
-__attribute__((constructor(1))) static void test_constr1(void)
+__attribute__((constructor(102))) static void test_constr1(void)
 {
 	printf("Constructor 1\n");
 }
@@ -34,13 +34,13 @@ int main(int argc, char **argv)
 }
 
 
-__attribute__((destructor(0))) static void test_destr0(void)
+__attribute__((destructor(101))) static void test_destr0(void)
 {
 	printf("Destructor 0\n");
 }
 
 
-__attribute__((destructor(1))) static void test_destr1(void)
+__attribute__((destructor(102))) static void test_destr1(void)
 {
 	printf("Destructor 1\n");
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
It fixes warning:
```
/github/workspace/phoenix-rtos-tests/initfini/main.c:19:1: warning: constructor priorities from 0 to 100 are reserved for the implementation [-Wprio-ctor-dtor]
```
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Priorities for constructor and destructor must be greater than 100. (as gcc says)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [X] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing linter checks and tests passed.
- [X] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
