### PR TITLE
runner: adapt to automatic go! command sending in plo

### DIFF
--- a/trunner/runners/ARMV7M7Runner.py
+++ b/trunner/runners/ARMV7M7Runner.py
@@ -122,8 +122,8 @@ class ARMV7M7Runner(DeviceRunner):
         try:
             self.reboot(cut_power=self.is_cut_power_used)
             with PloTalker(self.serial_port) as plo:
+                plo.interrupt_counting()
                 plo.wait_prompt()
-
                 if not test.exec_cmd:
                     # We got plo prompt, we are ready for sending the "go!" command.
                     return True

--- a/trunner/runners/common.py
+++ b/trunner/runners/common.py
@@ -242,6 +242,12 @@ class PloTalker:
         obj.plo = pexpect_fd
         return obj
 
+    def interrupt_counting(self):
+        """ Interrupts timer counting to enter plo """
+        self.plo.expect_exact('Waiting for input', timeout=3)
+        self.plo.send('\r\n')
+        self.plo.expect_exact('\n')
+
     def open(self):
         try:
             self.serial = serial.Serial(self.port, baudrate=self.baudrate)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
- runner: adapt to automatic go! command sending in plo

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Target solution is sending go! command in plo automaticly.
This change will make it possible and will work for current configuration too.

JIRA: CI-103

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt106x).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (https://github.com/phoenix-rtos/phoenix-rtos-project/pull/303).
- [ ] I will merge this PR by myself when appropriate.
