### PR TITLE
use ia32 generic testing script and handle programs with arguments in test-ps

### DIFF
--- a/psh/test-ps.py
+++ b/psh/test-ps.py
@@ -35,7 +35,10 @@ def harness(p):
             try:
                 pid, ppid, pr, state, cpu, wait, time, vmem, thr, task = line.split()
             except ValueError:
-                assert False, f'wrong ps output: {line}'
+                try:
+                    pid, ppid, pr, state, cpu, wait, time, vmem, thr, task, arguments = line.split()
+                except ValueError:
+                    assert False, f'wrong ps output: {line}'
             # handle for example /bin/psh
             if task.endswith('psh'):
                 task = 'psh'

--- a/trunner/device.py
+++ b/trunner/device.py
@@ -5,14 +5,7 @@ from .config import PHRTOS_PROJECT_DIR, DEVICE_SERIAL_USB, PHOENIXD_PORT
 
 
 QEMU_CMD = {
-    'ia32-generic': (
-        'qemu-system-i386',
-        [
-            '-hda', f'{PHRTOS_PROJECT_DIR}/_boot/phoenix-ia32-generic.disk',
-            '-nographic',
-            '-monitor', 'none'
-        ]
-    )
+    'ia32-generic': f'{PHRTOS_PROJECT_DIR}/scripts/ia32-generic-test.sh'
 }
 
 
@@ -20,7 +13,7 @@ class RunnerFactory:
     @staticmethod
     def create(target, serial, log=False):
         if target == 'ia32-generic':
-            return QemuRunner(*QEMU_CMD[target], log=log)
+            return QemuRunner(QEMU_CMD[target], log=log)
         if target == 'host-pc':
             return HostRunner(log=log)
         if target == 'armv7m7-imxrt106x':

--- a/trunner/runners/QemuRunner.py
+++ b/trunner/runners/QemuRunner.py
@@ -16,10 +16,9 @@ from .common import Runner
 class QemuRunner(Runner):
     """This class provides interface to run test case using QEMU as a device."""
 
-    def __init__(self, qemu, args, log):
+    def __init__(self, qemu, log):
         super().__init__(log)
         self.qemu = qemu
-        self.args = args
 
     def flash(self):
         """No-op method for QemuRunner, forced inheritance from Runner class"""
@@ -29,7 +28,7 @@ class QemuRunner(Runner):
         if test.skipped():
             return
 
-        proc = pexpect.spawn(self.qemu, args=self.args, encoding='ascii', timeout=test.timeout)
+        proc = pexpect.spawn(self.qemu, encoding='ascii', timeout=test.timeout)
         if self.logpath:
             proc.logfile = open(self.logpath, "a")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

- trunner: add using testing script for launching ia32-generic emualtor
- psh: handle programs with arguments in test-ps

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

JIRA: CI-116

Now the command for running qemu (ia32-generic target) is now placed strictly in test runner:
![Screenshot from 2022-03-25 12-30-04](https://user-images.githubusercontent.com/77304431/160113898-95ed4bf4-d002-4d32-a002-b9ea393b6bdc.png)

It may be better to create the proper script in `scripts` directory that could be used by a test runner. If there is a need for change in qemu running it will be done only in the `scripts` directory (it's easier to remember about changing similar script in the same directory than changing some file in tests repository).

After enabling testing script the lwip with arguments will be present in ps output and `ValueError` will occur. The second commit fixes it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (https://github.com/phoenix-rtos/phoenix-rtos-project/pull/367).
- [ ] I will merge this PR by myself when appropriate.
