### PR TITLE
ci: add rootfs to artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,12 +54,19 @@ jobs:
           param4: 'project'
           param5: 'image'
 
-      # step 4: upload contents of "_boot" as build artifacts
+      # step 4: tar rootfs
+      - name: Tar rootfs
+        working-directory: _fs
+        run: tar -cvf ../rootfs-${{ matrix.target }}.tar ${{ matrix.target }}/root
+
+      # step 5: upload "_boot" directory and tarball of rootfs as build artifacts
       - name: Upload build artifacts
         uses: actions/upload-artifact@v2
         with:
           name: phoenix-rtos-${{ matrix.target }}
-          path: _boot
+          path: |
+            _boot
+            rootfs-${{ matrix.target }}.tar
 
   test:
     needs: build
@@ -88,11 +95,10 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: phoenix-rtos-${{ matrix.target }}
-          path: _boot
 
-      - name: Fix file permissions
-        if: ${{ matrix.target == 'host-pc' }}
-        run: find _boot/host-pc/ -type f -exec chmod 755 {} \;
+      - name: Untar rootfs
+        working-directory: _fs
+        run: tar -xvf ../rootfs-${{ matrix.target }}.tar
 
       - name: Test runner
         uses: ./.github/actions/phoenix-runner

--- a/trunner/config.py
+++ b/trunner/config.py
@@ -40,6 +40,10 @@ DEVICE_TARGETS = ['armv7m7-imxrt106x']
 DEVICE_SERIAL = "/dev/ttyACM0"
 
 
+def rootfs(target: str) -> Path:
+    return PHRTOS_PROJECT_DIR / '_fs' / target / 'root'
+
+
 class ParserError(Exception):
     pass
 

--- a/trunner/device.py
+++ b/trunner/device.py
@@ -13,7 +13,7 @@ import serial
 
 from pexpect.exceptions import TIMEOUT, EOF
 
-from .config import PHRTOS_PROJECT_DIR, DEVICE_SERIAL
+from .config import PHRTOS_PROJECT_DIR, DEVICE_SERIAL, rootfs
 from .tools.color import Color
 
 
@@ -381,7 +381,7 @@ class IMXRT106xRunner(DeviceRunner):
         """Loads test ELF into syspage using plo"""
 
         phd = None
-        load_dir = 'test/armv7m7-imxrt106x'
+        load_dir = str(rootfs(test.target) / 'bin')
         try:
             with PloTalker(self.port) as plo:
                 self.boot()
@@ -444,10 +444,11 @@ class HostRunner(Runner):
         if test.skipped():
             return
 
-        test_bin = PHRTOS_PROJECT_DIR / '_boot' / test.target / test.exec_cmd[0]
+        test_path = rootfs(test.target) / 'bin' / test.exec_cmd[0]
+
         try:
             proc = pexpect.spawn(
-                str(test_bin),
+                str(test_path),
                 args=test.exec_cmd[1:],
                 encoding='utf-8',
                 timeout=test.timeout


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Tests are now installed in the `fs/{target}/root/bin` but are run from `_boot` directory which requires additional copy step in building phase. Instead, run tests directly from the `_fs/{target}` directory.

According to upload-artifacts docs:
> If multiple paths are provided as input, the least common ancestor of all the search paths will be used as the root directory of the artifact.

So we can leave it at is and content of the zip will be following:
```
phoenix-rtos-ia32-generic.zip after unziping:
- _boot/phoenix-ia32-generic.disk
- rootfs-ia32-generic.tar
```

Or we can move `rootfs-ia32-generic.tar` into _boot and then upload directory, so it will looks like:
```
phoenix-rtos-ia32-generic.zip after unziping:
- phoenix-ia32-generic.disk
- rootfs-ia32-generic.tar
```

I have prepared changes for phoenix-rtos-project and  I can make PRs in other repos. Just let me know if it looks ok right now.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [X] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [X] Tested by hand on: (host-pc, ia32-generic).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing linter checks and tests passed.
- [X] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [X] I will merge this PR by myself when appropriate.
