### PR TITLE
resolve_path: missing_dir should return NULL

### DIFF
--- a/libc/resolve_path.c
+++ b/libc/resolve_path.c
@@ -175,8 +175,17 @@ TEST(resolve_path, missing_leaf)
 	check_null_and_errno(ENOENT, resolve_path("/etc/missing_file", NULL, 1, 0));
 	check_and_free_str("/etc/missing_file", resolve_path("/etc/missing_file", NULL, 1, 1));
 
+	check_and_free_str("/x", resolve_path("/x", NULL, 1, 1));
+	check_and_free_str("/etc/x", resolve_path("/etc/x", NULL, 1, 1));
+
 	check_null_and_errno(ENOENT, resolve_path("/etc/missing_dir/.", NULL, 1, 0));
-	check_and_free_str("/etc/missing_dir", resolve_path("/etc/missing_dir/.", NULL, 1, 1));
+	check_null_and_errno(ENOENT, resolve_path("/etc/missing_dir/.", NULL, 1, 1));
+}
+
+TEST(resolve_path, missing_branch)
+{
+	check_null_and_errno(ENOENT, resolve_path("/etc/missing_dir/missing_file", NULL, 1, 0));
+	check_null_and_errno(ENOENT, resolve_path("/etc/x/missing_file", NULL, 1, 0));
 }
 #endif
 
@@ -471,6 +480,7 @@ TEST_GROUP_RUNNER(resolve_path)
 
 #ifdef __phoenix__
 	RUN_TEST_CASE(resolve_path, missing_leaf);
+	RUN_TEST_CASE(resolve_path, missing_branch);
 #endif
 
 	RUN_TEST_CASE(resolve_path, symlink_abs);


### PR DESCRIPTION
JIRA: PD-160

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
According to (https://github.com/phoenix-rtos/libphoenix/pull/117) resolve_path should return NULL if presented a path with missing branch (not missing leaf). This PR changes output expected by test.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (https://github.com/phoenix-rtos/libphoenix/pull/117)
- [ ] I will merge this PR by myself when appropriate.
