### PR TITLE
runner: fix searcher regex for pexpect fail output

### DIFF
--- a/trunner/testcase.py
+++ b/trunner/testcase.py
@@ -112,7 +112,7 @@ class TestCase:
         # Look for searched pattern
         # pexpect searcher object is cleared when timeout exception is raised
         # parse patterns directly from the exception message
-        r_searched = r"[\d+]: (?:re.compile\()?b?'(.*)'\)?"
+        r_searched = r"[\d+]: (?:re.compile\()?b?['\"](.*)['\"]\)?"
         searched_patterns = re.findall(r_searched, exc.value)
 
         self.exception += Color.colorify('EXPECTED:\n', Color.BOLD)


### PR DESCRIPTION
JIRA: PD-192

<!--- Provide a general summary of your changes in the Title above -->
- fix searcher regex for pexpect fail output
## Description
<!--- Describe your changes shortly -->
- searcher regex didn't find string with apostrophe
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

![Screenshot from 2021-09-22 14-07-31](https://user-images.githubusercontent.com/77304431/134348743-00dab915-fb8d-4918-a574-9c1399fdec78.png)
before fix:
![Screenshot from 2021-09-22 14-08-40](https://user-images.githubusercontent.com/77304431/134348793-f8ac0b38-e92b-4ad4-8950-d7062fab6c61.png)
after fix:
![Screenshot from 2021-09-22 15-06-48](https://user-images.githubusercontent.com/77304431/134349124-22b47417-eae1-47c9-9924-ed66e56e3060.png)
after fix:


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
