### PR TITLE
psh: add `date` command tests

### DIFF
--- a/psh/test-date.py
+++ b/psh/test-date.py
@@ -1,0 +1,189 @@
+# Phoenix-RTOS
+#
+# phoenix-rtos-tests
+#
+# psh date command test
+#
+# Copyright 2022, 2023 Phoenix Systems
+# Author: Mateusz Niewiadomski, Mateusz Bloch
+#
+# This file is part of Phoenix-RTOS.
+#
+# %LICENSE%
+#
+
+import psh.tools.psh as psh
+
+DFLT_DATE_REG = r"\w{3}, \d{2} \w{3} (?:\d{2}|\d{4}),? \d{2}:\d{2}:\d{2}(?:\w{3}|\w{4})?\r+\n"
+SPEC_DATE_REG = r"Sun, 13 Sep (?:20|2020),? 12:26:4\d(?:\w{3}|\w{4})?\r+\n"  # arbitrary date of epoch 1600000000 GMT
+HUGE_DATE_REG = r"Tue, 19 Jan (?:38|2038),? 03:14:0\d(?:\w{3}|\w{4})?\r+\n"  # arbitrary date of epoch 2147483647 GMT
+ZERO_DATE_REG = r"Thu, 01 Jan (?:70|1970),? 00:00:0\d(?:\w{3}|\w{4})?\r+\n"  # arbitrary date of epoch 0 GMT
+
+
+# Utility functions
+def invalid_format(format):
+    return f"date: invalid format '{str(format)}'"
+
+
+def invalid_date(format):
+    return f"date: invalid date '{format}'"
+
+
+def unrec_arg(arg):
+    return f"Unrecognized argument: {arg}"
+
+
+# Test parts
+def test_corrects(p):
+    """Testing correct `date` commands"""
+
+    # Test help
+    psh.assert_cmd(p, "date -h", expected=r"Usage(.*?)FORMAT(.*?)\r+\n", is_regex=True)
+
+    # Test printing and formatting
+    psh.assert_cmd(p, "date", expected=DFLT_DATE_REG, is_regex=True)
+    psh.assert_cmd(p, "date +%Y", expected=r"\b(19|20)\d{2}\r+\n", is_regex=True)
+    psh.assert_cmd(p, "date +%H:%M:%Sformat", expected=r"\d{2}:\d{2}:\d{2}format\r+\n", is_regex=True)
+
+    # Test setting to value
+    psh.assert_cmd(p, "date -s @1600000000", expected=SPEC_DATE_REG, is_regex=True)
+    psh.assert_cmd(p, "date", expected=SPEC_DATE_REG, is_regex=True)
+
+    # Test setting to 0
+    psh.assert_cmd(p, "date -s @0", expected=ZERO_DATE_REG, is_regex=True)
+    psh.assert_cmd(p, "date", expected=ZERO_DATE_REG, is_regex=True)
+
+    # Test date parsing
+    psh.assert_cmd(p, "date -d @1600000000", expected=SPEC_DATE_REG, is_regex=True)
+    psh.assert_cmd(p, "date", expected=DFLT_DATE_REG, is_regex=True)
+
+    # Test date parsing for 0
+    psh.assert_cmd(p, "date -d @0", expected=ZERO_DATE_REG, is_regex=True)
+    psh.assert_cmd(p, "date", expected=DFLT_DATE_REG, is_regex=True)
+
+
+def test_incorrect_dateprint(p):
+    """Test incorrect or rare commandlines for printing date"""
+
+    # Incorrect FORMAT passed when printing date
+    psh.assert_cmd(p, "date operand1", expected=invalid_format("operand1"), result="fail")
+    psh.assert_cmd(p, "date", expected=DFLT_DATE_REG, is_regex=True)
+
+    # Incorrect FORMAT passed when printing date
+    psh.assert_cmd(p, "date +operand1", expected="operand1")
+    psh.assert_cmd(p, "date", expected=DFLT_DATE_REG, is_regex=True)
+
+    # too many arguments passed to print, should print first redundant
+    psh.assert_cmd(p, "date operand1 operand2 operand3", expected=unrec_arg("operand2"), result="fail")
+    psh.assert_cmd(p, "date", expected=DFLT_DATE_REG, is_regex=True)
+
+    # nonexistent format '%k' passed to print
+    psh.assert_cmd(p, "date +%Y%k%Y", expected=r"\b(19|20)\d{2}%k(19|20)\d{2}\r+\n", is_regex=True)
+    psh.assert_cmd(p, "date", expected=DFLT_DATE_REG, is_regex=True)
+
+
+def test_incorrect_datewrite(p):
+    """Test incorrect commandlines for setting date (no edge cases)"""
+
+    # No argument passed
+    psh.assert_cmd(p, "date -s", expected="date: option requires an argument -- s", result="fail")
+    psh.assert_cmd(p, "date", expected=DFLT_DATE_REG, is_regex=True)
+
+    # invalid time value
+    psh.assert_cmd(p, "date -s 123456789operand1", expected=invalid_date("123456789operand1"), result="fail")
+
+    # too many arguments
+    psh.assert_cmd(p, "date -s 1600000000 +format operand1", expected=unrec_arg("operand1"), result="fail")
+    psh.assert_cmd(p, "date", expected=DFLT_DATE_REG, is_regex=True)
+
+    # no integer number
+    psh.assert_cmd(p, "date -s @1600000000.1234567890", expected=invalid_date("@1600000000.1234567890"), result="fail")
+    psh.assert_cmd(p, "date", expected=DFLT_DATE_REG, is_regex=True)
+
+    # Issue: #801 https://github.com/phoenix-rtos/phoenix-rtos-project/issues/801
+    return
+
+    # negative number
+    psh.assert_cmd(p, "date -s @-1600000000", expected=SPEC_DATE_REG, result="fail")
+    psh.assert_cmd(p, "date", expected=DFLT_DATE_REG, is_regex=True)
+
+
+def test_incorrect_dateparse(p):
+    # No argument passed
+    psh.assert_cmd(p, "date -d", expected="date: option requires an argument -- d", result="fail")
+    psh.assert_cmd(p, "date", expected=DFLT_DATE_REG, is_regex=True)
+
+    # too many arguments
+    psh.assert_cmd(p, "date -d @1600000000 +format operand1", expected=unrec_arg("operand1"), result="fail")
+    psh.assert_cmd(p, "date", expected=DFLT_DATE_REG, is_regex=True)
+
+    # invalid time value
+    psh.assert_cmd(p, "date -d @1600000000operand1", expected=invalid_date("@1600000000operand1"), result="fail")
+    psh.assert_cmd(p, "date", expected=DFLT_DATE_REG, is_regex=True)
+
+    # no '@' sign
+    psh.assert_cmd(p, "date -d 1600000000", expected=invalid_date("1600000000"), result="fail")
+    psh.assert_cmd(p, "date", expected=DFLT_DATE_REG, is_regex=True)
+
+    # no integer number
+    psh.assert_cmd(p, "date -d @1600000000.1234567890", expected=invalid_date("@1600000000.1234567890"), result="fail")
+    psh.assert_cmd(p, "date", expected=DFLT_DATE_REG, is_regex=True)
+
+    # Issue: #801 https://github.com/phoenix-rtos/phoenix-rtos-project/issues/801
+    return
+
+    # negative number
+    psh.assert_cmd(p, "date -d @-1600000000", expected=SPEC_DATE_REG, result="fail")
+    psh.assert_cmd(p, "date", expected=DFLT_DATE_REG, is_regex=True)
+
+
+def test_edges(p):
+    """Test edge cases for epoch value passed to `date -s epoch"""
+
+    # maximum value for int32
+    psh.assert_cmd(p, "date -s @2147483647", expected=HUGE_DATE_REG, is_regex=True)
+    psh.assert_cmd(p, "date", expected=HUGE_DATE_REG, is_regex=True)
+    psh.assert_cmd(p, "date +%Y", expected="2038")
+    psh.assert_cmd(p, "date -s @0", expected=DFLT_DATE_REG, is_regex=True)
+
+    psh.assert_cmd(p, "date -d @2147483647", expected=HUGE_DATE_REG, is_regex=True)
+    psh.assert_cmd(p, "date", expected=DFLT_DATE_REG, is_regex=True)
+
+    # beyond int32 value
+    psh.assert_cmd(p, "date -s @2147483648", expected=HUGE_DATE_REG, is_regex=True)
+    psh.assert_cmd(p, "date", expected=HUGE_DATE_REG, is_regex=True)
+    psh.assert_cmd(p, "date +%Y", expected="2038")
+    psh.assert_cmd(p, "date -s @0", expected=DFLT_DATE_REG, is_regex=True)
+
+    psh.assert_cmd(p, "date -d @2147483648", expected=HUGE_DATE_REG, is_regex=True)
+    psh.assert_cmd(p, "date", expected=DFLT_DATE_REG, is_regex=True)
+
+    # Issue: #370 https://github.com/phoenix-rtos/phoenix-rtos-project/issues/370
+    return
+
+    psh.assert_cmd(
+        p,
+        "date -s @10000000000000000",
+        expected=r"Sat, 25 Jan (?:55|316889355),? \d{2}:\d{2}:\d{2}(?:\w{3}|\w{4})?\r+\n",
+        is_regex=True,
+    )
+    psh.assert_cmd(p, "date", expected=r"Sat, 25 Jan (?:55|316889355),? \d{2}:\d{2}:\d{2}\r+\n", is_regex=True)
+    psh.assert_cmd(p, "date +%Y", expected="316889355")
+    psh.assert_cmd(p, "date -s @0", DFLT_DATE_REG, is_regex=True)
+
+    psh.assert_cmd(
+        p,
+        "date -d @10000000000000000",
+        expected=r"Sat, 25 Jan 55 \d{2}:\d{2}:\d{2}(?:\w{3}|\w{4})?\r+\n",
+        is_regex=True,
+    )
+    psh.assert_cmd(p, "date", expected=DFLT_DATE_REG, is_regex=True)
+
+
+@psh.run
+def harness(p):
+    test_corrects(p)
+    test_incorrect_dateprint(p)
+    test_incorrect_datewrite(p)
+    test_incorrect_dateparse(p)
+    test_edges(p)

--- a/psh/test.yaml
+++ b/psh/test.yaml
@@ -22,6 +22,9 @@ test:
         - name: echo
           harness: test-echo.py
 
+        - name: date
+          harness: test-date.py
+
         - name: prompt
           harness: test-prompt.py
 


### PR DESCRIPTION
JIRA: PD-249

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Tests of `date` psh applet

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These tests were written alongside with `date` applet which is under review here:
 - https://github.com/phoenix-rtos/phoenix-rtos-utils/pull/123
This is a try of __Test Driven Developement__ procedure application for me.  

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work:
  - https://github.com/phoenix-rtos/phoenix-rtos-utils/pull/123
- [ ] I will merge this PR by myself when appropriate.
