### PR TITLE
trunner: runners importing and HostRunner logic change

### DIFF
--- a/trunner/device.py
+++ b/trunner/device.py
@@ -1,7 +1,5 @@
 # Imports of available runners
-from .runners.HostRunner import HostRunner
-from .runners.QemuRunner import QemuRunner
-from .runners.IMXRT106xRunner import IMXRT106xRunner
+from .runners import HostRunner, QemuRunner, IMXRT106xRunner
 
 from .config import PHRTOS_PROJECT_DIR, DEVICE_SERIAL, DEVICE_SERIAL_USB
 

--- a/trunner/runners/HostRunner.py
+++ b/trunner/runners/HostRunner.py
@@ -8,7 +8,6 @@
 #
 
 import pexpect
-import signal
 
 from .common import Runner
 from .common import rootfs
@@ -24,17 +23,12 @@ class HostRunner(Runner):
         test_path = rootfs(test.target) / 'bin' / test.exec_cmd[0]
 
         try:
-            proc = pexpect.spawn(
+            with pexpect.spawn(
                 str(test_path),
                 args=test.exec_cmd[1:],
-                encoding='utf-8',
-                timeout=test.timeout
-            )
+                encoding="utf-8",
+                timeout=test.timeout,
+            ) as proc:
+                test.handle(proc, psh=False)
         except pexpect.exceptions.ExceptionPexpect:
             test.handle_exception()
-            return
-
-        try:
-            test.handle(proc, psh=False)
-        finally:
-            proc.kill(signal.SIGTERM)

--- a/trunner/runners/__init__.py
+++ b/trunner/runners/__init__.py
@@ -1,0 +1,16 @@
+#
+# Phoenix-RTOS test runner
+#
+# runners package definition
+#
+# Every new runner shall be imported only here and added to __all__ for import clarity
+#
+# Copyright 2021 Phoenix Systems
+# Authors: Mateusz Niewiadomski
+#
+
+from .HostRunner import HostRunner
+from .QemuRunner import QemuRunner
+from .IMXRT106xRunner import IMXRT106xRunner
+
+__all__ = ['HostRunner', 'QemuRunner', 'IMXRT106xRunner']

--- a/trunner/runners/common.py
+++ b/trunner/runners/common.py
@@ -27,8 +27,6 @@ from trunner.tools.color import Color
 
 
 _BOOT_DIR = PHRTOS_PROJECT_DIR / '_boot'
-_HOME_DIR = os.path.expanduser('~')
-_LOGFILE = _HOME_DIR + '/logfile.dat'
 
 
 def rootfs(target: str) -> Path:
@@ -39,11 +37,6 @@ def is_github_actions():
     return os.getenv('GITHUB_ACTIONS', False)
 
 
-def save_in_logfile(wait_time=0):
-    with open(_LOGFILE, "a") as f:
-        f.write(f'{wait_time}\n')
-
-
 def wait_for_dev(port, timeout=0):
     asleep = 0
 
@@ -52,9 +45,7 @@ def wait_for_dev(port, timeout=0):
         time.sleep(0.01)
         asleep += 0.01
         if timeout and asleep >= timeout:
-            save_in_logfile(wait_time=asleep)
             raise TimeoutError
-    save_in_logfile(wait_time=asleep)
 
 
 def power_usb_ports(enable: bool):


### PR DESCRIPTION
JIRA: CI-89

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Little changes to trunner logic in:
 - HostRunner: safer process killing logic
 - runners package: created runners package with all runners available
 - removed logging feature which is obsolete by now (added and confirmed @damianloew )

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
 - HostRunner logic has a loophole where the process can be left running after `SIGTERM`
 - runners package ease the process of adding new runner by aggregating runners into package which can be easily imported in `device.py` 
 - logging in current form is obsolete and if it will be back it should be done with different approach 

Following the issue:
 - https://github.com/phoenix-rtos/phoenix-rtos-project/issues/214

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
