### PR TITLE
runner: resolve path backwards

### DIFF
--- a/trunner/config.py
+++ b/trunner/config.py
@@ -13,7 +13,9 @@ from typing import Dict, List, Tuple
 def resolve_phrtos_dir() -> Path:
     path = Path.cwd().absolute()
     try:
-        idx = path.parts.index('phoenix-rtos-project')
+        # Find last occurrence of phoenix-rtos-project
+        inverted_idx = path.parts[::-1].index('phoenix-rtos-project')
+        idx = len(path.parts) - 1 - inverted_idx
     except ValueError:
         print('Runner is lanuched not from the phoenix-rtos-project directory')
         return path


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Look for `phoenix-rots-project` in path from right to left instead from left to right.

`phoenix-rtos-project` run tests on a self-hosted runner using a path `/github-runner/_work/phoenix-rtos-project/phoenix-rtos-project`. The path should be split after second `phoenix-rtos-project` - not the first one. Knowing that, choose last occurrence of `phoenix-rtos-project`. 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
