### PR TITLE
runner: fix RPi import

### DIFF
--- a/trunner/device.py
+++ b/trunner/device.py
@@ -12,7 +12,7 @@ import serial
 
 try:
     import RPi.GPIO
-except ImportError:
+except (ImportError, RuntimeError):
     pass
 
 from .config import PHRTOS_PROJECT_DIR, DEVICE_SERIAL


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

Temporary fix: catch RuntimeError on RPi.GPIO import. I don't know right now why new `devel` image raises `RuntimeError` instead of `ImportError` as earlier. One solution might be to move importing RPi.GPIO into `IMXRT106xRunner` class.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
