### PR TITLE
psh: tools: handle empty string and lists in assert_cmd expected argument and other small corrections for psh test module

### DIFF
--- a/psh/tools/README.md
+++ b/psh/tools/README.md
@@ -4,17 +4,17 @@
 
 The python module `psh` makes writing harness tests easier. It provides the following functions:
 
-* `assert_cmd(pexpect_proc, cmd, expected, msg, is_regex)` - Sends a specified command and asserts that it's displayed correctly with optional expected output and next prompt. The function also checks if there are no unwanted pieces of information. It's possible to pass a regex in the `expected` argument, but then `is_regex` has to be set True. The regex should be passed as one raw string and match `EOL` after an expected output. Multi-line expected outputs have to be passed in a tuple, with lines in specific items. There is also a possibility to pass an additional message to print if the assertion fails. For a more readable assertion message in case that the test fails, the expected output is printed as regex, but in separate lines. So EOL, which is `r'(\r+)\n'` is replaced by `'\n'`.
+* `assert_cmd(pexpect_proc, cmd, expected='', msg='', is_regex=False)` - Sends a specified command and asserts that it's displayed correctly with optional expected output and next prompt. The function also checks if there are no unwanted pieces of information. It's possible to pass a regex in the `expected` argument, but then `is_regex` has to be set True. The regex should be passed as one raw string and match `EOL` after an expected output. Multi-line expected outputs have to be passed in a tuple, with lines in specific items. There is also a possibility to pass an additional message to print if the assertion fails. For a more readable assertion message in case that the test fails, the expected output is printed as regex, but in separate lines. So EOL, which is `r'(\r+)\n'` is replaced by `'\n'`.
 
-* `assert_only_prompt(pexpect_proc)` - assert psh prompt with the appropriate esc sequence.
+* `assert_only_prompt(pexpect_proc)` - Assert psh prompt with the appropriate esc sequence.
 
-* `assert_prompt(pexpect_proc, msg, timeout, catch_timeout)` - asserts psh prompt by searching only for `'(psh)% '` in buffer (without checking an escape sequence). There is also a possibility to pass a message to print if the assertion fails and set timeout arguments.
+* `assert_prompt(pexpect_proc, msg='', timeout=-1, catch_timeout=True)` - Asserts psh prompt by searching only for `'(psh)% '` in buffer (without checking an escape sequence). There is also a possibility to pass a message to print if the assertion fails and set timeout arguments.
 
-* `assert_prompt_fail(pexpect_proc, msg, timeout)` - assert, that there is no psh prompt in the read buffer.
+* `assert_prompt_fail(pexpect_proc, msg='', timeout=-1)` - Assert, that there is no psh prompt in the read buffer.
 
-* `assert_exec(pexpect_proc, prog, expected, msg)` - same as `assert_cmd`, but input is selected appropriately for the current target platform (using sysexec or /bin/prog_name). So for example instead of using `assert_cmd('/bin/psh')` or `assert_cmd('sysexec psh')` use `assert_exec(prog='psh')`.
+* `assert_exec(pexpect_proc, prog, expected='', msg='')` - Same as `assert_cmd`, but input is selected appropriately for the current target platform (using sysexec or /bin/prog_name). So for example instead of using `assert_cmd('/bin/psh')` or `assert_cmd('sysexec psh')` use `assert_exec(prog='psh')`.
 
-* `init(pexpect_proc)` - runs psh and next, asserts the first prompt.
+* `init(pexpect_proc)` - Runs psh and next, asserts the first prompt.
 
 The `pexpect_proc` argument is the [pexpect](https://pexpect.readthedocs.io/en/stable/api/index.html) process returned by `pexpect.spawn()` method. Each functional test has the spawned process passed in the argument, which is `p`, please see examples below.
 
@@ -35,7 +35,7 @@ The `pexpect_proc` argument is the [pexpect](https://pexpect.readthedocs.io/en/s
   ```
 
 
-* The multi-line Hello World assertion (assuming that, `helloworld` binary, which prints 'Hello\nWorld\n' is provided)
+* The multi-line assertion (assuming that `helloworld` is a binary which prints 'Hello\nWorld' is provided)
 
   ```python
   import psh.tools.psh as psh

--- a/psh/tools/psh.py
+++ b/psh/tools/psh.py
@@ -5,7 +5,7 @@
 #
 # psh module with tools for psh related tests
 #
-# Copyright 2021 Phoenix Systems
+# Copyright 2021, 2022 Phoenix Systems
 # Author: Jakub Sarzyński, Damian Loewnau
 #
 # This file is part of Phoenix-RTOS.
@@ -37,16 +37,16 @@ def _readable(exp_regex):
     return exp_regex.replace(PROMPT, '(psh)% ')
 
 
-def assert_cmd(pexpect_proc, cmd, expected, msg='', is_regex=False):
+def assert_cmd(pexpect_proc, cmd, expected='', msg='', is_regex=False):
     ''' Sends specified command and asserts that it's displayed correctly
     with optional expected output and next prompt'''
     pexpect_proc.sendline(cmd)
     cmd = re.escape(cmd)
+    exp_regex = ''
     if is_regex:
         exp_regex = expected
-    else:
-        exp_regex = ''
-        if not isinstance(expected, tuple):
+    elif expected != '':
+        if not (isinstance(expected, tuple) or isinstance(expected, list)):
             expected = tuple((expected,))
         for line in expected:
             line = re.escape(line)
@@ -55,7 +55,7 @@ def assert_cmd(pexpect_proc, cmd, expected, msg='', is_regex=False):
     exp_regex = cmd + EOL + exp_regex + PROMPT
     exp_readable = _readable(exp_regex)
     msg = f'Expected output regex was: \n---\n{exp_readable}\n---\n' + msg
-    assert pexpect_proc.expect([exp_regex, pexpect.TIMEOUT]) == 0, msg
+    assert pexpect_proc.expect([exp_regex, pexpect.TIMEOUT, pexpect.EOF]) == 0, msg
 
 
 def assert_only_prompt(pexpect_proc):
@@ -76,12 +76,12 @@ def assert_prompt(pexpect_proc, msg='', timeout=-1, catch_timeout=True):
 
 
 def assert_prompt_fail(pexpect_proc, msg='', timeout=-1):
-    patterns = ['(psh)% ', pexpect.TIMEOUT]
+    patterns = ['(psh)% ', pexpect.TIMEOUT, pexpect.EOF]
     idx = pexpect_proc.expect_exact(patterns, timeout=timeout)
-    assert idx == 1, msg
+    assert idx != 0, msg
 
 
-def assert_exec(pexpect_proc, prog, expected, msg=''):
+def assert_exec(pexpect_proc, prog, expected='', msg=''):
     ''' Executes specified program and asserts that it's displayed correctly
     with optional expected output and next prompt'''
     if CURRENT_TARGET in DEVICE_TARGETS:
@@ -89,7 +89,7 @@ def assert_exec(pexpect_proc, prog, expected, msg=''):
     else:
         exec_cmd = f'/bin/{prog}'
 
-    pexpect_proc.assert_cmd(exec_cmd, expected, msg)
+    assert_cmd(pexpect_proc, exec_cmd, expected, msg)
 
 
 def run(pexpect_proc):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Small changes in psh test module (does not affect existing tests):
- fix assert_exec function in psh module (the function hasn't been used before)
- handle passing empty string and tuples in `expected` argument in assert_cmd function
- small corections in README.md for psh test module
- pass pexpect.EOF to `pexpect.expect` in order to print assertion message when EOF occured
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
JIRA: PD-77

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
