### PR TITLE
tests-libc: adding tests of unistd.h getopt() function

### DIFF
--- a/libc/main.c
+++ b/libc/main.c
@@ -21,6 +21,7 @@ void runner(void)
 	RUN_TEST_GROUP(getpwd);
 	RUN_TEST_GROUP(resolve_path);
 	RUN_TEST_GROUP(file);
+	RUN_TEST_GROUP(unistd_getopt);
 }
 
 

--- a/libc/unistd_getopt.c
+++ b/libc/unistd_getopt.c
@@ -1,0 +1,336 @@
+/*
+ * Phoenix-RTOS
+ *
+ * libc-tests
+ *
+ * Testing POSIX compatibility of getopt() unistd.h function
+ *
+ * Copyright 2021 Phoenix Systems
+ * Author: Marek Bialowas
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <ctype.h>
+
+#include <unity_fixture.h>
+
+#define NOERR       0
+#define OPTREQ      1
+#define UNKNOWNOPT  2
+#define UNKNOWNCHAR 4
+#define NOARG       8
+#define ABORT       16
+
+
+struct getopt_t {
+	int aflag;
+	int bflag;
+	char *cvalue;
+	int nonopts;
+
+	unsigned int err;
+};
+
+
+int testargc = 0;
+struct getopt_t ret;
+
+/* updates `results` structure according to getopt() operations */
+int testmain(int argc, char *argv[], struct getopt_t *results, const char *optstring)
+{
+	int c;
+	int arg;
+
+	while ((c = getopt(argc, argv, optstring)) != -1)
+		switch (c) {
+			case 'a':
+				results->aflag++;
+				break;
+			case 'b':
+				results->bflag++;
+				break;
+			case 'c':
+				results->cvalue = optarg;
+				break;
+			case '?':
+				if (optopt == 'c')
+					results->err |= OPTREQ;
+				else if (isprint(optopt))
+					results->err |= UNKNOWNOPT;
+				else
+					results->err |= UNKNOWNCHAR;
+				break;
+			case ':':
+				results->err |= NOARG;
+				break;
+			default:
+				results->err |= ABORT;
+		}
+
+	for (arg = optind; arg < argc; arg++)
+		results->nonopts++;
+
+	return 0;
+}
+
+
+TEST_GROUP(unistd_getopt);
+
+TEST_SETUP(unistd_getopt)
+{
+	/* default presets of results structure */
+	ret.aflag = 0;
+	ret.bflag = 0;
+	ret.cvalue = NULL;
+	ret.err = NOERR;
+	ret.nonopts = 0;
+
+	/* reset of getopt() index value optind */
+	optind = 1;
+}
+
+
+TEST_TEAR_DOWN(unistd_getopt)
+{
+}
+
+TEST(unistd_getopt, getopt_zeroargs)
+{
+	/* mocks of main() arguments */
+	char *testargv[] = { "cmd" };
+	testargc = 1;
+
+	testmain(testargc, testargv, &ret, "abc:");
+
+	TEST_ASSERT_EQUAL_INT(NOERR, ret.err);
+	TEST_ASSERT_EQUAL_INT(0, ret.aflag);
+	TEST_ASSERT_EQUAL_INT(0, ret.bflag);
+	TEST_ASSERT_NULL(ret.cvalue);
+	TEST_ASSERT_EQUAL_INT(0, ret.nonopts);
+}
+
+
+TEST(unistd_getopt, getopt_normal_flags)
+{
+	/* mocks of main() arguments */
+	char *testargv[] = { "cmd", "-a", "-b" };
+	testargc = 3;
+
+	testmain(testargc, testargv, &ret, "abc:");
+
+	TEST_ASSERT_EQUAL_INT(NOERR, ret.err);
+	TEST_ASSERT_EQUAL_INT(1, ret.aflag);
+	TEST_ASSERT_EQUAL_INT(1, ret.bflag);
+	TEST_ASSERT_NULL(ret.cvalue);
+	TEST_ASSERT_EQUAL_INT(0, ret.nonopts);
+}
+
+
+TEST(unistd_getopt, getopt_joined_flags)
+{
+	/* mocks of main() arguments */
+	char *testargv[] = { "cmd", "-ab" };
+	testargc = 2;
+
+	testmain(testargc, testargv, &ret, "abc:");
+
+	TEST_ASSERT_EQUAL_INT(NOERR, ret.err);
+	TEST_ASSERT_EQUAL_INT(1, ret.aflag);
+	TEST_ASSERT_EQUAL_INT(1, ret.bflag);
+	TEST_ASSERT_NULL(ret.cvalue);
+	TEST_ASSERT_EQUAL_INT(0, ret.nonopts);
+}
+
+
+TEST(unistd_getopt, getopt_normal_parameter)
+{
+	/* mocks of main() arguments */
+	char *testargv[] = { "cmd", "-c", "foo" };
+	testargc = 3;
+
+	testmain(testargc, testargv, &ret, "abc:");
+
+	TEST_ASSERT_EQUAL_INT(NOERR, ret.err);
+	TEST_ASSERT_EQUAL_INT(0, ret.aflag);
+	TEST_ASSERT_EQUAL_INT(0, ret.bflag);
+	TEST_ASSERT_EQUAL_STRING("foo", ret.cvalue);
+	TEST_ASSERT_EQUAL_INT(0, ret.nonopts);
+}
+
+TEST(unistd_getopt, getopt_normal_optparameter)
+{
+	/* mocks of main() arguments */
+	char *testargv[] = { "cmd", "-c", "-a", "-b" };
+	testargc = 4;
+
+	testmain(testargc, testargv, &ret, "abc:");
+
+	TEST_ASSERT_EQUAL_INT(NOERR, ret.err);
+	TEST_ASSERT_EQUAL_INT(0, ret.aflag);
+	TEST_ASSERT_EQUAL_INT(1, ret.bflag);
+	TEST_ASSERT_EQUAL_STRING("-a", ret.cvalue);
+	TEST_ASSERT_EQUAL_INT(0, ret.nonopts);
+}
+
+
+TEST(unistd_getopt, getopt_joined_parameter)
+{
+	/* mocks of main() arguments */
+	char *testargv[] = { "cmd", "-cfoo" };
+	testargc = 2;
+
+	testmain(testargc, testargv, &ret, "abc:");
+
+	TEST_ASSERT_EQUAL_INT(NOERR, ret.err);
+	TEST_ASSERT_EQUAL_INT(0, ret.aflag);
+	TEST_ASSERT_EQUAL_INT(0, ret.bflag);
+	TEST_ASSERT_EQUAL_STRING("foo", ret.cvalue);
+	TEST_ASSERT_EQUAL_INT(0, ret.nonopts);
+}
+
+
+TEST(unistd_getopt, getopt_nonopt)
+{
+	/* mocks of main() arguments */
+	char *testargv[] = { "cmd", "arg1" };
+	testargc = 2;
+
+	testmain(testargc, testargv, &ret, "abc:");
+
+	TEST_ASSERT_EQUAL_INT(NOERR, ret.err);
+	TEST_ASSERT_EQUAL_INT(0, ret.aflag);
+	TEST_ASSERT_EQUAL_INT(0, ret.bflag);
+	TEST_ASSERT_NULL(ret.cvalue);
+	TEST_ASSERT_EQUAL_INT(1, ret.nonopts);
+}
+
+
+TEST(unistd_getopt, getopt_parameter_nonopt)
+{
+	/* mocks of main() arguments */
+	char *testargv[] = { "cmd", "-c", "foo", "arg" };
+	testargc = 4;
+
+	testmain(testargc, testargv, &ret, "abc:");
+	TEST_ASSERT_EQUAL_INT(NOERR, ret.err);
+	TEST_ASSERT_EQUAL_INT(0, ret.aflag);
+	TEST_ASSERT_EQUAL_INT(0, ret.bflag);
+	TEST_ASSERT_EQUAL_STRING("foo", ret.cvalue);
+	TEST_ASSERT_EQUAL_INT(1, ret.nonopts);
+}
+
+
+TEST(unistd_getopt, getopt_endofargs_doubledash)
+{
+	/* mocks of main() arguments */
+	char *testargv[] = { "cmd", "-a", "--", "-b" };
+	testargc = 4;
+
+	testmain(testargc, testargv, &ret, "abc:");
+	TEST_ASSERT_EQUAL_INT(NOERR, ret.err);
+	TEST_ASSERT_EQUAL_INT(1, ret.aflag);
+	TEST_ASSERT_EQUAL_INT(0, ret.bflag);
+	TEST_ASSERT_NULL(ret.cvalue);
+	TEST_ASSERT_EQUAL_INT(1, ret.nonopts);
+}
+
+
+TEST(unistd_getopt, getopt_endofargs_singledash)
+{
+	/* mocks of main() arguments */
+	char *testargv[] = { "cmd", "-a", "-", "-b" };
+	testargc = 4;
+
+	testmain(testargc, testargv, &ret, "abc:");
+	TEST_ASSERT_EQUAL_INT(NOERR, ret.err);
+	TEST_ASSERT_EQUAL_INT(1, ret.aflag);
+	TEST_ASSERT_EQUAL_INT(0, ret.bflag);
+	TEST_ASSERT_NULL(ret.cvalue);
+	TEST_ASSERT_EQUAL_INT(2, ret.nonopts);
+}
+
+TEST(unistd_getopt, getopt_unknownopt)
+{
+	/* mocks of main() arguments */
+	char *testargv[] = { "cmd", "-axb", "-c", "--", "arg1", "arg2" };
+	testargc = 6;
+
+	testmain(testargc, testargv, &ret, "abc:");
+	TEST_ASSERT_EQUAL_INT(UNKNOWNOPT, ret.err);
+	TEST_ASSERT_EQUAL_INT(1, ret.aflag);
+	TEST_ASSERT_EQUAL_INT(1, ret.bflag);
+	TEST_ASSERT_EQUAL_STRING("--", ret.cvalue);
+	TEST_ASSERT_EQUAL_INT(2, ret.nonopts);
+}
+
+
+TEST(unistd_getopt, getopt_unknownopt_optreq)
+{
+	/* mocks of main() arguments */
+	char *testargv[] = { "cmd", "-axb", "-c" };
+	testargc = 3;
+
+	testmain(testargc, testargv, &ret, "abc:");
+	TEST_ASSERT_EQUAL_INT(UNKNOWNOPT | OPTREQ, ret.err);
+	TEST_ASSERT_EQUAL_INT(1, ret.aflag);
+	TEST_ASSERT_EQUAL_INT(1, ret.bflag);
+	TEST_ASSERT_NULL(ret.cvalue);
+	TEST_ASSERT_EQUAL_INT(0, ret.nonopts);
+}
+
+TEST(unistd_getopt, getopt_noarg)
+{
+	/* mocks of main() arguments */
+	char *testargv[] = { "cmd", "-ab", "-c" };
+	testargc = 3;
+
+	testmain(testargc, testargv, &ret, ":abc:");
+	TEST_ASSERT_EQUAL_INT(NOARG, ret.err);
+	TEST_ASSERT_EQUAL_INT(1, ret.aflag);
+	TEST_ASSERT_EQUAL_INT(1, ret.bflag);
+	TEST_ASSERT_NULL(ret.cvalue);
+	TEST_ASSERT_EQUAL_INT(0, ret.nonopts);
+}
+
+TEST(unistd_getopt, getopt_unknownopt_noarg)
+{
+	/* mocks of main() arguments */
+	char *testargv[] = { "cmd", "-axb", "-c" };
+	testargc = 3;
+
+	testmain(testargc, testargv, &ret, ":abc:");
+	TEST_ASSERT_EQUAL_INT(UNKNOWNOPT | NOARG, ret.err);
+	TEST_ASSERT_EQUAL_INT(1, ret.aflag);
+	TEST_ASSERT_EQUAL_INT(1, ret.bflag);
+	TEST_ASSERT_NULL(ret.cvalue);
+	TEST_ASSERT_EQUAL_INT(0, ret.nonopts);
+}
+
+
+TEST_GROUP_RUNNER(unistd_getopt)
+{
+	RUN_TEST_CASE(unistd_getopt, getopt_zeroargs);
+	RUN_TEST_CASE(unistd_getopt, getopt_normal_flags);
+	RUN_TEST_CASE(unistd_getopt, getopt_joined_flags);
+
+	RUN_TEST_CASE(unistd_getopt, getopt_normal_parameter);
+	RUN_TEST_CASE(unistd_getopt, getopt_normal_optparameter);
+	RUN_TEST_CASE(unistd_getopt, getopt_joined_parameter);
+
+	RUN_TEST_CASE(unistd_getopt, getopt_nonopt);
+	RUN_TEST_CASE(unistd_getopt, getopt_parameter_nonopt);
+	RUN_TEST_CASE(unistd_getopt, getopt_endofargs_singledash);
+	RUN_TEST_CASE(unistd_getopt, getopt_endofargs_doubledash);
+	RUN_TEST_CASE(unistd_getopt, getopt_unknownopt_optreq);
+	RUN_TEST_CASE(unistd_getopt, getopt_unknownopt);
+
+	RUN_TEST_CASE(unistd_getopt, getopt_noarg);
+	RUN_TEST_CASE(unistd_getopt, getopt_unknownopt_noarg);
+}


### PR DESCRIPTION
JIRA: CI-100

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
adding tests of libphoenix unistd.h function `getopt()` checking its POSIX compliance and checking for its operability

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bringing POSIX compliance to libphoenix functions from unistd.h library

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
