### PR TITLE
meterfs: Adapted to bigger record overhead (4 -> 8 bytes)

### DIFF
--- a/meterfs/test_meterfs_writeread.c
+++ b/meterfs/test_meterfs_writeread.c
@@ -183,7 +183,7 @@ TEST(meterfs_writeread, file_end)
 TEST(meterfs_writeread, many_records)
 {
 	int i;
-	file_info_t info = { 13, 36000, 12, 0 };
+	file_info_t info = { 16, 36000, 12, 0 };
 
 	common.fd = common_preallocOpenFile("file0", info.sectors, info.filesz, info.recordsz);
 


### PR DESCRIPTION
JIRA: DTR-179

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
In DTR-179 meterfs record overhead was increased from 4 to 8 bytes (to accommodate checksum). This caused one test to fail - not sufficient number of sectors was allocated for a file

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (host-pc).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
