### PR TITLE
tests-libc: add tests of pid/uid related functions in unistd.h

### DIFF
--- a/libc/main.c
+++ b/libc/main.c
@@ -22,6 +22,7 @@ void runner(void)
 	RUN_TEST_GROUP(resolve_path);
 	RUN_TEST_GROUP(file);
 	RUN_TEST_GROUP(unistd_getopt);
+	RUN_TEST_GROUP(unistd_uids);
 	RUN_TEST_GROUP(string_strlcpy);
 	RUN_TEST_GROUP(string_strlcat);
 }

--- a/libc/unistd_uids.c
+++ b/libc/unistd_uids.c
@@ -1,0 +1,187 @@
+/*
+ * Phoenix-RTOS
+ *
+ * libc-tests
+ *
+ * Testing getuid functions form unistd.h
+ *
+ * Copyright 2022 Phoenix Systems
+ * Author: Mateusz Niewiadomski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <string.h>
+#include <unistd.h>
+#include <sys/wait.h>
+#include <stdlib.h>
+
+#include <unity_fixture.h>
+
+
+pid_t child[6], parent[3], pid;
+
+
+TEST_GROUP(unistd_uids);
+
+
+TEST_SETUP(unistd_uids)
+{
+	pid = parent[0] = parent[1] = parent[2] = -1;
+}
+
+
+TEST_TEAR_DOWN(unistd_uids)
+{
+}
+
+/*
+	Testing correct return values for:
+	getpid, getppid, getuid(), geteuid, 
+	getpgid, getpgrp, getsid, getgid, getegid
+
+	for self standing process
+*/
+TEST(unistd_uids, getuids_parent)
+{
+	TEST_ASSERT_GREATER_THAN_INT(0, getpid());
+	TEST_ASSERT_GREATER_THAN_INT(0, getppid());
+
+	pid = getpid();
+	TEST_ASSERT_GREATER_THAN_INT(0, getpgid(pid));
+	TEST_ASSERT_GREATER_THAN_INT(0, getpgrp());
+	TEST_ASSERT_GREATER_THAN_INT(0, getsid(pid));
+
+	/*
+		tests are run as root, but following functions are
+		declared but unimplemented in libphoenix.
+		Reference: https://github.com/phoenix-rtos/phoenix-rtos-project/issues/280
+	*/
+	TEST_IGNORE();
+	TEST_ASSERT_GREATER_THAN_INT(0, getgid());
+	TEST_ASSERT_GREATER_THAN_INT(0, getegid());
+	TEST_ASSERT_EQUAL_INT(0, getuid());
+	TEST_ASSERT_EQUAL_INT(0, geteuid());
+}
+
+TEST(unistd_uids, setuids_parent)
+{
+	/*
+		setuid(), seteuid(), setgid(), setegid() are stub implemented so testing them
+		is pointless, yet marking this in testing process should occur.
+		Reference: https://github.com/phoenix-rtos/phoenix-rtos-project/issues/280
+	*/
+	TEST_IGNORE();
+}
+
+TEST(unistd_uids, setpuids_setsid)
+{
+	int err, siderr = -1;
+
+	parent[0] = getpid();
+	parent[1] = getpgrp();
+	parent[2] = getsid(getpid());
+
+	pid = vfork();
+	if (pid == 0) {
+		child[0] = getpid();
+		child[1] = getpgrp();
+		child[2] = getsid(getpid());
+
+		siderr = setsid();
+
+		child[3] = getpid();
+		child[4] = getpgrp();
+		child[5] = getsid(getpid());
+
+		_exit(siderr != 0);
+	}
+	else {
+		waitpid(pid, &err, 0);
+	}
+
+	/* assert exit status from child is zero */
+	TEST_ASSERT_EQUAL_INT(0, WEXITSTATUS(err));
+
+	/* assert correctness of parent pid, group and session */
+	TEST_ASSERT_GREATER_THAN_INT(0, parent[0]);  /* nonzero pid */
+	TEST_ASSERT_GREATER_THAN_INT(0, parent[1]);  /* nonzero pgid */
+	TEST_ASSERT_GREATER_THAN_INT(0, parent[2]);  /* nonzero sid */
+	TEST_ASSERT_EQUAL_INT(parent[0], parent[1]); /* pid == pgid */
+	TEST_ASSERT_EQUAL_INT(parent[1], parent[2]); /* pgid == sid */
+
+	/* assert correctness of child pid/group/session before setsid */
+	TEST_ASSERT_NOT_EQUAL_INT(parent[0], child[0]); /* parent-child have different pid */
+	TEST_ASSERT_EQUAL_INT(parent[1], child[1]);     /* equal pgrp */
+	TEST_ASSERT_EQUAL_INT(parent[2], child[2]);     /* equal sid */
+
+	/* after sid the pid, group id and session id of child should be equal */
+	TEST_ASSERT_NOT_EQUAL_INT(parent[0], child[3]); /* parent-child have different pid */
+	TEST_ASSERT_EQUAL_INT(child[3], child[4]);      /* pid == pgrp */
+	TEST_ASSERT_EQUAL_INT(child[4], child[5]);      /* pgrp == sid */
+}
+
+TEST(unistd_uids, setpuids_setpgid)
+{
+	/* 
+		setpgid() changes child session for no reason.
+		The same applies for set setpgrp()
+		https://github.com/phoenix-rtos/phoenix-rtos-project/issues/282
+	*/
+	TEST_IGNORE();
+
+	int err, pgrperr = -1;
+
+	parent[0] = getpid();
+	parent[1] = getpgrp();
+	parent[2] = getsid(getpid());
+
+	pid = vfork();
+	if (pid == 0) {
+		child[0] = getpid();
+		child[1] = getpgrp();
+		child[2] = getsid(getpid());
+
+		pgrperr = setpgid(0, 0);
+
+		child[3] = getpid();
+		child[4] = getpgrp();
+		child[5] = getsid(getpid());
+
+		_exit(pgrperr != 0);
+	}
+	else {
+		waitpid(pid, &err, 0);
+	}
+
+	/* assert exit status from child is zero */
+	TEST_ASSERT_EQUAL_INT(0, WEXITSTATUS(err));
+
+	/* assert correctness of parent pid, group and session */
+	TEST_ASSERT_GREATER_THAN_INT(0, parent[0]);  /* nonzero pid */
+	TEST_ASSERT_GREATER_THAN_INT(0, parent[1]);  /* nonzero pgid */
+	TEST_ASSERT_GREATER_THAN_INT(0, parent[2]);  /* nonzero sid */
+	TEST_ASSERT_EQUAL_INT(parent[0], parent[1]); /* pid == pgid */
+	TEST_ASSERT_EQUAL_INT(parent[1], parent[2]); /* pgid == sid */
+
+	/* assert correctness of child pid/group/session before setsid */
+	TEST_ASSERT_NOT_EQUAL_INT(parent[0], child[0]); /* parent-child have different pid */
+	TEST_ASSERT_EQUAL_INT(parent[1], child[1]);     /* equal pgrp */
+	TEST_ASSERT_EQUAL_INT(parent[2], child[2]);     /* equal sid */
+
+	/* after sid the pid, group id and session id of child should be equal */
+	TEST_ASSERT_NOT_EQUAL_INT(parent[0], child[3]); /* parent-child have different pid */
+	TEST_ASSERT_NOT_EQUAL_INT(parent[2], child[5]); /* parent-child have different sid */
+	TEST_ASSERT_EQUAL_INT(child[3], child[4]);      /* pid == pgrp */
+	TEST_ASSERT_NOT_EQUAL_INT(child[3], child[5]);  /* pid != sid */
+}
+
+TEST_GROUP_RUNNER(unistd_uids)
+{
+	RUN_TEST_CASE(unistd_uids, getuids_parent);
+	RUN_TEST_CASE(unistd_uids, setuids_parent);
+	RUN_TEST_CASE(unistd_uids, setpuids_setsid);
+	RUN_TEST_CASE(unistd_uids, setpuids_setpgid)
+}


### PR DESCRIPTION
JIRA: CI-100

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
 - Adding tests of functions from unistd.h that cope with processes `pid`s and `uid`s
 - Couple IGNOREs as couple issues were found.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Issues related to these tests:
 - https://github.com/phoenix-rtos/phoenix-rtos-project/issues/279
 - https://github.com/phoenix-rtos/phoenix-rtos-project/issues/280
 - https://github.com/phoenix-rtos/phoenix-rtos-project/issues/282

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
