### PR TITLE
busybox: add running busybox testsuite

### DIFF
--- a/busybox/Makefile
+++ b/busybox/Makefile
@@ -1,0 +1,4 @@
+NAME := test_busybox
+LOCAL_SRCS := test_busybox.c
+
+include $(binary.mk)

--- a/busybox/test_busybox.c
+++ b/busybox/test_busybox.c
@@ -1,0 +1,48 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <dirent.h>
+#include <errno.h>
+
+int main(int argc, char **argv)
+{
+	int ret;
+	char cmdargs[20];
+	char cmd[140] = "cd /usr/test/busybox/testsuite/ && export PATH=/bin:/sbin:/usr/bin:/usr/sbin && export bindir=/bin && ./runtest";
+	DIR *dir = opendir("/usr/test/busybox/testsuite");
+
+	if (dir) {
+		closedir(dir);
+	}
+	else if (ENOENT == errno) {
+		fprintf(stderr, "There is no busybox test suite to run, build project with \"LONG_TEST = 'y'\"\n");
+		return 1;
+	}
+	else {
+		fprintf(stderr, "There is problem with opening existing /bin/testsuite directory: %s\n", strerror(errno));
+		return 1;
+	}
+
+	if (argc == 2 && (strlen(argv[1]) <= (sizeof(cmdargs) - 5)))
+		sprintf(cmdargs, " -v %s", argv[1]);
+	else if (argc == 1)
+		sprintf(cmdargs, " -v");
+	else {
+		fprintf(stderr, "The argument is too long!");
+		return 1;
+	}
+	strncat(cmd, cmdargs, sizeof(cmd) - strlen(cmd) - 1);
+
+	if ((ret = system(cmd)) < 0) {
+		fprintf(stderr, "system function failed: %s\n", strerror(errno));
+		return 1;
+	}
+
+	if (argc == 2)
+		printf("\n****A single test of the Busybox Test Suite completed****\n\n");
+	else if (argc == 1)
+		printf("\n****The Busybox Test Suite completed****\n\n");
+
+	return 0;
+}

--- a/busybox/test_busybox.yaml
+++ b/busybox/test_busybox.yaml
@@ -1,0 +1,113 @@
+test:
+    type: busybox
+    tests:
+        - name: busybox
+          exec: test_busybox busybox
+        - name: basename
+          exec: test_busybox basename
+        - name: bunzip2
+          ignore: True
+          exec: test_busybox bunzip2
+        - name: bzcat
+          exec: test_busybox bzcat
+        - name: cat
+          exec: test_busybox cat
+        - name: cmp
+          exec: test_busybox cmp
+        - name: cp
+          exec: test_busybox cp
+        - name: cut
+          exec: test_busybox cut
+        - name: date
+          ignore: True
+          exec: test_busybox date
+        - name: dd
+          ignore: True
+          exec: test_busybox dd
+        - name: diff
+          exec: test_busybox diff
+        - name: dirname
+          exec: test_busybox dirname
+        - name: echo
+          ignore: True
+          exec: test_busybox echo
+        - name: "false"
+          exec: test_busybox "false"
+        - name: find
+          exec: test_busybox find
+        - name: grep
+          ignore: True
+          exec: test_busybox grep
+        - name: gunzip
+          ignore: True
+          exec: test_busybox gunzip
+        - name: gzip
+          exec: test_busybox gzip
+        - name: head
+          exec: test_busybox head
+        - name: id
+          exec: test_busybox id
+        - name: ln
+          exec: test_busybox ln
+        - name: ls
+          exec: test_busybox ls
+        - name: md5sum
+          exec: test_busybox md5sum
+        - name: mkdir
+          exec: test_busybox mkdir
+        - name: mv
+          ignore: True
+          exec: test_busybox mv
+        - name: od
+          exec: test_busybox od
+        - name: paste
+          exec: test_busybox paste
+        - name: printf
+          ignore: True
+          exec: test_busybox printf
+        - name: pwd
+          exec: test_busybox pwd
+        - name: readlink
+          exec: test_busybox readlink
+        - name: rm
+          exec: test_busybox rm
+        - name: rmdir
+          exec: test_busybox rmdir
+        - name: sed
+          ignore: True
+          exec: test_busybox sed
+        - name: sha1sum
+          exec: test_busybox sha1sum
+        - name: sha256sum
+          exec: test_busybox sha256sum
+        - name: sha3sum
+          exec: test_busybox sha3sum
+        - name: sha512sum
+          exec: test_busybox sha512sum
+        - name: sort
+          exec: test_busybox sort
+        - name: tail
+          exec: test_busybox tail
+        - name: tar
+          ignore: True
+          exec: test_busybox tar
+        - name: tee
+          exec: test_busybox tee
+        - name: test
+          exec: test_busybox test
+        - name: touch
+          exec: test_busybox touch
+        - name: tr
+          exec: test_busybox tr
+        - name: "true"
+          exec: test_busybox "true"
+        - name: uniq
+          exec: test_busybox uniq
+        - name: wc
+          exec: test_busybox wc
+        - name: which
+          ignore: True
+          exec: test_busybox which
+        - name: xargs
+          ignore: True
+          exec: test_busybox xargs

--- a/runner.py
+++ b/runner.py
@@ -78,6 +78,14 @@ def parse_args():
                         default=False, action='store_true',
                         help="Board will not be flashed by runner.")
 
+    # Add alternative option "--long-test" "" for long-test argument, which is False
+    # Needed for proper disabling long tests in gh actions
+    # because of problem with passing empty argument through gh workflows
+    parser.add_argument("--long-test",
+                        type=bool,
+                        nargs='?', default=False, const=True,
+                        help="Long tests will be run")
+
     args = parser.parse_args()
 
     args.log_level = logging_level[args.log_level]
@@ -107,7 +115,8 @@ def main():
                          build=args.build,
                          flash=not args.no_flash,
                          serial=(args.serial, args.baudrate),
-                         log=(args.log_level == logging.DEBUG)
+                         log=(args.log_level == logging.DEBUG),
+                         long_test=args.long_test
                          )
 
     passed, failed, skipped = runner.run()

--- a/trunner/harness.py
+++ b/trunner/harness.py
@@ -33,6 +33,35 @@ class UnitTestResult:
         return res
 
 
+class BusyboxTestResult:
+    """Class representing results of execution of the Busybox test suite."""
+
+    PASS = 'PASS'
+    FAIL = 'FAIL'
+    IGNORE = 'SKIPPED'
+
+    def __init__(self, name, status, msg=''):
+        self.name = name
+        self.status = status
+        self.msg = msg
+
+    def __str__(self):
+        if self.status == BusyboxTestResult.PASS:
+            color = Color.OK
+        elif self.status == BusyboxTestResult.FAIL:
+            color = Color.FAIL
+        elif self.status == BusyboxTestResult.IGNORE:
+            color = Color.SKIP
+
+        status = Color.colorify(self.status, color)
+
+        res = f"{status}: {self.name}"
+        if self.status == BusyboxTestResult.FAIL:
+            res += '\n\t\tTest case verbose output from busybox test suite:\n'
+            res += f'{self.msg}'
+        return res
+
+
 class UnitTestHarness:
     """Class providing harness for parsing output of Unity tests"""
 
@@ -85,3 +114,42 @@ class UnitTestHarness:
                 assert len(test_results) == total
 
                 return test_results
+
+
+class BusyboxTestHarness:
+    """Class providing harness for parsing output of the Busybox test suite"""
+
+    RESULT = r"(PASS|SKIPPED|FAIL): (.+?)\r+\n"
+    FINAL = r"\*\*\*\*(The Busybox Test Suite completed|A single test of the Busybox Test Suite completed)\*\*\*\*\r+\n"
+    MESSAGE = r"(.*?)\r+\n"
+
+    @staticmethod
+    def harness(proc):
+        test_results = []
+        test = None
+        msg = ""
+
+        while True:
+            idx = proc.expect([
+                BusyboxTestHarness.RESULT,
+                BusyboxTestHarness.FINAL,
+                BusyboxTestHarness.MESSAGE
+            ], timeout=45)
+            groups = proc.match.groups()
+            if idx != 2 and test:
+                # We ended processing test result and message
+                if msg and test['status'] == 'FAIL':
+                    test['msg'] = msg
+                    msg = ''
+
+                test_results.append(BusyboxTestResult(**test))
+
+            if idx == 0:
+                test = dict(zip(('status', 'name'), groups))
+            elif idx == 1:
+                break
+            elif idx == 2:
+                line = groups[0]
+                msg += '\n\t\t' + line
+
+        return test_results

--- a/trunner/test_runner.py
+++ b/trunner/test_runner.py
@@ -11,13 +11,14 @@ from .runners.common import Runner
 class TestsRunner:
     """Class responsible for loading, building and running tests"""
 
-    def __init__(self, targets, test_paths, serial, build=True, flash=True, log=False):
+    def __init__(self, targets, test_paths, serial, build=True, flash=True, log=False, long_test=False):
         self.targets = targets
         self.test_configs = []
         self.test_paths = test_paths
         self.tests_per_target = {k: [] for k in targets}
         self.build = build
         self.flash = flash
+        self.long_test = long_test
         self.runners = None
         self.serial = serial
         self.log = log
@@ -35,7 +36,7 @@ class TestsRunner:
     def parse_tests(self):
         self.test_configs = []
         for path in self.test_paths:
-            args = ParserArgs(yaml_path=path, targets=self.targets)
+            args = ParserArgs(yaml_path=path, targets=self.targets, long_test=self.long_test)
             config = TestCaseConfig.from_yaml(args)
             self.test_configs.extend(config.tests)
             logging.debug(f"File {path} parsed successfuly\n")

--- a/trunner/testcase.py
+++ b/trunner/testcase.py
@@ -7,7 +7,7 @@ import traceback
 
 from pexpect.exceptions import TIMEOUT, EOF
 
-from .harness import UnitTestHarness, UnitTestResult
+from .harness import UnitTestHarness, BusyboxTestHarness, UnitTestResult, BusyboxTestResult
 from .tools.color import Color
 from .config import DEVICE_TARGETS
 
@@ -257,6 +257,46 @@ class TestCaseUnit(TestCase):
         return res
 
 
+class TestCaseBusybox(TestCase):
+    """The test case representing Busybox test suite."""
+
+    def __init__(
+        self,
+        name,
+        target,
+        timeout,
+        exec_cmd,
+        psh=True,
+        use_sysexec=False,
+        status=TestCase.FAILED
+    ):
+        super().__init__(name, target, timeout, psh, exec_cmd, use_sysexec, status)
+        self.harness = BusyboxTestHarness.harness
+        self.test_results = []
+
+    def log_test_status(self):
+        super().log_test_status()
+
+        for test in self.test_results:
+            if test.status == BusyboxTestResult.FAIL:
+                logging.info(f"\t{test}\n")
+            else:
+                logging.debug(f"\t{test}\n")
+
+    def handle(self, proc):
+        res = super().handle(proc)
+
+        if self.status == TestCase.PASSED:
+            self.test_results = res
+
+        for test in self.test_results:
+            if test.status == BusyboxTestResult.FAIL:
+                self.status = TestCase.FAILED
+                break
+
+        return res
+
+
 class TestCaseFactory:
     """Class responsible for creating TestCase based on a config loaded from YAML"""
 
@@ -282,6 +322,15 @@ class TestCaseFactory:
                 timeout=test['timeout'],
                 psh=test['psh'],
                 harness_path=test['harness'],
+                exec_cmd=test.get('exec'),
+                use_sysexec=use_sysexec,
+                status=status
+            )
+        if test['type'] == 'busybox':
+            return TestCaseBusybox(
+                name=test['name'],
+                target=test['target'],
+                timeout=test['timeout'],
                 exec_cmd=test.get('exec'),
                 use_sysexec=use_sysexec,
                 status=status


### PR DESCRIPTION
JIRA: RTOS-59

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
- busybox: add running busybox testsuite
- busybox: add a check if the test suite is in the bin directory
- busybox: add strerror and _exit from child process when failed 
- busybox: add posixsrv exec error handling 
- busybox: allow test_busybox to be run using test runner as single test 
- busybox: add long_test argument for runner to allow running busybox test suite
- busybox: temporarily disable check if posixsrv has been run properly, because of waitpid WNOHANG problem
- busybox: add export bindir variable, because of test suite location change
- busybox: allow to run each busybox command tests seperately using test runner
- runner: add alternative option for disabling long tests, check long_test arg earlier

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Test_busybox runs a busybox testsuite (which is copied to /usr/test/busybox)
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic - qemu).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (https://github.com/phoenix-rtos/phoenix-rtos-ports/pull/18).
- [ ] I will merge this PR by myself when appropriate.
