### PR TITLE
libc: add test for fclose(stdin)

### DIFF
--- a/libc/file.c
+++ b/libc/file.c
@@ -1,0 +1,82 @@
+/*
+ * Phoenix-RTOS
+ *
+ * libc-tests
+ *
+ * Testing POSIX file operations.
+ *
+ * Copyright 2021 Phoenix Systems
+ * Author: Marek Bialowas
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+/* make compilable against glibc (all these tests were run on host against libc/linux kernel) */
+#define _GNU_SOURCE
+
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <limits.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include <unity_fixture.h>
+
+#include "common.h"
+
+
+TEST_GROUP(file);
+
+TEST_SETUP(file)
+{
+}
+
+
+TEST_TEAR_DOWN(file)
+{
+}
+
+
+TEST(file, fclose_stdin)
+{
+	int save_stdin = dup(STDIN_FILENO);
+	TEST_ASSERT_GREATER_THAN(-1, save_stdin);
+
+	TEST_ASSERT_EQUAL_INT(0, fclose(stdin));
+
+	/* reopen/recreate the stdin */
+	TEST_ASSERT_EQUAL_INT(STDIN_FILENO, dup2(save_stdin, STDIN_FILENO));
+	stdin = fdopen(STDIN_FILENO, "r");
+	TEST_ASSERT_NOT_NULL(stdin);
+
+	/* note: not actually testing if stdin works */
+}
+
+
+TEST(file, fclose_stdin_ebadf)
+{
+	int save_stdin = dup(STDIN_FILENO);
+	TEST_ASSERT_GREATER_THAN(-1, save_stdin);
+
+	TEST_ASSERT_EQUAL_INT(0, close(STDIN_FILENO));
+	TEST_ASSERT_EQUAL_INT(-1, fclose(stdin));
+	TEST_ASSERT_EQUAL_INT(EBADF, errno);
+
+	/* reopen the stdin */
+	TEST_ASSERT_EQUAL_INT(STDIN_FILENO, dup2(save_stdin, STDIN_FILENO));
+
+	/* note: not actually testing if stdin works */
+}
+
+
+TEST_GROUP_RUNNER(file)
+{
+	RUN_TEST_CASE(file, fclose_stdin);
+	RUN_TEST_CASE(file, fclose_stdin_ebadf);
+}

--- a/libc/main.c
+++ b/libc/main.c
@@ -19,6 +19,7 @@
 void runner(void)
 {
 	RUN_TEST_GROUP(resolve_path);
+	RUN_TEST_GROUP(file);
 }
 
 


### PR DESCRIPTION
## Description
Bug: phoenix-rtos/phoenix-rtos-project#133

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [x] New test added: **this PR**
- [x] Tested by hand on: `ia32-generic`, `imx6ull`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
