### PR TITLE
MicroPython: getting rid of warnings during compilation MicroPython tests

### DIFF
--- a/micropython/test_micropython.c
+++ b/micropython/test_micropython.c
@@ -34,7 +34,7 @@ void upyth_errMsg(const char *msg)
 }
 
 
-char *upyth_concat(const char *str1, const char *str2)
+char *upyth_concat(char *str1, const char *str2)
 {
 	int len;
 	char *res;
@@ -53,7 +53,7 @@ int upyth_optionsGet(const char *path, char **options)
 {
 	FILE *f;
 	char *line = NULL;
-	int lineLen = 0;
+	size_t lineLen = 0;
 	int optionsLen;
 	char *newLine;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
This PR contains small adjustments in MicroPython tests.It gets rid of warnings during compilation of `test_micropython.c` file.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
More elegant code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here). `ia32-generic-qemu`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
