### PR TITLE
psh: disable psh tests for armv7a9-zynq7000-qemu

### DIFF
--- a/psh/test.yaml
+++ b/psh/test.yaml
@@ -1,7 +1,7 @@
 test:
     targets:
-      #TODO: remove when armv7a9-zynq7000-qemu and riscv64-generic-qemu targets will stop being experimental
-      include: [armv7a9-zynq7000-qemu, riscv64-generic-qemu]
+      #TODO: remove when riscv64-generic-qemu target will stop being experimental
+      include: [riscv64-generic-qemu]
 
     tests:
         - name: auth


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

 - psh: disable psh tests for armv7a9-zynq7000-qemu

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

DONE: PD-288

After adding busybox to armv7a9-zynq7000 target psh isn't run by default.
It's the temporary solution before adding support for running psh from ash.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
