### PR TITLE
libc: add exec functions tests

### DIFF
--- a/libc/harness/Makefile
+++ b/libc/harness/Makefile
@@ -1,0 +1,5 @@
+LOCAL_DIR := $(call my-dir)
+NAME := test_exec
+SRCS := $(wildcard $(LOCAL_DIR)*.c)
+
+include $(binary.mk)

--- a/libc/harness/test.yaml
+++ b/libc/harness/test.yaml
@@ -1,0 +1,6 @@
+test:
+    tests:
+        - name: exec
+          harness: test_exec.py
+          targets:
+              exclude: [armv7m7-imxrt106x]

--- a/libc/harness/test_exec.c
+++ b/libc/harness/test_exec.c
@@ -1,0 +1,204 @@
+/*
+ * Phoenix-RTOS
+ *
+ * libc-tests
+ *
+ * executable program for various exec functions
+ *
+ * Copyright 2021 Phoenix Systems
+ * Author: Damian Loewnau
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <ctype.h>
+#include <unistd.h>
+#include <string.h>
+#include <libgen.h>
+#include <errno.h>
+
+extern char **environ;
+
+
+static void test_exec_execveEnv(bool changeEnv)
+{
+	char *const arg[] = { "/bin/to_exec", NULL };
+	if (changeEnv) {
+		char *const env[] = { "TEST1=exec_value", NULL };
+		setenv("TEST1", "invalid_value", 1);
+		setenv("TEST2", "should_dissapear", 1);
+
+		if (execve("/bin/test_exec", arg, env) == -1) {
+			fprintf(stderr, "execve function failed: %s\n", strerror(errno));
+
+			exit(EXIT_FAILURE);
+		}
+	}
+	else {
+		setenv("TEST1", "unchanged_value", 1);
+
+		if (execve("/bin/test_exec", arg, environ) == -1) {
+			fprintf(stderr, "execve function failed: %s\n", strerror(errno));
+
+			exit(EXIT_FAILURE);
+		}
+	}
+}
+
+
+static void test_exec_execvePath(void)
+{
+	char *const arg[] = { "to_exec", NULL };
+
+	setenv("PATH", "/bin:/sbin:/usr/bin:/usr/sbin", 1);
+
+	if (execve("test_exec", arg, environ) == -1) {
+		fprintf(stderr, "execve function failed: %s\n", strerror(errno));
+
+		exit(EXIT_FAILURE);
+	}
+}
+
+
+static void test_exec_execvpeEnv(bool changeEnv)
+{
+	char *const arg[] = { "/bin/to_exec", NULL };
+	if (changeEnv) {
+		char *const env[] = { "TEST1=exec_value", NULL };
+		setenv("TEST1", "invalid_value", 1);
+		setenv("TEST2", "should_dissapear", 1);
+
+		if (execvpe("/bin/test_exec", arg, env) == -1) {
+			fprintf(stderr, "execvpe function failed: %s\n", strerror(errno));
+
+			exit(EXIT_FAILURE);
+		}
+	}
+	else {
+		setenv("TEST1", "unchanged_value", 1);
+
+		if (execvpe("/bin/test_exec", arg, environ) == -1) {
+			fprintf(stderr, "execvpe function failed: %s\n", strerror(errno));
+
+			exit(EXIT_FAILURE);
+		}
+	}
+}
+
+
+static void test_exec_execvpePath(void)
+{
+	char *const arg[] = { "to_exec", NULL };
+
+	setenv("PATH", "/bin:/sbin:/usr/bin:/usr/sbin", 1);
+
+	if (execvpe("test_exec", arg, environ) == -1) {
+		fprintf(stderr, "execve function failed: %s\n", strerror(errno));
+
+		exit(EXIT_FAILURE);
+	}
+}
+
+
+static void test_exec_execvpEnv(void)
+{
+	char *const arg[] = { "/bin/to_exec", NULL };
+
+	setenv("TEST1", "unchanged_value", 1);
+
+	if (execvp("/bin/test_exec", arg) == -1) {
+		fprintf(stderr, "execvp function failed: %s\n", strerror(errno));
+
+		exit(EXIT_FAILURE);
+	}
+}
+
+
+static void test_exec_execvpPath(void)
+{
+	char *const arg[] = { "to_exec", NULL };
+
+	setenv("PATH", "/bin:/sbin:/usr/bin:/usr/sbin", 1);
+
+	if (execvp("test_exec", arg) == -1) {
+		fprintf(stderr, "execvp function failed: %s\n", strerror(errno));
+
+		exit(EXIT_FAILURE);
+	}
+}
+
+
+int main(int argc, char *argv[])
+{
+	bool changeEnv;
+
+	if (!strcmp(basename(argv[0]), "to_exec")) {
+		int i;
+		printf("argc = %d\n", argc);
+
+		for (i = 0; argv[i] != NULL; i++) {
+			printf("argv[%d] = %s\n", i, argv[i]);
+		}
+
+		for (i = 0; environ[i] != NULL; i++) {
+			printf("environ[%d] = %s\n", i, environ[i]);
+		}
+	}
+	else {
+		if ((argc == 1) || (atoi(argv[1]) > 10) || (atoi(argv[1]) < 0)) {
+			fprintf(stderr, "Please specify test case number (1 to 10)\n");
+			return 1;
+		}
+
+		clearenv();
+
+		switch (atoi(argv[1])) {
+			case 1:
+				changeEnv = true;
+				test_exec_execveEnv(changeEnv);
+				break;
+
+			case 2:
+				changeEnv = false;
+				test_exec_execveEnv(changeEnv);
+				break;
+
+			case 3:
+				changeEnv = true;
+				test_exec_execvePath();
+				break;
+
+			case 4:
+				changeEnv = true;
+				test_exec_execvpeEnv(changeEnv);
+				break;
+
+			case 5:
+				changeEnv = false;
+				test_exec_execvpeEnv(changeEnv);
+				break;
+
+			case 6:
+				test_exec_execvpePath();
+				break;
+
+			case 7:
+				test_exec_execvpEnv();
+				break;
+
+			case 8:
+				test_exec_execvpPath();
+				break;
+
+			default:
+				break;
+		}
+	}
+
+	return 0;
+}

--- a/libc/harness/test_exec.py
+++ b/libc/harness/test_exec.py
@@ -1,0 +1,109 @@
+# Phoenix-RTOS
+#
+# libc-tests
+#
+# various exec functions tests
+#
+# Copyright 2021 Phoenix Systems
+# Author: Damian Loewnau
+#
+# This file is part of Phoenix-RTOS.
+#
+# %LICENSE%
+#
+
+from psh.tools.basic import run_psh, assert_only_prompt, assert_expected
+
+
+def assert_execve_env_changed(p):
+    cmd = '/bin/test_exec 1'
+    expected = (r'(argc = 1(\r+)\n)'
+                r'(argv\[0\] = /bin/to_exec(\r+)\n)'
+                r'(environ\[0\] = TEST1=exec_value(\r+)\n)'
+                r'(\r\x1b\[0J\(psh\)%)')
+
+    assert_expected(p, cmd, expected, "Wrong output of execve function with changed environment")
+
+
+def assert_execve_env_unchanged(p):
+    cmd = '/bin/test_exec 2'
+    expected = (r'(argc = 1(\r+)\n)'
+                r'(argv\[0\] = /bin/to_exec(\r+)\n)'
+                r'(environ\[0\] = TEST1=unchanged_value(\r+)\n)'
+                r'(\r\x1b\[0J\(psh\)%)')
+
+    assert_expected(p, cmd, expected, "Wrong output of execve function with unchanged environment")
+
+
+def assert_execve_path_searched(p):
+    cmd = '/bin/test_exec 3'
+    expected = (r'(argc = 1(\r+)\n)'
+                r'(argv\[0\] = to_exec(\r+)\n)'
+                r'(environ\[0\] = PATH=/bin:/sbin:/usr/bin:/usr/sbin(\r+)\n)'
+                r'(\r\x1b\[0J\(psh\)%)')
+
+    assert_expected(p, cmd, expected, "Wrong output of execve function with searching in PATH environment variable")
+
+
+def assert_execvpe_env_changed(p):
+    cmd = '/bin/test_exec 4'
+    expected = (r'(argc = 1(\r+)\n)'
+                r'(argv\[0\] = /bin/to_exec(\r+)\n)'
+                r'(environ\[0\] = TEST1=exec_value(\r+)\n)'
+                r'(\r\x1b\[0J\(psh\)%)')
+
+    assert_expected(p, cmd, expected, "Wrong output of execvpe function with changed environment")
+
+
+def assert_execvpe_env_unchanged(p):
+    cmd = '/bin/test_exec 5'
+    expected = (r'(argc = 1(\r+)\n)'
+                r'(argv\[0\] = /bin/to_exec(\r+)\n)'
+                r'(environ\[0\] = TEST1=unchanged_value(\r+)\n)'
+                r'(\r\x1b\[0J\(psh\)%)')
+
+    assert_expected(p, cmd, expected, "Wrong output of execvpe function with unchanged environment")
+
+
+def assert_execvpe_path_searched(p):
+    cmd = '/bin/test_exec 6'
+    expected = (r'(argc = 1(\r+)\n)'
+                r'(argv\[0\] = to_exec(\r+)\n)'
+                r'(environ\[0\] = PATH=/bin:/sbin:/usr/bin:/usr/sbin(\r+)\n)'
+                r'(\r\x1b\[0J\(psh\)%)')
+
+    assert_expected(p, cmd, expected, "Wrong output of execvpe function with searching in PATH environment variable")
+
+
+def assert_execvp_env_unchanged(p):
+    cmd = '/bin/test_exec 7'
+    expected = (r'(argc = 1(\r+)\n)'
+                r'(argv\[0\] = /bin/to_exec(\r+)\n)'
+                r'(environ\[0\] = TEST1=unchanged_value(\r+)\n)'
+                r'(\r\x1b\[0J\(psh\)%)')
+
+    assert_expected(p, cmd, expected, "Wrong output of execvp function with unchanged environment")
+
+
+def assert_execvp_path_searched(p):
+    cmd = '/bin/test_exec 8'
+    expected = (r'(argc = 1(\r+)\n)'
+                r'(argv\[0\] = to_exec(\r+)\n)'
+                r'(environ\[0\] = PATH=/bin:/sbin:/usr/bin:/usr/sbin(\r+)\n)'
+                r'(\r\x1b\[0J\(psh\)%)')
+
+    assert_expected(p, cmd, expected, "Wrong output of execvp function with searching in PATH environment variable")
+
+
+def harness(p):
+    run_psh(p)
+    assert_only_prompt(p)
+
+    assert_execve_env_changed(p)
+    assert_execve_env_unchanged(p)
+    assert_execve_path_searched(p)
+    assert_execvpe_env_changed(p)
+    assert_execvpe_env_unchanged(p)
+    assert_execvpe_path_searched(p)
+    assert_execvp_env_unchanged(p)
+    assert_execvp_path_searched(p)

--- a/psh/tools/basic.py
+++ b/psh/tools/basic.py
@@ -6,7 +6,7 @@
 # basic tools for psh related tests
 #
 # Copyright 2021 Phoenix Systems
-# Author: Jakub Sarzyński
+# Author: Jakub Sarzyński, Damian Loewnau
 #
 # This file is part of Phoenix-RTOS.
 #
@@ -14,6 +14,12 @@
 #
 
 import pexpect
+
+
+def assert_expected(p, cmd, expected, msg=''):
+    p.sendline(cmd)
+    p.expect_exact(cmd)
+    assert p.expect([expected, pexpect.TIMEOUT]) == 0, msg
 
 
 def run_psh(p):


### PR DESCRIPTION
JIRA: PD-175

<!--- Provide a general summary of your changes in the Title above -->
add exec functions tests
## Description
<!--- Describe your changes shortly -->
- create directory harness for harness tests in libc directory
- create text_exec.c, which executes itself using execve, execvpe, and execvp (different test cases)
- create harness test_exec.py, which executes test_exec.c with individual test cases
- add assert_expected function to psh/tools/basic.py

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When running busybox tests, there was a suspicion that the execve function was not working properly
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic - qemu).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
