### PR TITLE
pthread_cond: fix return values

### DIFF
--- a/libc/pthread_cond.c
+++ b/libc/pthread_cond.c
@@ -47,8 +47,8 @@ TEST(test_pthread_cond, pthread_condattr_setclock)
 	/* Only 'CLOCK_MONOTONIC' supported */
 	TEST_ASSERT_EQUAL(EOK, pthread_condattr_getclock(&attr, &clock));
 	TEST_ASSERT_EQUAL(CLOCK_MONOTONIC, clock);
-	TEST_ASSERT_EQUAL(-EINVAL, pthread_condattr_setclock(&attr, CLOCK_MONOTONIC_RAW));
-	TEST_ASSERT_EQUAL(-EINVAL, pthread_condattr_setclock(&attr, CLOCK_REALTIME));
+	TEST_ASSERT_EQUAL(EINVAL, pthread_condattr_setclock(&attr, CLOCK_MONOTONIC_RAW));
+	TEST_ASSERT_EQUAL(EINVAL, pthread_condattr_setclock(&attr, CLOCK_REALTIME));
 }
 
 
@@ -62,7 +62,7 @@ TEST(test_pthread_cond, pthread_condattr_setpshared)
 	/* Only 'PTHREAD_PROCESS_PRIVATE' supported */
 	TEST_ASSERT_EQUAL(EOK, pthread_condattr_getpshared(&attr, &pshared));
 	TEST_ASSERT_EQUAL(PTHREAD_PROCESS_PRIVATE, pshared);
-	TEST_ASSERT_EQUAL(-EINVAL, pthread_condattr_setpshared(&attr, PTHREAD_PROCESS_SHARED));
+	TEST_ASSERT_EQUAL(EINVAL, pthread_condattr_setpshared(&attr, PTHREAD_PROCESS_SHARED));
 }
 
 
@@ -158,7 +158,7 @@ TEST(test_pthread_cond, pthread_cond_timedwait_fail_signal_incorrect_timeout)
 	TEST_ASSERT_EQUAL(EOK, pthread_join(second, NULL));
 
 	TEST_ASSERT_EQUAL(EOK, err_first.err1);
-	TEST_ASSERT_EQUAL(-ETIMEDOUT, err_first.err2);
+	TEST_ASSERT_EQUAL(ETIMEDOUT, err_first.err2);
 	TEST_ASSERT_EQUAL(EOK, err_first.err3);
 	TEST_ASSERT_EQUAL(EOK, err_second.err1);
 	TEST_ASSERT_EQUAL(EOK, err_second.err2);
@@ -180,7 +180,7 @@ TEST(test_pthread_cond, pthread_cond_timedwait_fail_signal_too_short_timeout)
 	TEST_ASSERT_EQUAL(EOK, pthread_join(second, NULL));
 
 	TEST_ASSERT_EQUAL(EOK, err_first.err1);
-	TEST_ASSERT_EQUAL(-ETIMEDOUT, err_first.err2);
+	TEST_ASSERT_EQUAL(ETIMEDOUT, err_first.err2);
 	TEST_ASSERT_EQUAL(EOK, err_first.err3);
 	TEST_ASSERT_EQUAL(EOK, err_second.err1);
 	TEST_ASSERT_EQUAL(EOK, err_second.err2);
@@ -231,10 +231,10 @@ TEST(test_pthread_cond, pthread_cond_timedwait_fail_broadcast_incorrect_timeout)
 	TEST_ASSERT_EQUAL(EOK, pthread_join(third, NULL));
 
 	TEST_ASSERT_EQUAL(EOK, err_first.err1);
-	TEST_ASSERT_EQUAL(-ETIMEDOUT, err_first.err2);
+	TEST_ASSERT_EQUAL(ETIMEDOUT, err_first.err2);
 	TEST_ASSERT_EQUAL(EOK, err_first.err3);
 	TEST_ASSERT_EQUAL(EOK, err_second.err1);
-	TEST_ASSERT_EQUAL(-ETIMEDOUT, err_second.err2);
+	TEST_ASSERT_EQUAL(ETIMEDOUT, err_second.err2);
 	TEST_ASSERT_EQUAL(EOK, err_second.err3);
 	TEST_ASSERT_EQUAL(EOK, err_third.err1);
 	TEST_ASSERT_EQUAL(EOK, err_third.err2);
@@ -258,10 +258,10 @@ TEST(test_pthread_cond, pthread_cond_timedwait_fail_broadcast_too_short_timeout)
 	TEST_ASSERT_EQUAL(EOK, pthread_join(third, NULL));
 
 	TEST_ASSERT_EQUAL(EOK, err_first.err1);
-	TEST_ASSERT_EQUAL(-ETIMEDOUT, err_first.err2);
+	TEST_ASSERT_EQUAL(ETIMEDOUT, err_first.err2);
 	TEST_ASSERT_EQUAL(EOK, err_first.err3);
 	TEST_ASSERT_EQUAL(EOK, err_second.err1);
-	TEST_ASSERT_EQUAL(-ETIMEDOUT, err_second.err2);
+	TEST_ASSERT_EQUAL(ETIMEDOUT, err_second.err2);
 	TEST_ASSERT_EQUAL(EOK, err_second.err3);
 	TEST_ASSERT_EQUAL(EOK, err_third.err1);
 	TEST_ASSERT_EQUAL(EOK, err_third.err2);


### PR DESCRIPTION
JIRA: RTOS-236

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
fix return values from pthread library
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- JIRA: RTOS-236
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order) https://github.com/phoenix-rtos/libphoenix/pull/203.
- [ ] I will merge this PR by myself when appropriate.
