### PR TITLE
workflows: add getting hardware test targets from one file

### DIFF
--- a/.github/hw_targets.json
+++ b/.github/hw_targets.json
@@ -1,0 +1,1 @@
+["armv7m7-imxrt106x"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,18 @@ on:
 
 # jobs
 jobs:
+  # getting hardware test targets from the file placed in phoenix-rtos-tests repository
+  get-hw-targets:
+    name: get hardware targets for testing
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get hardware test targets
+        id: get_file
+        run: |
+          echo "::set-output name=matrix::$(curl https://raw.githubusercontent.com/phoenix-rtos/phoenix-rtos-tests/damianloew/get_hw_targets_from_file/.github/hw_targets.json)"
+    outputs:
+      matrix: ${{ steps.get_file.outputs.matrix }}
+
   build:
     name: build image
     runs-on: ubuntu-latest
@@ -111,14 +123,14 @@ jobs:
           target: ${{ matrix.target }}
 
   test-hw:
-    needs: build
+    needs: ['build', 'get-hw-targets']
     name: run tests on hardware
     runs-on: ${{ matrix.target }}
     outputs:
       runner_result: ${{ steps.runner.outcome }}
     strategy:
       matrix:
-        target: ['armv7m7-imxrt106x']
+        target: ${{ fromJson(needs.get-hw-targets.outputs.matrix) }}
 
     steps:
       - name: Checkout phoenix-rtos-project


### PR DESCRIPTION
JIRA: CI-97

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

workflows: add getting hardware test targets from one file

- add getting targets for test-hw job from file in phoenix-rtos-tests (temporarily from this branch, after merge the file will be in master branch and I will update it)
- add file hw_targets.json file in .github directory


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change will allow adding and removing hardware targets for testing simply by editing one file (instead of all ci.yaml files in various repos).
 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
