### PR TITLE
trunner: plo: switch to sending CR instead of CRLF, remove baudrate arg for phoenixd

### DIFF
--- a/trunner/runners/common.py
+++ b/trunner/runners/common.py
@@ -254,7 +254,7 @@ class PloTalker:
     def interrupt_counting(self):
         """ Interrupts timer counting to enter plo """
         self.plo.expect_exact('Waiting for input', timeout=3)
-        self.plo.send('\r\n')
+        self.plo.send('\n')
         self.plo.expect_exact('\n')
 
     def open(self):
@@ -292,7 +292,8 @@ class PloTalker:
             raise PloError(line, expected="(plo)% ")
 
     def cmd(self, cmd, timeout=8):
-        self.plo.send(cmd + '\r\n')
+        # Plo requires only CR, when sending command
+        self.plo.send(cmd + '\r')
         # Wait for an eoched command
         self.plo.expect_exact(cmd)
         # There might be some ASCII escape characters, we wait only for a new line
@@ -317,7 +318,7 @@ class PloTalker:
         )
 
     def go(self):
-        self.plo.send('go!\r\n')
+        self.plo.send('go!\r')
 
 
 class Runner(ABC):

--- a/trunner/runners/common.py
+++ b/trunner/runners/common.py
@@ -136,7 +136,6 @@ class Phoenixd:
         self,
         target,
         port,
-        baudrate=460800,
         dir='.',
         cwd=None,
         wait_dispatcher=True
@@ -145,7 +144,6 @@ class Phoenixd:
             cwd = boot_dir(target)
         self.cwd = cwd
         self.port = port
-        self.baudrate = baudrate
         self.dir = dir
         self.proc = None
         self.reader_thread = None
@@ -164,7 +162,7 @@ class Phoenixd:
                 break
 
             if self.wait_dispatcher and not self.dispatcher_event.is_set():
-                msg = f'Starting message dispatcher on [{self.port}] (speed={self.baudrate})'
+                msg = f'Starting message dispatcher on [{self.port}]'
                 if msg in line:
                     self.dispatcher_event.set()
 
@@ -180,7 +178,6 @@ class Phoenixd:
         self.proc = pexpect.spawn(
             'phoenixd',
             ['-p', self.port,
-             '-b', str(self.baudrate),
              '-s', self.dir],
             cwd=self.cwd,
             encoding='ascii'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

 - trunner: plo: switch to sending CR instead of CRLF
 - trunner: remove baudrate arg for phoenixd
 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

 - There were issue, where LF was left in the buffer, because plo parsed only CR

 - Baudrate arg is no longer needed

JIRA: PD-306
JIRA: PD-307

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
