### PR TITLE
runner: `--baudrate` option and `psh` yaml property

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -65,9 +65,14 @@ def parse_args():
                         help="Specify verbosity level. By default uses level info.")
 
     parser.add_argument("-s", "--serial",
-                        default=config.DEVICE_SERIAL,
+                        default=config.DEVICE_SERIAL_PORT,
                         help="Specify serial to communicate with device board. "
                              "By default uses %(default)s.")
+
+    parser.add_argument("-b", "--baudrate",
+                        default=config.DEVICE_SERIAL_BAUDRATE,
+                        help="Specify the connection speed of serial. "
+                             "By default uses 115200")
 
     parser.add_argument("--no-flash",
                         default=False, action='store_true',
@@ -85,7 +90,10 @@ def parse_args():
         args.target = config.ALL_TARGETS
 
     if not args.serial:
-        args.serial = config.DEVICE_SERIAL
+        args.serial = config.DEVICE_SERIAL_PORT
+
+    if not args.baudrate:
+        args.serial = config.DEVICE_SERIAL_BAUDRATE
 
     return args
 
@@ -110,7 +118,8 @@ def main():
                          test_paths=args.test,
                          build=args.build,
                          flash=not args.no_flash,
-                         serial=args.serial)
+                         serial=(args.serial, args.baudrate)
+                         )
 
     passed, failed, skipped = runner.run()
 

--- a/trunner/config.py
+++ b/trunner/config.py
@@ -45,9 +45,6 @@ DEVICE_SERIAL_BAUDRATE = 115200
 # DEVICE_SERIAL USB port address
 DEVICE_SERIAL_USB = "1-1.4"
 
-# Default psh prompt
-DEFAULT_PROMPT = '(psh)% '
-
 
 class ParserError(Exception):
     pass
@@ -112,7 +109,6 @@ class Config(dict):
     def setdefaults(self) -> None:
         self.setdefault('ignore', False)
         self.setdefault('type', 'unit')
-        self.setdefault('prompt', '(psh)% ')
         self.setdefault('psh', True)
         self.setdefault('timeout', PYEXPECT_TIMEOUT)
         self.setdefault_targets()
@@ -144,7 +140,7 @@ class TestConfig(Config):
 
 
 class ConfigParser:
-    KEYWORDS: Tuple[str, ...] = ('exec', 'harness', 'ignore', 'name', 'targets', 'psh', 'prompt', 'timeout', 'type')
+    KEYWORDS: Tuple[str, ...] = ('exec', 'harness', 'ignore', 'name', 'targets', 'psh', 'timeout', 'type')
     TEST_TYPES: Tuple[str, ...] = ('unit', 'harness')
 
     def parse_keywords(self, config: Config) -> None:
@@ -220,22 +216,11 @@ class ConfigParser:
 
         config['exec'] = shlex.split(exec_cmd)
 
-    def parse_prompt(self, config: Config) -> None:
-        prompt = config.get('prompt')
-        if not prompt:
-            return
-
     def parse_psh(self, config: Config) -> None:
-        psh = config.get('psh')
-        if not psh:
-            return
-        psh = str(psh).lower()
-        if psh == 'true':
-            config['psh'] = True
-        elif psh == 'false':
-            config['psh'] = False
-        else:
-            raise ParserError(f'psh value of {psh} is not "True" or "False"')
+        psh = config.get('psh', True)
+
+        if not isinstance(psh, bool):
+            raise ParserError(f'psh must be a boolean value (true/false) not {psh}')
 
     def parse(self, config: Config) -> None:
         self.parse_keywords(config)
@@ -245,7 +230,6 @@ class ConfigParser:
         self.parse_timeout(config)
         self.parse_ignore(config)
         self.parse_exec(config)
-        self.parse_prompt(config)
         self.parse_psh(config)
 
     def resolve_harness(self, config: Config, path: Path) -> None:

--- a/trunner/config.py
+++ b/trunner/config.py
@@ -39,7 +39,8 @@ DEFAULT_TARGETS = [target for target in ALL_TARGETS
 DEVICE_TARGETS = ['armv7m7-imxrt106x']
 
 # Port to communicate with hardware board
-DEVICE_SERIAL = "/dev/serial/by-path/platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.4:1.1"
+DEVICE_SERIAL_PORT = "/dev/serial/by-path/platform-fd500000.pcie-pci-0000:01:00.0-usb-0:1.4:1.1"
+DEVICE_SERIAL_BAUDRATE = 115200
 
 # DEVICE_SERIAL USB port address
 DEVICE_SERIAL_USB = "1-1.4"

--- a/trunner/runners/HostRunner.py
+++ b/trunner/runners/HostRunner.py
@@ -22,6 +22,9 @@ class HostRunner(Runner):
 
         test_path = rootfs(test.target) / 'bin' / test.exec_cmd[0]
 
+        # host-pc tests must not use psh prompt
+        test.psh = False
+
         try:
             with pexpect.spawn(
                 str(test_path),
@@ -29,6 +32,6 @@ class HostRunner(Runner):
                 encoding="utf-8",
                 timeout=test.timeout,
             ) as proc:
-                test.handle(proc, psh=False)
+                test.handle(proc)
         except pexpect.exceptions.ExceptionPexpect:
             test.handle_exception()

--- a/trunner/runners/IMXRT106xRunner.py
+++ b/trunner/runners/IMXRT106xRunner.py
@@ -94,7 +94,7 @@ class IMXRT106xRunner(DeviceRunner):
 
         phd = None
         try:
-            with PloTalker(self.port) as plo:
+            with PloTalker(self.serial_port) as plo:
                 Psu(script=self.SDP).run()
                 plo.wait_prompt()
                 with Phoenixd(self.phoenixd_port) as phd:
@@ -121,7 +121,7 @@ class IMXRT106xRunner(DeviceRunner):
         load_dir = str(rootfs(test.target) / 'bin')
         self.reboot(cut_power=self.is_cut_power_used)
         try:
-            with PloTalker(self.port) as plo:
+            with PloTalker(self.serial_port) as plo:
                 # Because of powering all Rpi ports after powering the board,
                 # there is need to second reboot (without cut power) in order to capture all data
                 # (when using _restart_by_poweroff)

--- a/trunner/runners/STM32L4Runner.py
+++ b/trunner/runners/STM32L4Runner.py
@@ -71,7 +71,7 @@ class STM32L4Runner(DeviceRunner):
             return
 
         try:
-            self.serial = serial.Serial(self.port, baudrate=115200)
+            self.serial = serial.Serial(self.serial_port, baudrate=self.serial_baudrate)
         except serial.SerialException:
             test.handle_exception()
             return

--- a/trunner/runners/common.py
+++ b/trunner/runners/common.py
@@ -320,8 +320,9 @@ class Runner:
 class DeviceRunner(Runner):
     """This class provides interface to run test case using serial port"""
 
-    def __init__(self, port):
-        self.port = port
+    def __init__(self, serial):
+        self.serial_port = serial[0]
+        self.serial_baudrate = serial[1]
         self.serial = None
 
     def run(self, test):
@@ -329,7 +330,7 @@ class DeviceRunner(Runner):
             return
 
         try:
-            self.serial = serial.Serial(self.port, baudrate=115200)
+            self.serial = serial.Serial(self.serial_port, baudrate=self.serial_baudrate)
         except serial.SerialException:
             test.handle_exception()
             return

--- a/trunner/test/test_config.py
+++ b/trunner/test/test_config.py
@@ -102,6 +102,26 @@ class Test_ConfigParser:
 
     @pytest.mark.parametrize('case, answer', [
         ({}, None),
+        ({'psh': True}, True),
+        ({'psh': False}, False),
+    ])
+    def test_psh_keyword(self, parser, case, answer):
+        test = TestConfig(case)
+        parser.parse_psh(test)
+        assert test.get('psh') == answer
+
+    @pytest.mark.parametrize('case', [
+        {'psh': 'false'},
+        {'psh': 1},
+        {'psh': 'yes'},
+    ])
+    def test_psh_keyword_exc(self, parser, case):
+        test = TestConfig(case)
+        with pytest.raises(ParserError):
+            parser.parse_psh(test)
+
+    @pytest.mark.parametrize('case, answer', [
+        ({}, None),
         ({'timeout': 1}, 1),
         ({'timeout': '10'}, 10),
         ({'timeout': 0}, 0),

--- a/trunner/test/test_exceptions.py
+++ b/trunner/test/test_exceptions.py
@@ -25,7 +25,8 @@ class TestPexpectException:
             name='xyz',
             target=ALL_TARGETS[0],
             timeout=3,
-            exec_cmd=['xyz']
+            exec_cmd=['xyz'],
+            psh=False
         )
 
     @pytest.fixture(scope="class")
@@ -59,7 +60,7 @@ class TestPexpectException:
 
         proc = pexpect.fdpexpect.fdspawn(fifo_r, encoding='utf-8', timeout=1)
         testcase.harness = TestPexpectException.fake_harness
-        testcase.handle(proc, psh=False)
+        testcase.handle(proc)
 
         # Release lock for writer to close fifo
         lock.release()
@@ -90,7 +91,7 @@ class TestPexpectException:
 
         proc = pexpect.fdpexpect.fdspawn(fifo_r, encoding='utf-8')
         testcase.harness = TestPexpectException.fake_harness
-        testcase.handle(proc, psh=False)
+        testcase.handle(proc)
 
         fifo_r.close()
 
@@ -125,7 +126,8 @@ class TestExceptionHandler:
             name='xyz',
             target=ALL_TARGETS[0],
             timeout=3,
-            exec_cmd=['xyz']
+            exec_cmd=['xyz'],
+            psh=False
         )
 
     def test_assert(self, testcase):
@@ -133,7 +135,7 @@ class TestExceptionHandler:
             assert False
 
         testcase.harness = TestExceptionHandler.fake_harness(foo)
-        testcase.handle(proc=None, psh=False)
+        testcase.handle(proc=None)
 
         TestExceptionHandler.assert_exc_msg(testcase, ('harness', 'foo'))
 
@@ -142,7 +144,7 @@ class TestExceptionHandler:
             assert False, "boo has failed!"
 
         testcase.harness = TestExceptionHandler.fake_harness(foo)
-        testcase.handle(proc=None, psh=False)
+        testcase.handle(proc=None)
 
         TestExceptionHandler.assert_exc_msg(testcase, ('harness', 'foo'))
         assert "boo has failed!" in testcase.exception
@@ -152,7 +154,7 @@ class TestExceptionHandler:
             raise Exception("boo has failed!")
 
         testcase.harness = TestExceptionHandler.fake_harness(foo)
-        testcase.handle(proc=None, psh=False)
+        testcase.handle(proc=None)
 
         TestExceptionHandler.assert_exc_msg(testcase, ('harness', 'foo'))
         assert 'Exception: boo has failed!' in testcase.exception


### PR DESCRIPTION
JIRA: SKAL-193

<!--- Provide a general summary of your changes in the Title above -->

## Description
Added two new features to runner:
 - `--baudrate` commandline option specifying the serial communication speed
 - `psh` yaml property which if runner should expect psh to appear on serial connection

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
 - `--baudrate`:
   - Some future test targets can have multiple serial speed connections, so this may be handy for development purposes.
   - For full configuration there should be options for parity bits/stop bits etc. but this should be done when those config options will be moved to some _yaml_ config file
   - this change should not be necessary for full CI, but rather for development of new runners, together with project specific runners
 - `psh`:
   - some tests or test targets may not run through `psh` shell so it should be possible to specify it

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (stm32l4).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
