### PR TITLE
runner: imxrt106x: add relay restart

### DIFF
--- a/trunner/config.py
+++ b/trunner/config.py
@@ -41,6 +41,9 @@ DEVICE_TARGETS = ['armv7m7-imxrt106x']
 # Port to communicate with hardware board
 DEVICE_SERIAL = "/dev/serial/by-path/platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.4:1.1"
 
+# DEVICE_SERIAL USB port address
+DEVICE_SERIAL_USB = "1-1.4"
+
 
 def rootfs(target: str) -> Path:
     return PHRTOS_PROJECT_DIR / '_fs' / target / 'root'

--- a/trunner/config.py
+++ b/trunner/config.py
@@ -39,7 +39,7 @@ DEFAULT_TARGETS = [target for target in ALL_TARGETS
 DEVICE_TARGETS = ['armv7m7-imxrt106x']
 
 # Port to communicate with hardware board
-DEVICE_SERIAL = "/dev/ttyACM0"
+DEVICE_SERIAL = "/dev/serial/by-path/platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.4:1.1"
 
 
 def rootfs(target: str) -> Path:

--- a/trunner/device.py
+++ b/trunner/device.py
@@ -40,8 +40,8 @@ def wait_for_dev(port, timeout=0):
 
     # naive wait for dev
     while not os.path.exists(port):
-        time.sleep(0.5)
-        asleep += 0.5
+        time.sleep(0.01)
+        asleep += 0.01
         if timeout and asleep >= timeout:
             raise TimeoutError
 


### PR DESCRIPTION
JIRA: CI-69

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

- runner: imxrt106x: change serial port to usb socket reference
- runner: imxrt106x: add _restart_by_poweroff procedure
- runner: imxrt106x: rename boot to reboot, add _restart_by_poweroff to it and add double reboot to load method
- runner: imxrt106x: decrease waiting for dev time step value
- runner: add power_usb_ports(enable: bool) function for power on and off rpi ports
- runner: add unbind_rpi_usb(port_address) function and DEVICE_SERIAL_USB const for port address

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It's for running each test on fresh mimxrt1064 eval kit (after power down and power up)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt106x - evk).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
