### PR TITLE
pshlogin: tests of login utility

### DIFF
--- a/psh/test-auth.py
+++ b/psh/test-auth.py
@@ -1,0 +1,92 @@
+# Phoenix-RTOS
+#
+# phoenix-rtos-tests
+#
+# "auth" psh applet test
+#
+# Copyright 2021 Phoenix Systems
+# Author: Mateusz Niewiadomski
+#
+# This file is part of Phoenix-RTOS.
+#
+# %LICENSE%
+#
+
+import string
+import pexpect
+
+from psh.tools.basic import run_psh, assert_only_prompt
+
+import psh.tools.login as logintools
+
+
+EOT = '\x04'
+BACKSPACE = '\x08'
+cred_ok = logintools.Credentials('defuser', '1234')
+cred_bad = logintools.Credentials('lorem', 'ipsum')
+cred_empty = logintools.Credentials('', '')
+
+
+def assert_auth(p):
+    p.send('auth\n')
+    assert p.expect_exact(['auth', pexpect.TIMEOUT], timeout=1) == 0, 'Error on entering command auth'
+    assert p.expect_exact(['Login:', pexpect.TIMEOUT], timeout=2) == 0, '"auth" applet does not launch'
+
+
+def harness(p):
+    # Run psh
+    run_psh(p)
+    assert_only_prompt(p)
+
+    # Check if auth app is available and login exit
+    assert_auth(p)
+    p.send(EOT)
+    assert p.expect_exact(['(psh)%', pexpect.TIMEOUT], timeout=1) == 0, 'Cannot exit "auth" during login passing'
+
+    # Exiting auth during password
+    assert_auth(p)
+    p.send(cred_bad.user + '\n')
+    p.send(EOT)
+    assert p.expect_exact(['(psh)%', pexpect.TIMEOUT], timeout=1) == 0, 'Cannot exit "auth": password passing'
+
+    # Good login
+    assert_auth(p)
+    logintools.assert_login(p, cred_ok.user, cred_ok.passwd)
+
+    # Wrong credentials
+    assert_auth(p)
+    logintools.assert_login_fail(p, cred_ok.user, cred_bad.passwd)
+
+    assert_auth(p)
+    logintools.assert_login_fail(p, cred_bad.user, cred_ok.passwd)
+    assert_auth(p)
+    logintools.assert_login_fail(p, cred_bad.user, cred_bad.passwd)
+
+    # Empty Credentials
+    assert_auth(p)
+    logintools.assert_login_fail(p, cred_ok.user, cred_empty.passwd)
+    assert_auth(p)
+    logintools.assert_login_fail(p, cred_bad.user, cred_empty.passwd)
+    assert_auth(p)
+    logintools.assert_login_empty(p, cred_empty.user)
+    p.send(EOT)  # assert_login_empty() with empty login does not go back to psh, exit needed
+
+    # Too long credentials
+    printables = string.printable
+    assert_auth(p)
+    p.send(printables + '\n')
+    assert p.expect_exact(['Login:', pexpect.TIMEOUT]) == 0, 'Long login does not repeat login procedure'
+    logintools.assert_login_fail(p, cred_ok.user, printables)  # too long password
+
+    # Test backspace
+    assert_auth(p)
+    p.send(cred_ok.user + cred_ok.user)
+    for i in range(len(cred_ok.user) + 1):  # Test just enough backspaces
+        p.send(BACKSPACE)
+    p.send(cred_ok.user[-1] + '\n')
+    assert p.expect_exact(["Password:", pexpect.TIMEOUT]) == 0
+    p.send(cred_ok.passwd)
+    for i in range(len(cred_ok.passwd) + 9):  # test too many backspaces
+        p.send(BACKSPACE)
+    p.send(cred_ok.passwd + '\n')
+    logintools.assert_good_login(p)

--- a/psh/test-auth.py
+++ b/psh/test-auth.py
@@ -15,7 +15,7 @@
 import string
 import pexpect
 
-from psh.tools.basic import run_psh, assert_only_prompt
+from psh.tools.basic import run_psh, assert_only_prompt, assert_prompt
 
 import psh.tools.login as logintools
 
@@ -41,13 +41,13 @@ def harness(p):
     # Check if auth app is available and login exit
     assert_auth(p)
     p.send(EOT)
-    assert p.expect_exact(['(psh)%', pexpect.TIMEOUT], timeout=1) == 0, 'Cannot exit "auth" during login passing'
+    assert_prompt(p, 'Cannot exit "auth" during login passing', timeout=1)
 
     # Exiting auth during password
     assert_auth(p)
     p.send(cred_bad.user + '\n')
     p.send(EOT)
-    assert p.expect_exact(['(psh)%', pexpect.TIMEOUT], timeout=1) == 0, 'Cannot exit "auth": password passing'
+    assert_prompt(p, 'Cannot exit "auth": password passing', timeout=1)
 
     # Good login
     assert_auth(p)
@@ -89,4 +89,4 @@ def harness(p):
     for i in range(len(cred_ok.passwd) + 9):  # test too many backspaces
         p.send(BACKSPACE)
     p.send(cred_ok.passwd + '\n')
-    logintools.assert_good_login(p)
+    assert_prompt(p, 'Login should pass but failed', timeout=1)

--- a/psh/test-mkdir.py
+++ b/psh/test-mkdir.py
@@ -3,7 +3,7 @@ import string
 
 from collections import namedtuple
 
-from psh.tools import run_psh, assert_only_prompt
+from psh.tools.basic import run_psh, assert_only_prompt
 
 File = namedtuple('File', ['name', 'owner', 'is_dir'])
 

--- a/psh/test-prompt.py
+++ b/psh/test-prompt.py
@@ -1,4 +1,4 @@
-from psh.tools import run_psh, assert_only_prompt
+from psh.tools.basic import run_psh, assert_only_prompt
 
 
 def harness(p):

--- a/psh/test-ps.py
+++ b/psh/test-ps.py
@@ -1,4 +1,4 @@
-from psh.tools import run_psh, assert_only_prompt
+from psh.tools.basic import run_psh, assert_only_prompt
 
 """
 (psh)% ps

--- a/psh/test-pshlogin.py
+++ b/psh/test-pshlogin.py
@@ -1,0 +1,74 @@
+
+# Phoenix-RTOS
+#
+# phoenix-rtos-tests
+#
+# pshlogin test
+#
+# Copyright 2021 Phoenix Systems
+# Author: Mateusz Niewiadomski
+#
+# This file is part of Phoenix-RTOS.
+#
+# %LICENSE%
+#
+import string
+
+import pexpect
+
+from psh.tools.basic import run_psh, assert_only_prompt
+
+import psh.tools.login as logintools
+
+
+EOT = '\x04'
+BACKSPACE = '\x08'
+cred_ok = logintools.Credentials('defuser', '1234')
+cred_ok_etc = logintools.Credentials('root', '1234')
+cred_bad = logintools.Credentials('lorem', 'ipsum')
+cred_empty = logintools.Credentials('', '')
+
+
+def assert_pshlogin(p):
+    p.send(logintools.pshlogin_cmd + '\n')
+    p.expect_exact(logintools.pshlogin_cmd)
+    idx = p.expect_exact(['Login:', '(psh)%', pexpect.TIMEOUT], timeout=1)
+    if idx == 1:
+        raise AssertionError('pshlogin is not available!')
+    if idx == 2:
+        raise AssertionError('pshlogin does not launch')
+
+
+def harness(p):
+    # Run psh
+    run_psh(p)
+    assert_only_prompt(p)
+
+    # Run pshlogin
+    assert_pshlogin(p)
+
+    # Wrong credentials
+    logintools.assert_login_fail(p, cred_ok_etc.user, cred_bad.passwd)  # good login, wrong password
+    logintools.assert_login_fail(p, cred_bad.user, cred_ok_etc.passwd)  # bad login, good password
+    logintools.assert_login_fail(p, cred_bad.user, cred_bad.passwd)  # bad login, bad password
+
+    # Empty Credentials
+    logintools.assert_login_fail(p, cred_ok_etc.user, cred_empty.passwd)  # good login, empty password
+    logintools.assert_login_fail(p, cred_bad.user, cred_empty.passwd)  # bad login, empty password
+    logintools.assert_login_empty(p, cred_empty.user)  # empty login, good password
+
+    # Good login, new psh is created
+    logintools.assert_login(p, cred_ok_etc.user, cred_ok_etc.passwd)
+
+    # Exit and try to login again but with defuser:
+    p.send(EOT)
+    assert_pshlogin(p)
+    logintools.assert_login_fail(p, cred_ok.user, cred_bad.passwd)
+    logintools.assert_login(p, cred_ok.user, cred_ok.passwd)
+    p.send(EOT)
+
+    # Too long credentials
+    assert_pshlogin(p)
+    p.send(string.printable + '\n')
+    assert p.expect_exact(['Login:', pexpect.TIMEOUT], timeout=2) == 0, 'Long login does not repeat login procedure'
+    logintools.assert_login_fail(p, cred_ok.user, string.printable)  # too long password

--- a/psh/test.yaml
+++ b/psh/test.yaml
@@ -1,5 +1,15 @@
 test:
     tests:
+        - name: auth
+          harness: test-auth.py
+
+        #FIXME - test-pshlogin.py is only for targets with root
+        - name: pshlogin
+          harness: test-pshlogin.py
+          targets:
+              value:
+                  - ia32-generic
+
         - name: prompt
           harness: test-prompt.py
 

--- a/psh/tools/basic.py
+++ b/psh/tools/basic.py
@@ -1,3 +1,18 @@
+
+# Phoenix-RTOS
+#
+# phoenix-rtos-tests
+#
+# basic tools for psh related tests
+#
+# Copyright 2021 Phoenix Systems
+# Author: Jakub Sarzyński
+#
+# This file is part of Phoenix-RTOS.
+#
+# %LICENSE%
+#
+
 def run_psh(p):
     p.send('psh\r\n')
     p.expect(r'psh(\r+)\n')

--- a/psh/tools/basic.py
+++ b/psh/tools/basic.py
@@ -13,6 +13,9 @@
 # %LICENSE%
 #
 
+import pexpect
+
+
 def run_psh(p):
     p.send('psh\r\n')
     p.expect(r'psh(\r+)\n')
@@ -23,3 +26,25 @@ def assert_only_prompt(p):
     prompt = '\r\x1b[0J' + '(psh)% '
     got = p.read(len(prompt))
     assert got == prompt, f'Expected:\n{prompt}\nGot:\n{got}'
+
+
+def assert_prompt(p, msg=None, timeout=-1, catch_timeout=True):
+    if not msg:
+        msg = ''
+
+    patterns = ['(psh)% ']
+    if catch_timeout:
+        patterns.append(pexpect.TIMEOUT)
+
+    idx = p.expect_exact(patterns, timeout=timeout)
+    # if catch_timeout is false then pyexpect exception is raised
+    assert idx == 0, msg
+
+
+def assert_prompt_fail(p, msg=None, timeout=-1):
+    if not msg:
+        msg = ''
+
+    patterns = ['(psh)% ', pexpect.TIMEOUT]
+    idx = p.expect_exact(patterns, timeout=timeout)
+    assert idx == 1, msg

--- a/psh/tools/login.py
+++ b/psh/tools/login.py
@@ -12,9 +12,12 @@
 #
 # %LICENSE%
 #
+from collections import namedtuple
+
 import pexpect
 
-from collections import namedtuple
+from psh.tools.basic import assert_prompt, assert_prompt_fail
+
 
 Credentials = namedtuple('Credentials', 'user passwd')
 pshlogin_cmd = '/bin/pshlogin'
@@ -27,22 +30,14 @@ def log_in(p, login, passwd):
     p.send(passwd + '\n')
 
 
-def assert_failed_login(p):
-    assert p.expect_exact(['(psh)%', pexpect.TIMEOUT], timeout=1) > 0, 'Login should fail but passed'
-
-
-def assert_good_login(p):
-    assert p.expect_exact(['(psh)%', pexpect.TIMEOUT], timeout=1) == 0, 'Login should pass but failed'
-
-
 def assert_login(p, login, passwd):
     log_in(p, login, passwd)
-    assert_good_login(p)
+    assert_prompt(p, 'Login should pass but failed', timeout=1)
 
 
 def assert_login_fail(p, login, passwd):
     log_in(p, login, passwd)
-    assert_failed_login(p)
+    assert_prompt_fail(p, 'Login should fail but passed', timeout=1)
 
 
 def assert_login_empty(p, login):

--- a/psh/tools/login.py
+++ b/psh/tools/login.py
@@ -1,0 +1,50 @@
+#
+# Phoenix-RTOS
+#
+# phoenix-rtos-tests
+#
+# tools for login related testing
+#
+# Copyright 2021 Phoenix Systems
+# Author: Mateusz Niewiadomski
+#
+# This file is part of Phoenix-RTOS.
+#
+# %LICENSE%
+#
+import pexpect
+
+from collections import namedtuple
+
+Credentials = namedtuple('Credentials', 'user passwd')
+pshlogin_cmd = '/bin/pshlogin'
+
+
+def log_in(p, login, passwd):
+    p.send(login + '\n')
+    assert p.expect_exact([login, pexpect.TIMEOUT]) == 0, 'Cannot enter login to login prompt'
+    assert p.expect_exact(["Password:", pexpect.TIMEOUT]) == 0
+    p.send(passwd + '\n')
+
+
+def assert_failed_login(p):
+    assert p.expect_exact(['(psh)%', pexpect.TIMEOUT], timeout=1) > 0, 'Login should fail but passed'
+
+
+def assert_good_login(p):
+    assert p.expect_exact(['(psh)%', pexpect.TIMEOUT], timeout=1) == 0, 'Login should pass but failed'
+
+
+def assert_login(p, login, passwd):
+    log_in(p, login, passwd)
+    assert_good_login(p)
+
+
+def assert_login_fail(p, login, passwd):
+    log_in(p, login, passwd)
+    assert_failed_login(p)
+
+
+def assert_login_empty(p, login):
+    p.send(login + '\n')
+    assert p.expect_exact(['Login:', pexpect.TIMEOUT]) == 0, 'Empty login doesn`t repeat logging'


### PR DESCRIPTION
Tests added for:
 - pshlogin (only ia32)
 - auth applet (all arch)

JIRA: PD-75

<!--- Provide a general summary of your changes in the Title above -->

## Description
Two separate tests added as it is now impossible to properly test `pshlogin` on imxrt1064 (it needs binary rename).
 - `test-pshlogin.py` tests launching psh with login prompt. It does not test exitability as it needs launching it as a first psh. It is currently only for ia32
- `test-auth.py` is a similar test to `test-pshlogin.py` but it launches login prompt using `auth` command accessible in `psh`. It is a way to test login logic (searching for password etc) works without spawning new `psh`

As `pshlogin` uses `auth` applet not all features are duplicated in `pshlogin` tests, especially in places where there are no concerns of memory usage (e.g backspace handling)

Tests regarding issues with:
 - entering correct and incorrect combinations of login and password (together with illegal credentials)
 - handling entering and exiting login prompt
 - handling backspace

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Those two tests, with current state of repository, checks if everything works correctly with login related components of Phoenix-RTOS.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
