### PR TITLE
meterfs: test partial record read

### DIFF
--- a/meterfs/test_meterfs_writeread.c
+++ b/meterfs/test_meterfs_writeread.c
@@ -43,6 +43,12 @@ static void turnCheck(int fd, file_info_t *info, char *bufftx, char *buffrx, uns
 		TEST_ASSERT_EQUAL(info->recordsz, file_read(fd, 0, buffrx, info->recordsz));
 
 		TEST_ASSERT_EQUAL_HEX8_ARRAY(bufftx, buffrx, info->recordsz);
+
+		if (info->recordsz > 2) {
+			memset(buffrx + 1, 'x', info->recordsz - 2);
+			TEST_ASSERT_EQUAL(info->recordsz - 2, file_read(fd, 1, buffrx + 1, info->recordsz - 2));
+			TEST_ASSERT_EQUAL_HEX8_ARRAY(bufftx, buffrx, info->recordsz);
+		}
 	}
 }
 


### PR DESCRIPTION
Adding read with non-zero offset to meterfs tests

## Motivation and Context
Reading files with non-zero offset fails on current meterfs due to checksum calculation error. This problem was introduced in https://github.com/phoenix-rtos/phoenix-rtos-filesystems/pull/61


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
