### PR TITLE
trunner: split runners into separate files

### DIFF
--- a/trunner/config.py
+++ b/trunner/config.py
@@ -45,10 +45,6 @@ DEVICE_SERIAL = "/dev/serial/by-path/platform-fd500000.pcie-pci-0000:01:00.0-usb
 DEVICE_SERIAL_USB = "1-1.4"
 
 
-def rootfs(target: str) -> Path:
-    return PHRTOS_PROJECT_DIR / '_fs' / target / 'root'
-
-
 class ParserError(Exception):
     pass
 

--- a/trunner/device.py
+++ b/trunner/device.py
@@ -1,9 +1,9 @@
 # Imports of available runners
-from .runners.IMXRT106xRunner import IMXRT106xRunner
-from .runners.QemuRunner import QemuRunner
 from .runners.HostRunner import HostRunner
+from .runners.QemuRunner import QemuRunner
+from .runners.IMXRT106xRunner import IMXRT106xRunner
 
-from .config import PHRTOS_PROJECT_DIR, DEVICE_SERIAL, DEVICE_SERIAL_USB, rootfs
+from .config import PHRTOS_PROJECT_DIR, DEVICE_SERIAL, DEVICE_SERIAL_USB
 
 
 QEMU_CMD = {
@@ -26,6 +26,6 @@ class RunnerFactory:
         if target == 'host-pc':
             return HostRunner()
         if target == 'armv7m7-imxrt106x':
-            return IMXRT106xRunner(DEVICE_SERIAL)
+            return IMXRT106xRunner((DEVICE_SERIAL, DEVICE_SERIAL_USB))
 
         raise ValueError(f"Unknown Runner target: {target}")

--- a/trunner/runners/HostRunner.py
+++ b/trunner/runners/HostRunner.py
@@ -1,4 +1,17 @@
-from .common import *
+#
+# Phoenix-RTOS test runner
+#
+# host-pc runner
+#
+# Copyright 2021 Phoenix SYstems
+# Authors: Jakub Sarzyński, Mateusz Niewiadomski, Damian Loewnau
+#
+
+import pexpect
+import signal
+
+from .common import Runner
+from .common import rootfs
 
 
 class HostRunner(Runner):

--- a/trunner/runners/QemuRunner.py
+++ b/trunner/runners/QemuRunner.py
@@ -1,4 +1,16 @@
-from .common import *
+#
+# Phoenix-RTOS test runner
+#
+# ia32-generic qemu emulator runner
+#
+# Copyright 2021 Phoenix SYstems
+# Authors: Jakub Sarzyński, Mateusz Niewiadomski, Damian Loewnau
+#
+
+import pexpect
+import signal
+
+from .common import Runner
 
 
 class QemuRunner(Runner):

--- a/trunner/runners/common.py
+++ b/trunner/runners/common.py
@@ -1,3 +1,12 @@
+#
+# Phoenix-RTOS test runner
+#
+# Common parts of phoenix-rtos test runners
+#
+# Copyright 2021 Phoenix SYstems
+# Authors: Jakub Sarzyński, Mateusz Niewiadomski, Damian Loewnau
+#
+
 import importlib
 import logging
 import os
@@ -11,16 +20,19 @@ import pexpect.fdpexpect
 import serial
 import subprocess
 
-from pexpect.exceptions import TIMEOUT, EOF
+from pathlib import Path
 
-sys.path.append('../trunner')
-from trunner.config import PHRTOS_PROJECT_DIR, DEVICE_SERIAL, DEVICE_SERIAL_USB, rootfs
+from trunner.config import PHRTOS_PROJECT_DIR
 from trunner.tools.color import Color
 
 
 _BOOT_DIR = PHRTOS_PROJECT_DIR / '_boot'
 _HOME_DIR = os.path.expanduser('~')
 _LOGFILE = _HOME_DIR + '/logfile.dat'
+
+
+def rootfs(target: str) -> Path:
+    return PHRTOS_PROJECT_DIR / '_fs' / target / 'root'
 
 
 def is_github_actions():
@@ -356,10 +368,3 @@ class GPIO:
 
     def low(self):
         self.gpio.output(self.pin, self.gpio.LOW)
-
-
-
-
-
-
-


### PR DESCRIPTION
JIRA: SKAL-177

<!--- Provide a general summary of your changes in the Title above -->

## Description
 - Device runners for each target are now split into separate files inside `trunner/runners/` subdirectory.
 - methods and classes that may be share across multiple targets are stored inside trunner/runners/common.py`
 - changed the way usb ports are passed to `IMXRT106xRunner`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
All runners are stored inside one big file `device.py`. Development of new runners continues and soon this will be a bottleneck.
This split aims to tidy up the structure of _trunner_ files. However there is still room for improvement as some target specific function from `common.py` may be moved to runner files. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic runner.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
