### PR TITLE
runner: catch unicode error

### DIFF
--- a/trunner/builder.py
+++ b/trunner/builder.py
@@ -57,7 +57,7 @@ class TargetBuilder:
         )
 
         while live_output:
-            output = proc.stdout.readline().decode('utf-8')
+            output = proc.stdout.readline().decode('ascii')
             if proc.poll() is not None and output == '':
                 break
             if output:
@@ -69,9 +69,9 @@ class TargetBuilder:
         else:
             logging.debug(f"Command {' '.join(args)} for {self.target} success!\n")
 
-        logging.error(err.decode('utf-8'))
+        logging.error(err.decode('ascii'))
         if not live_output:
-            logging.info(out.decode('utf-8'))
+            logging.info(out.decode('ascii'))
 
         if proc.returncode != 0 and exit_at_error:
             sys.exit(1)

--- a/trunner/runners/HostRunner.py
+++ b/trunner/runners/HostRunner.py
@@ -33,7 +33,7 @@ class HostRunner(Runner):
             with pexpect.spawn(
                 str(test_path),
                 args=test.exec_cmd[1:],
-                encoding="utf-8",
+                encoding="ascii",
                 timeout=test.timeout,
             ) as proc:
                 if self.logpath:

--- a/trunner/runners/QemuRunner.py
+++ b/trunner/runners/QemuRunner.py
@@ -29,7 +29,7 @@ class QemuRunner(Runner):
         if test.skipped():
             return
 
-        proc = pexpect.spawn(self.qemu, args=self.args, encoding='utf-8', timeout=test.timeout)
+        proc = pexpect.spawn(self.qemu, args=self.args, encoding='ascii', timeout=test.timeout)
         if self.logpath:
             proc.logfile = open(self.logpath, "a")
 

--- a/trunner/runners/common.py
+++ b/trunner/runners/common.py
@@ -103,7 +103,7 @@ class Psu:
             'psu',
             [f'{self.script}'],
             cwd=self.cwd,
-            encoding='utf-8'
+            encoding='ascii'
         )
 
         self.read_output()
@@ -176,7 +176,7 @@ class Phoenixd:
              '-b', str(self.baudrate),
              '-s', self.dir],
             cwd=self.cwd,
-            encoding='utf-8'
+            encoding='ascii'
         )
 
         self.dispatcher_event = threading.Event()
@@ -258,7 +258,7 @@ class PloTalker:
             raise
 
         try:
-            self.plo = pexpect.fdpexpect.fdspawn(self.serial, encoding='utf-8', timeout=8)
+            self.plo = pexpect.fdpexpect.fdspawn(self.serial, encoding='ascii', timeout=8)
         except Exception:
             self.serial.close()
             raise
@@ -366,7 +366,7 @@ class DeviceRunner(Runner):
             test.handle_exception()
             return
 
-        proc = pexpect.fdpexpect.fdspawn(self.serial, encoding='utf-8', timeout=test.timeout)
+        proc = pexpect.fdpexpect.fdspawn(self.serial, encoding='ascii', timeout=test.timeout)
         if self.logpath:
             proc.logfile = open(self.logpath, "a")
 

--- a/trunner/test/test_exceptions.py
+++ b/trunner/test/test_exceptions.py
@@ -58,7 +58,7 @@ class TestPexpectException:
 
         fifo_r = open(self.FIFO, 'r')
 
-        proc = pexpect.fdpexpect.fdspawn(fifo_r, encoding='utf-8', timeout=1)
+        proc = pexpect.fdpexpect.fdspawn(fifo_r, encoding='ascii', timeout=1)
         testcase.harness = TestPexpectException.fake_harness
         testcase.handle(proc)
 
@@ -89,7 +89,7 @@ class TestPexpectException:
         # Wait for end of write to get EOF
         thread.join()
 
-        proc = pexpect.fdpexpect.fdspawn(fifo_r, encoding='utf-8')
+        proc = pexpect.fdpexpect.fdspawn(fifo_r, encoding='ascii')
         testcase.harness = TestPexpectException.fake_harness
         testcase.handle(proc)
 

--- a/trunner/testcase.py
+++ b/trunner/testcase.py
@@ -90,29 +90,19 @@ class TestCase:
         try:
             # Wait for a prompt
             proc.expect_exact('(psh)% ')
+            if self.exec_cmd:
+                if self.use_sysexec:
+                    self.sysexec(proc)
+                else:
+                    self.exec(proc)
         except (TIMEOUT, EOF) as exc:
-            msg = 'Waiting for psh prompt failed!\n'
+            msg = "Execution of test binary failed!\n"
             self.exception = Color.colorify(msg, Color.BOLD)
             self.handle_pyexpect_error(proc, exc)
             return
         except UnicodeDecodeError as exc:
             self.handle_unicode_error(proc, exc)
             return
-
-        if self.exec_cmd:
-            try:
-                if self.use_sysexec:
-                    self.sysexec(proc)
-                else:
-                    self.exec(proc)
-            except (TIMEOUT, EOF) as exc:
-                msg = f'Executing {self.exec_cmd} failed!\n'
-                self.exception = Color.colorify(msg, Color.BOLD)
-                self.handle_pyexpect_error(proc, exc)
-                return
-            except UnicodeDecodeError:
-                self.handle_unicode_error(proc)
-                return
 
     def handle_pyexpect_error(self, proc, exc):
         self.status = TestCase.FAILED_TIMEOUT


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

- add handling UnicodeDecodeError exception
- trunner: change codec from utf-8 to ascii
- trunner: combine two try blocks into one in test execution

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

For the problem known from the following issue: https://github.com/phoenix-rtos/phoenix-rtos-project/issues/295 instead of Unicode Decode Error and aborting test runner, the output is printed.

Before change (test-helloworld prints here the following file content: ab�c):
![Screenshot from 2022-02-14 10-47-06](https://user-images.githubusercontent.com/77304431/153840513-3cbe0e60-63b6-4665-b7b4-39188475e401.png)


After change:
![Screenshot from 2022-03-01 14-55-35](https://user-images.githubusercontent.com/77304431/156182718-e1c83b26-25d2-4fae-9019-a77a503cc597.png)


https://github.com/phoenix-rtos/phoenix-rtos-project/issues/175

JIRA: PD-238

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
