### PR TITLE
runner: full log dump after "-l debug" option

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -106,7 +106,8 @@ def main():
                          test_paths=args.test,
                          build=args.build,
                          flash=not args.no_flash,
-                         serial=(args.serial, args.baudrate)
+                         serial=(args.serial, args.baudrate),
+                         log=(args.log_level == logging.DEBUG)
                          )
 
     passed, failed, skipped = runner.run()

--- a/trunner/device.py
+++ b/trunner/device.py
@@ -18,7 +18,7 @@ QEMU_CMD = {
 
 class RunnerFactory:
     @staticmethod
-    def create(target, serial, log):
+    def create(target, serial, log=False):
         if target == 'ia32-generic':
             return QemuRunner(*QEMU_CMD[target], log=log)
         if target == 'host-pc':

--- a/trunner/device.py
+++ b/trunner/device.py
@@ -18,16 +18,16 @@ QEMU_CMD = {
 
 class RunnerFactory:
     @staticmethod
-    def create(target, serial):
+    def create(target, serial, log):
         if target == 'ia32-generic':
-            return QemuRunner(*QEMU_CMD[target])
+            return QemuRunner(*QEMU_CMD[target], log=log)
         if target == 'host-pc':
-            return HostRunner()
+            return HostRunner(log=log)
         if target == 'armv7m7-imxrt106x':
-            return IMXRT106xRunner((serial, DEVICE_SERIAL_USB), PHOENIXD_PORT, is_rpi_host=True)
+            return IMXRT106xRunner((serial, DEVICE_SERIAL_USB), PHOENIXD_PORT, is_rpi_host=True, log=log)
         if target == 'armv7m7-imxrt117x':
-            return IMXRT117xRunner(serial, PHOENIXD_PORT, is_rpi_host=True)
+            return IMXRT117xRunner(serial, PHOENIXD_PORT, is_rpi_host=True, log=log)
         if target == 'armv7m4-stm32l4':
-            return STM32L4Runner(serial)
+            return STM32L4Runner(serial, log=log)
 
         raise ValueError(f"Unknown Runner target: {target}")

--- a/trunner/runners/ARMV7M7Runner.py
+++ b/trunner/runners/ARMV7M7Runner.py
@@ -49,7 +49,7 @@ class ARMV7M7Runner(DeviceRunner):
     SDP = None
     IMAGE = None
 
-    def __init__(self, serial, is_rpi_host=True):
+    def __init__(self, serial, is_rpi_host=True, log=False):
         # has to be defined before super, because Runner constructor calls set_status, where it's used
         self.is_rpi_host = is_rpi_host
         if self.is_rpi_host:
@@ -60,7 +60,7 @@ class ARMV7M7Runner(DeviceRunner):
             self.boot_gpio = GPIO(4)
             self.leds = {'red': GPIO(13), 'green': GPIO(18), 'blue': GPIO(12)}
 
-        super().__init__(serial)
+        super().__init__(serial, log)
         # default values, redefined by specified target runners
         self.phoenixd_port = None
         self.is_cut_power_used = False

--- a/trunner/runners/ARMV7M7Runner.py
+++ b/trunner/runners/ARMV7M7Runner.py
@@ -14,7 +14,7 @@ import select
 
 from pexpect.exceptions import TIMEOUT, EOF
 from trunner.tools.color import Color
-from .common import Psu, Phoenixd, PhoenixdError, PloError, PloTalker, DeviceRunner, Runner
+from .common import LOG_PATH, Psu, Phoenixd, PhoenixdError, PloError, PloTalker, DeviceRunner, Runner
 from .common import GPIO, phd_error_msg, rootfs
 
 
@@ -59,6 +59,7 @@ class ARMV7M7Runner(DeviceRunner):
             self.power_gpio.high()
             self.boot_gpio = GPIO(4)
             self.leds = {'red': GPIO(13), 'green': GPIO(18), 'blue': GPIO(12)}
+            self.logpath = LOG_PATH
 
         super().__init__(serial, log)
         # default values, redefined by specified target runners
@@ -98,6 +99,8 @@ class ARMV7M7Runner(DeviceRunner):
         try:
             self.reboot(serial_downloader=True, cut_power=self.is_cut_power_used)
             with PloTalker(self.serial_port) as plo:
+                if self.logpath:
+                    plo.plo.logfile = open(self.logpath, "a")
                 Psu(script=self.SDP).run()
                 plo.wait_prompt()
                 with Phoenixd(self.phoenixd_port) as phd:
@@ -122,6 +125,8 @@ class ARMV7M7Runner(DeviceRunner):
         try:
             self.reboot(cut_power=self.is_cut_power_used)
             with PloTalker(self.serial_port) as plo:
+                if self.logpath:
+                    plo.plo.logfile = open(self.logpath, "a")
                 plo.interrupt_counting()
                 plo.wait_prompt()
                 if not test.exec_cmd:

--- a/trunner/runners/HostRunner.py
+++ b/trunner/runners/HostRunner.py
@@ -36,6 +36,8 @@ class HostRunner(Runner):
                 encoding="utf-8",
                 timeout=test.timeout,
             ) as proc:
+                if self.logpath:
+                    proc.logfile = open(self.logpath, "w")
                 test.handle(proc)
         except pexpect.exceptions.ExceptionPexpect:
             test.handle_exception()

--- a/trunner/runners/HostRunner.py
+++ b/trunner/runners/HostRunner.py
@@ -37,7 +37,7 @@ class HostRunner(Runner):
                 timeout=test.timeout,
             ) as proc:
                 if self.logpath:
-                    proc.logfile = open(self.logpath, "w")
+                    proc.logfile = open(self.logpath, "a")
                 test.handle(proc)
         except pexpect.exceptions.ExceptionPexpect:
             test.handle_exception()

--- a/trunner/runners/IMXRT106xRunner.py
+++ b/trunner/runners/IMXRT106xRunner.py
@@ -30,8 +30,8 @@ class IMXRT106xRunner(ARMV7M7Runner):
     SDP = 'plo-ram-armv7m7-imxrt106x.sdp'
     IMAGE = 'phoenix-armv7m7-imxrt106x.disk'
 
-    def __init__(self, port, phoenixd_port, is_rpi_host=True):
-        super().__init__(port[0], is_rpi_host)
+    def __init__(self, port, phoenixd_port, is_rpi_host=True, log=False):
+        super().__init__(port[0], is_rpi_host, log)
         self.port_usb = port[1]
         self.phoenixd_port = phoenixd_port
         # restart by power off is temporarily disabled for this target

--- a/trunner/runners/IMXRT117xRunner.py
+++ b/trunner/runners/IMXRT117xRunner.py
@@ -27,7 +27,7 @@ class IMXRT117xRunner(ARMV7M7Runner):
     SDP = 'plo-ram-armv7m7-imxrt117x.sdp'
     IMAGE = 'phoenix-armv7m7-imxrt117x.disk'
 
-    def __init__(self, port, phoenixd_port, is_cut_power_used=False, is_rpi_host=True):
+    def __init__(self, port, phoenixd_port, is_cut_power_used=False, is_rpi_host=True, log=False):
         super().__init__(port, is_rpi_host)
         self.phoenixd_port = phoenixd_port
         self.is_cut_power_used = is_cut_power_used

--- a/trunner/runners/QemuRunner.py
+++ b/trunner/runners/QemuRunner.py
@@ -16,7 +16,8 @@ from .common import Runner
 class QemuRunner(Runner):
     """This class provides interface to run test case using QEMU as a device."""
 
-    def __init__(self, qemu, args):
+    def __init__(self, qemu, args, log):
+        super().__init__(log)
         self.qemu = qemu
         self.args = args
 
@@ -29,6 +30,8 @@ class QemuRunner(Runner):
             return
 
         proc = pexpect.spawn(self.qemu, args=self.args, encoding='utf-8', timeout=test.timeout)
+        if self.logpath:
+            proc.logfile = open(self.logpath, "a")
 
         try:
             test.handle(proc)

--- a/trunner/runners/STM32L4Runner.py
+++ b/trunner/runners/STM32L4Runner.py
@@ -84,6 +84,8 @@ class STM32L4Runner(DeviceRunner):
             codec_errors='ignore',
             timeout=test.timeout
             )
+        if self.logpath:
+            proc.logfile = open(self.logpath, "a")
 
         # FIXME - race on start of Phoenix-RTOS between dummyfs and psh
         # flushing the buffer and sending newline

--- a/trunner/runners/common.py
+++ b/trunner/runners/common.py
@@ -258,7 +258,7 @@ class PloTalker:
             raise
 
         try:
-            self.plo = pexpect.fdpexpect.fdspawn(self.serial, timeout=8)
+            self.plo = pexpect.fdpexpect.fdspawn(self.serial, encoding='utf-8', timeout=8)
         except Exception:
             self.serial.close()
             raise

--- a/trunner/runners/common.py
+++ b/trunner/runners/common.py
@@ -28,6 +28,8 @@ from trunner.tools.color import Color
 
 _BOOT_DIR = PHRTOS_PROJECT_DIR / '_boot'
 
+LOG_PATH = '/tmp/phoenix_test.log'
+
 
 def rootfs(target: str) -> Path:
     return PHRTOS_PROJECT_DIR / '_fs' / target / 'root'
@@ -318,10 +320,16 @@ class Runner(ABC):
     SUCCESS = 'SUCCESS'
     FAIL = 'FAIL'
 
-    def __init__(self):
+    def __init__(self, log=False):
         # Busy status is set from the start to the end of the specified runner's run
         self.status = Runner.BUSY
         self.set_status(self.status)
+        if log:
+            if os.path.exists(LOG_PATH):
+                os.remove(LOG_PATH)
+            self.logpath = LOG_PATH
+        else:
+            self.logpath = None
 
     def set_status(self, status):
         """Method for sygnalising a current runner status: busy/failed/succeeded"""
@@ -342,8 +350,8 @@ class Runner(ABC):
 class DeviceRunner(Runner):
     """This class provides interface to run tests on hardware targets using serial port"""
 
-    def __init__(self, serial):
-        super().__init__()
+    def __init__(self, serial, log=False):
+        super().__init__(log)
         self.serial_port = serial[0]
         self.serial_baudrate = serial[1]
         self.serial = None
@@ -359,6 +367,8 @@ class DeviceRunner(Runner):
             return
 
         proc = pexpect.fdpexpect.fdspawn(self.serial, encoding='utf-8', timeout=test.timeout)
+        if self.logpath:
+            proc.logfile = open(self.logpath, "a")
 
         try:
             PloTalker.from_pexpect(proc).go()

--- a/trunner/test_runner.py
+++ b/trunner/test_runner.py
@@ -11,7 +11,7 @@ from .runners.common import Runner
 class TestsRunner:
     """Class responsible for loading, building and running tests"""
 
-    def __init__(self, targets, test_paths, serial, build=True, flash=True):
+    def __init__(self, targets, test_paths, serial, build=True, flash=True, log=False):
         self.targets = targets
         self.test_configs = []
         self.test_paths = test_paths
@@ -20,6 +20,7 @@ class TestsRunner:
         self.flash = flash
         self.runners = None
         self.serial = serial
+        self.log = log
 
     def search_for_tests(self):
         paths = []
@@ -40,7 +41,11 @@ class TestsRunner:
             logging.debug(f"File {path} parsed successfuly\n")
 
     def run(self):
-        self.runners = {target: RunnerFactory.create(target=target, serial=self.serial) for target in self.targets}
+        self.runners = {target: RunnerFactory.create(
+            target=target,
+            serial=self.serial,
+            log=self.log
+            ) for target in self.targets}
         self.search_for_tests()
         self.parse_tests()
 


### PR DESCRIPTION
JIRA: CI-107

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Add functionality to "-l debug" option of runner so that it dumps everything that was read into a file in /tmp/ directory

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For inspection purposes runner should have an option to dump everything it has read from target device.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
