### PR TITLE
adapt test runner and ls tests to a new armv7a9-zynq7000

### DIFF
--- a/psh/test-ls-rootfs.py
+++ b/psh/test-ls-rootfs.py
@@ -65,6 +65,21 @@ def assert_ls_t(p):
     psh.assert_cmd(p, f'ls -t {ROOT_TEST_DIR}', expected_pattern, msg, is_regex=True)
 
 
+def assert_ls_S(p):
+    expected_pattern = r'.*?psh' + SEPARATOR_PATTERN + r'.*?empty_file' + SEPARATOR_PATTERN + r'.*?'
+    expected_pattern = expected_pattern + psh.EOL
+
+    psh.assert_cmd(p, 'touch /bin/empty_file', '', 'Wrong output when creating empty file!')
+
+    # TODO: use only newly created files, when it will be possible to write content to a file
+    psh.assert_cmd(
+        pexpect_proc=p,
+        cmd='ls -1S /bin',
+        expected=expected_pattern,
+        msg='Wrong output, when calling `ls -1S`',
+        is_regex=True)
+
+
 def assert_multi(p):
     files = []
     for i in range(20):
@@ -101,6 +116,6 @@ def harness(p):
     assert_extralong(p)
 
     psh_cmds = psh.get_commands(p)
-    if 'date' in psh_cmds:
-        assert_ls_t(p)
+    assert_ls_t(p)
+    assert_ls_S(p)
     assert_ls_pshcmds(p, psh_cmds)

--- a/psh/test_ls.py
+++ b/psh/test_ls.py
@@ -138,14 +138,6 @@ def assert_ls_r(p, files):
     psh.assert_cmd(p, f'ls -r {TEST_DIR_BASIC}', expected, msg, is_regex=True)
 
 
-def assert_ls_S(p, files):
-    # it's common that empty directories has larger size than empty files
-    size_sorted_files = list(sorted(files, key=lambda x: (0, x) if x == 'dir' else (1, x)))
-    expected = create_ordered_pattern(size_sorted_files)
-    msg = 'Wrong output, when calling `ls -S`'
-    psh.assert_cmd(p, f'ls -S {TEST_DIR_BASIC}', expected, msg, is_regex=True)
-
-
 def harness(p):
     listed_files = ('test1', 'test0', 'dir')
     to_create_files = ('.hidden',) + listed_files
@@ -164,4 +156,3 @@ def harness(p):
     assert_ls_h(p)
     assert_ls_l(p, listed_files)
     assert_ls_r(p, listed_files)
-    assert_ls_S(p, listed_files)

--- a/trunner/runners/QemuRunner.py
+++ b/trunner/runners/QemuRunner.py
@@ -34,7 +34,7 @@ class QemuRunner(Runner):
         if test.skipped():
             return
 
-        proc = pexpect.spawn(self.cmd, encoding='ascii', timeout=test.timeout)
+        proc = pexpect.spawn(self.cmd, encoding='utf-8', timeout=test.timeout)
         if self.logpath:
             proc.logfile = open(self.logpath, "a")
 

--- a/trunner/runners/common.py
+++ b/trunner/runners/common.py
@@ -366,7 +366,7 @@ class DeviceRunner(Runner):
             test.handle_exception()
             return
 
-        proc = pexpect.fdpexpect.fdspawn(self.serial, encoding='ascii', timeout=test.timeout)
+        proc = pexpect.fdpexpect.fdspawn(self.serial, encoding='utf-8', timeout=test.timeout)
         if self.logpath:
             proc.logfile = open(self.logpath, "a")
 

--- a/trunner/testcase.py
+++ b/trunner/testcase.py
@@ -89,7 +89,11 @@ class TestCase:
     def exec_test(self, proc):
         try:
             # Wait for a prompt
-            proc.expect_exact('(psh)% ')
+            # On armv7a9-zynq7000-qemu jffs initialization may take to ~20s, that's why it's set to 25
+            if self.target == "armv7a9-zynq7000-qemu":
+                proc.expect_exact('(psh)% ', timeout=25)
+            else:
+                proc.expect_exact('(psh)% ')
             if self.exec_cmd:
                 if self.use_sysexec:
                     self.sysexec(proc)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
- psh: ls: move size test case to test-ls-rootfs
- psh: ls: make -f arg case more flexible
- trunner: adapt timeout and encoding to a new armv7a9-zynq7000


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Default timeout for pyexpect was too low for jffs init on armv7a9-zynq7000-qemu
- Because of non-ascii character in init logs (©) switch back to utf-8 encoding in psh
- -f argument test case assumed that not sorted files are listed by creation time, which is wrong for jffs. Checking files order in this case has been disabled.
- The correction of size sorting was checked by listing an empty file and an empty directory.
    Assumption that directory has larger size than a file is wrong for jffs.
    Now size size sorting assertion is done by comparing empty file with psh binary in /bin.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (armv7a9-zynq7000-qemu with newest mtd changes).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
