### PR TITLE
tests: auth timing loophole fix

### DIFF
--- a/psh/test-auth.py
+++ b/psh/test-auth.py
@@ -54,18 +54,18 @@ def harness(p):
 
     # Wrong credentials
     assert_auth(p)
-    logintools.assert_login_fail(p, cred_ok.user, cred_bad.passwd)
+    logintools.assert_login_fail(p, cred_ok.user, cred_bad.passwd, expect_psh_afterwards=True)
 
     assert_auth(p)
-    logintools.assert_login_fail(p, cred_bad.user, cred_ok.passwd)
+    logintools.assert_login_fail(p, cred_bad.user, cred_ok.passwd, expect_psh_afterwards=True)
     assert_auth(p)
-    logintools.assert_login_fail(p, cred_bad.user, cred_bad.passwd)
+    logintools.assert_login_fail(p, cred_bad.user, cred_bad.passwd, expect_psh_afterwards=True)
 
     # Empty Credentials
     assert_auth(p)
-    logintools.assert_login_fail(p, cred_ok.user, cred_empty.passwd)
+    logintools.assert_login_fail(p, cred_ok.user, cred_empty.passwd, expect_psh_afterwards=True)
     assert_auth(p)
-    logintools.assert_login_fail(p, cred_bad.user, cred_empty.passwd)
+    logintools.assert_login_fail(p, cred_bad.user, cred_empty.passwd, expect_psh_afterwards=True)
     assert_auth(p)
     logintools.assert_login_empty(p, cred_empty.user)
     p.send(EOT)  # assert_login_empty() with empty login does not go back to psh, exit needed

--- a/psh/tools/login.py
+++ b/psh/tools/login.py
@@ -35,9 +35,11 @@ def assert_login(p, login, passwd):
     psh.assert_prompt(p, msg='Login should pass but failed', timeout=1)
 
 
-def assert_login_fail(p, login, passwd):
+def assert_login_fail(p, login, passwd, expect_psh_afterwards=False):
     log_in(p, login, passwd)
     psh.assert_prompt_fail(p, msg='Login should fail but passed', timeout=1)
+    if expect_psh_afterwards:
+        psh.assert_prompt(p, msg='Login should pass but failed')
 
 
 def assert_login_empty(p, login):


### PR DESCRIPTION
DONE: CI-114

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Fix waiting for psh prompt in login test

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixture:
-`auth` applet, after passing empty password shall wait 1 second and then close, effectively going back to psh (showing psh prompt)
- `assert_login_fail()` uses `assert_prompt_fail()` which guarantees that for given time (1 second here) psh prompt **doesn`t** appear on screen
- after that the new test commences where `auth` is written into console

If psh prompt appears a liitle bit late than 1s, the test can already assert its absence and immediately write `auth` to console which will be written into _nothing_ as the command interpreter is not yet present. Thus it fails next test case which thinks it properly called `auth` command when it did not. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
