### PR TITLE
add led test state signalling for imxrt106x runner

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -89,6 +89,18 @@ def parse_args():
     return args
 
 
+def print_summary_successed(runner):
+    print("Succeeded!")
+    if 'armv7m7-imxrt106x' in runner.targets:
+        runner.runners['armv7m7-imxrt106x'].led('green', 'on')
+
+
+def print_summary_failed(runner):
+    print("Failed!")
+    if 'armv7m7-imxrt106x' in runner.targets:
+        runner.runners['armv7m7-imxrt106x'].led('red', 'on')
+
+
 def main():
     args = parse_args()
     set_logger(args.log_level)
@@ -108,10 +120,10 @@ def main():
     logging.info(summary)
 
     if failed == 0:
-        print("Succeeded!")
+        print_summary_successed(runner)
         sys.exit(0)
     else:
-        print("Failed!")
+        print_summary_failed(runner)
         sys.exit(1)
 
 

--- a/trunner/device.py
+++ b/trunner/device.py
@@ -324,7 +324,7 @@ class GPIO:
 
         self.gpio.setmode(self.gpio.BCM)
         self.gpio.setwarnings(False)
-        self.gpio.setup(self.pin, self.gpio.OUT)
+        self.gpio.setup(self.pin, self.gpio.OUT, initial=self.gpio.LOW)
 
     def high(self):
         self.gpio.output(self.pin, self.gpio.HIGH)
@@ -351,6 +351,23 @@ class IMXRT106xRunner(DeviceRunner):
         self.reset_gpio = GPIO(17)
         self.reset_gpio.high()
         self.boot_gpio = GPIO(4)
+        self.ledr_gpio = GPIO(13)
+        self.ledg_gpio = GPIO(18)
+        self.ledb_gpio = GPIO(12)
+        self.ledb_gpio.high()
+
+    def led(self, color, state="on"):
+        if state == "on" or state == "off":
+            self.ledr_gpio.low()
+            self.ledg_gpio.low()
+            self.ledb_gpio.low()
+        if state == "on":
+            if color == "red":
+                self.ledr_gpio.high()
+            if color == "green":
+                self.ledg_gpio.high()
+            if color == "blue":
+                self.ledb_gpio.high()
 
     def reset(self):
         self.reset_gpio.low()


### PR DESCRIPTION
JIRA: CI-63

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
-if test runner starts running tests - blue led is on
-if test runner fails - red led is on
-if test runner succeed - green led is on
 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It provides information about tests status in rack unit for testing 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt1064 evk).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
