### PR TITLE
psh: change behaviour when passing regex to assert_cmd in psh test module

### DIFF
--- a/psh/test-cat-shells.py
+++ b/psh/test-cat-shells.py
@@ -19,7 +19,7 @@ def harness(p):
     psh.init(p)
 
     fname = 'etc/shells'
-    fcontent = r'# /etc/shells: valid login shells(\r+)\n/bin/sh'
+    expected = r'# /etc/shells: valid login shells(\r+)\n/bin/sh(\r+)\n'
     cmd = f'cat {fname}'
 
-    psh.assert_cmd(p, cmd, expected=fcontent, msg='The /etc/shells/ file content is invalid', is_regex=True)
+    psh.assert_cmd(p, cmd, expected, msg='The /etc/shells/ file content is invalid', is_regex=True)

--- a/psh/tools/README.md
+++ b/psh/tools/README.md
@@ -4,7 +4,7 @@
 
 The python module `psh` makes writing harness tests easier. It provides the following functions:
 
-* `assert_cmd(pexpect_proc, cmd, expected, msg, is_regex)` - Sends a specified command and asserts that it's displayed correctly with optional expected output and next prompt. The function also checks if there are no unwanted pieces of information. It's possible to pass a regex in the `expected` argument, but then `is_regex` has to be set True. Multi-line expected outputs have to be passed in a tuple, with lines in specific items. There is also a possibility to pass an additional message to print if the assertion fails. For a more readable assertion message in case that the test fails, the expected output is printed as regex, but in separate lines. So EOL, which is `r'(\r+)\n'` is replaced by `'\n'`.
+* `assert_cmd(pexpect_proc, cmd, expected, msg, is_regex)` - Sends a specified command and asserts that it's displayed correctly with optional expected output and next prompt. The function also checks if there are no unwanted pieces of information. It's possible to pass a regex in the `expected` argument, but then `is_regex` has to be set True. The regex should be passed as one raw string and match `EOL` after an expected output. Multi-line expected outputs have to be passed in a tuple, with lines in specific items. There is also a possibility to pass an additional message to print if the assertion fails. For a more readable assertion message in case that the test fails, the expected output is printed as regex, but in separate lines. So EOL, which is `r'(\r+)\n'` is replaced by `'\n'`.
 
 * `assert_only_prompt(pexpect_proc)` - assert psh prompt with the appropriate esc sequence.
 

--- a/psh/tools/psh.py
+++ b/psh/tools/psh.py
@@ -42,13 +42,15 @@ def assert_cmd(pexpect_proc, cmd, expected, msg='', is_regex=False):
     with optional expected output and next prompt'''
     pexpect_proc.sendline(cmd)
     cmd = re.escape(cmd)
-    exp_regex = ''
-    if not isinstance(expected, tuple):
-        expected = tuple((expected,))
-    for line in expected:
-        if not is_regex:
+    if is_regex:
+        exp_regex = expected
+    else:
+        exp_regex = ''
+        if not isinstance(expected, tuple):
+            expected = tuple((expected,))
+        for line in expected:
             line = re.escape(line)
-        exp_regex += line + EOL
+            exp_regex += line + EOL
 
     exp_regex = cmd + EOL + exp_regex + PROMPT
     exp_readable = _readable(exp_regex)


### PR DESCRIPTION

JIRA: PD-77

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

disable matching `EOL` after expected output when passing regex to `assert_cmd()` function in psh test module

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Finally it's easier to match multi line output using regex when matching last `EOL` is disabled.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
