### PR TITLE
enable all available  tests for zynq7000-qemu (waiting for QuickRunner)

### DIFF
--- a/libc/test.yaml
+++ b/libc/test.yaml
@@ -4,5 +4,7 @@ test:
         - name: unit
           exec: test-libc
           #FIXME: symlink tests will fail on non-rootfs targets
+          # TODO: enable the test for armv7a9-zynq7000-qemu after resolving #445 issue
+          # https://github.com/phoenix-rtos/phoenix-rtos-project/issues/445
           targets:
-              exclude: [armv7m7-imxrt106x-evk, armv7m7-imxrt117x-evk]
+              exclude: [armv7m7-imxrt106x-evk, armv7m7-imxrt117x-evk, armv7a9-zynq7000-qemu]

--- a/psh/test.yaml
+++ b/psh/test.yaml
@@ -1,7 +1,7 @@
 test:
     targets:
       #TODO: remove when riscv64-generic-qemu target will stop being experimental
-      include: [riscv64-generic-qemu, armv7a9-zynq7000-qemu]
+      include: [riscv64-generic-qemu]
 
     tests:
         - name: gibber

--- a/psh/test.yaml
+++ b/psh/test.yaml
@@ -40,6 +40,11 @@ test:
 
         - name: kill
           harness: test-kill.py
+          targets:
+              # TODO: enable after resolving the #448 issue
+              # https://github.com/phoenix-rtos/phoenix-rtos-project/issues/448
+              exclude:
+                  - armv7a9-zynq7000-qemu
 
         - name: mkdir
           harness: test-mkdir.py

--- a/psh/test.yaml
+++ b/psh/test.yaml
@@ -1,7 +1,7 @@
 test:
     targets:
       #TODO: remove when riscv64-generic-qemu target will stop being experimental
-      include: [riscv64-generic-qemu]
+      include: [riscv64-generic-qemu, armv7a9-zynq7000-qemu]
 
     tests:
         - name: gibber

--- a/trunner/config.py
+++ b/trunner/config.py
@@ -40,12 +40,12 @@ ALL_TARGETS = ['armv7a9-zynq7000-qemu',
                'ia32-generic-qemu',
                'riscv64-generic-qemu']
 
-EXPERIMENTAL_TARGETS = ['armv7a9-zynq7000-qemu', 'armv7m4-stm32l4x6-nucleo', 'riscv64-generic-qemu']
+EXPERIMENTAL_TARGETS = ['armv7m4-stm32l4x6-nucleo', 'riscv64-generic-qemu']
 # Default targets used by parser if 'target' value is absent
 DEFAULT_TARGETS = [target for target in ALL_TARGETS
                    if target not in EXPERIMENTAL_TARGETS + ['host-generic-pc']]
 
-SYSEXEC_TARGETS = ['armv7a9-zynq7000-qemu', 'armv7m7-imxrt106x-evk', 'armv7m7-imxrt117x-evk', 'riscv64-generic-qemu']
+SYSEXEC_TARGETS = ['armv7m7-imxrt106x-evk', 'armv7m7-imxrt117x-evk', 'riscv64-generic-qemu']
 
 QEMU_TARGETS = ['armv7a9-zynq7000-qemu', 'ia32-generic-qemu', 'riscv64-generic-qemu']
 

--- a/trunner/config.py
+++ b/trunner/config.py
@@ -49,8 +49,15 @@ SYSEXEC_TARGETS = ['armv7a9-zynq7000-qemu', 'armv7m7-imxrt106x-evk', 'armv7m7-im
 
 QEMU_TARGETS = ['armv7a9-zynq7000-qemu', 'ia32-generic-qemu', 'riscv64-generic-qemu']
 
+# Targets, where busybox ash starts by default
+ASH_TARGETS = ['armv7a9-zynq7000-qemu']
+
 # Tests intended to run in long test campaigns
 LONG_TESTS = ['busybox', 'mbedtls', 'micropython_std', 'micropython_repl']
+
+PSH_PROMPT = "(psh)% "
+DEFAULT_PROMPT = PSH_PROMPT
+ASH_PROMPT = "root@?:~ # "
 
 CURRENT_TARGET = None
 

--- a/trunner/testcase.py
+++ b/trunner/testcase.py
@@ -94,12 +94,10 @@ class TestCase:
     def exec_test(self, proc):
         try:
             # Wait for a prompt
-            # On armv7a9-zynq7000-qemu jffs initialization may take to ~25s, that's why it's set to 30
-            # It's related to the #448 issue
-            # https://github.com/phoenix-rtos/phoenix-rtos-project/issues/448
-
-            if self.target == "armv7a9-zynq7000-qemu":
-                proc.expect_exact(self.prompt, timeout=30)
+            # On zynq7000-qemu target the system initialization may take more time
+            # Especially on gh hosted ruunners (even if locally it takes 4-5s)
+            if self.target == 'armv7a9-zynq7000-qemu':
+                proc.expect_exact(self.prompt, timeout=25)
             else:
                 proc.expect_exact(self.prompt)
             if self.exec_cmd:

--- a/trunner/testcase.py
+++ b/trunner/testcase.py
@@ -94,7 +94,7 @@ class TestCase:
     def exec_test(self, proc):
         try:
             # Wait for a prompt
-            # On armv7a9-zynq7000-qemu jffs initialization may take to ~20s, that's why it's set to 25
+            # On armv7a9-zynq7000-qemu jffs initialization may take to ~25s, that's why it's set to 30
             # It's related to the #448 issue
             # https://github.com/phoenix-rtos/phoenix-rtos-project/issues/448
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

- trunner: restore psh tests on zynq7000-qemu
- enable running unit tests on zynq7000-qemu
- psh: temporarily disable test-kill for zynq7000-qemu

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (https://github.com/phoenix-rtos/phoenix-rtos-project/pull/449).
- [ ] I will merge this PR by myself when appropriate.
