### PR TITLE
improve initialization and add deinitialization in psh tests

### DIFF
--- a/psh/test-auth.py
+++ b/psh/test-auth.py
@@ -34,10 +34,8 @@ def assert_auth(p):
     assert p.expect_exact(['Login:', pexpect.TIMEOUT], timeout=2) == 0, '"auth" applet does not launch'
 
 
+@psh.run
 def harness(p):
-    # Run psh
-    psh.init(p)
-
     # Check if auth app is available and login exit
     assert_auth(p)
     p.send(EOT)

--- a/psh/test-auth.py
+++ b/psh/test-auth.py
@@ -19,8 +19,9 @@ import psh.tools.psh as psh
 
 import psh.tools.login as logintools
 
+from psh.tools.psh import EOT
 
-EOT = '\x04'
+
 BACKSPACE = '\x08'
 cred_ok = logintools.Credentials('defuser', '1234')
 cred_bad = logintools.Credentials('lorem', 'ipsum')

--- a/psh/test-autocompletion.py
+++ b/psh/test-autocompletion.py
@@ -50,9 +50,8 @@ def assert_hints(p, path, hints):
     psh.assert_prompt(p, msg='No prompt after hints test', timeout=1)
 
 
+@psh.run
 def harness(p):
-    psh.init(p)
-
     mkdir(p, 'etc')
 
     # Create test environment

--- a/psh/test-cat-shells.py
+++ b/psh/test-cat-shells.py
@@ -15,9 +15,8 @@
 import psh.tools.psh as psh
 
 
+@psh.run
 def harness(p):
-    psh.init(p)
-
     fname = 'etc/shells'
     expected = r'# /etc/shells: valid login shells(\r+)\n/bin/sh(\r+)\n'
     cmd = f'cat {fname}'

--- a/psh/test-cat.py
+++ b/psh/test-cat.py
@@ -31,9 +31,8 @@ def assert_cat_h(p):
     psh.assert_cmd(p, cmd, expected=help)
 
 
+@psh.run
 def harness(p):
-    psh.init(p)
-
     # need to add more test cases when it will be possible to write content to the file
     assert_cat_err(p)
     assert_cat_h(p)

--- a/psh/test-echo.py
+++ b/psh/test-echo.py
@@ -15,9 +15,8 @@
 import psh.tools.psh as psh
 
 
+@psh.run
 def harness(p):
-    psh.init(p)
-
     # Simple check
     psh.assert_cmd(p, 'echo', '\r+\n', 'empty echo fail', is_regex=True)
     psh.assert_cmd(p, 'echo loremipsum', 'loremipsum', 'simple text not echoed back')

--- a/psh/test-echo.py
+++ b/psh/test-echo.py
@@ -17,7 +17,6 @@ import psh.tools.psh as psh
 
 def harness(p):
     psh.init(p)
-    psh.assert_prompt(p)
 
     # Simple check
     psh.assert_cmd(p, 'echo', '\r+\n', 'empty echo fail', is_regex=True)

--- a/psh/test-gibber.py
+++ b/psh/test-gibber.py
@@ -47,9 +47,8 @@ def assert_not_ascii(p):
     psh.assert_prompt_after_cmd(p, chars, "Prompt not seen when sending non-ascii characters")
 
 
+@psh.run
 def harness(p):
-    psh.init(p)
-
     assert_printable(p)
     assert_unprintable(p)
     assert_not_ascii(p)

--- a/psh/test-history.py
+++ b/psh/test-history.py
@@ -89,9 +89,8 @@ def assert_empty(p):
     psh.assert_cmd(p, 'history', '  1  history', msg)
 
 
+@psh.run
 def harness(p):
-    psh.init(p)
-
     psh_cmds = psh.get_commands(p)
 
     assert_help(p)

--- a/psh/test-kill.py
+++ b/psh/test-kill.py
@@ -38,7 +38,7 @@ def get_process_list(p):
     return ps_list
 
 
-def create_psh_processes(p, count):
+def create_psh_processes(p, count, already_spawned):
     psh_pid_list = []
     msg = 'Failed to create new psh process'
     for _ in range(count):
@@ -51,7 +51,7 @@ def create_psh_processes(p, count):
             psh_pid_list.append(proc['pid'])
 
     psh_pid_count = len(psh_pid_list)
-    assert psh_pid_count == count, f'Created {psh_pid_count} psh processes, instead of {count}'
+    assert (psh_pid_count - already_spawned) == count, f'Created {psh_pid_count } psh processes, instead of {count}'
 
     return psh_pid_list
 
@@ -89,5 +89,6 @@ def harness(p):
 
     assert_errors(p)
 
-    pid_list = create_psh_processes(p, 3)
+    sleep_pshs = sum((proc['state'] == 'sleep' and proc['task'] in ('psh', '/bin/psh')) for proc in get_process_list(p))
+    pid_list = create_psh_processes(p, 3, already_spawned=sleep_pshs)
     assert_kill_procs(p, pid_list)

--- a/psh/test-kill.py
+++ b/psh/test-kill.py
@@ -84,9 +84,8 @@ def assert_errors(p):
     psh.assert_cmd(p, f'kill {pid}', '', msg)
 
 
+@psh.run
 def harness(p):
-    psh.init(p)
-
     assert_errors(p)
 
     sleep_pshs = sum((proc['state'] == 'sleep' and proc['task'] in ('psh', '/bin/psh')) for proc in get_process_list(p))

--- a/psh/test-ls-rootfs.py
+++ b/psh/test-ls-rootfs.py
@@ -106,8 +106,8 @@ def assert_extralong(p):
     psh.assert_cmd(p, f'ls {testdir_long}', expected, msg, is_regex=True)
 
 
+@psh.run
 def harness(p):
-    psh.init(p)
     create_testdir(p, ROOT_TEST_DIR)
 
     # these cases may not work on non-rootfs targets, because of too many internal directories

--- a/psh/test-ls.py
+++ b/psh/test-ls.py
@@ -136,12 +136,11 @@ def assert_ls_r(p, files):
     psh.assert_cmd(p, f'ls -r {TEST_DIR_BASIC}', expected, msg, is_regex=True)
 
 
+@psh.run
 def harness(p):
     listed_files = ('test1', 'test0', 'dir')
     to_create_files = ('.hidden',) + listed_files
     all_files = ('.', '..') + to_create_files
-
-    psh.init(p)
 
     create_testdir(p, ROOT_TEST_DIR)
     prepare_testdir(p, to_create_files)

--- a/psh/test-mkdir.py
+++ b/psh/test-mkdir.py
@@ -102,10 +102,9 @@ def assert_first_prompt(p):
     assert got == prompt, f'Expected:\n{prompt}\nGot:\n{got}'
 
 
+@psh.run
 def harness(p):
     chars = list(set(string.printable) - set(string.whitespace) - set('/'))
-
-    psh.init(p)
 
     assert_dir_created(p, 'example_dir')
     files = ls(p)

--- a/psh/test-prompt.py
+++ b/psh/test-prompt.py
@@ -1,5 +1,7 @@
 import psh.tools.psh as psh
 
 
+@psh.run
 def harness(p):
-    psh.init(p)
+    # psh.init() already asserts prompt
+    pass

--- a/psh/test-ps.py
+++ b/psh/test-ps.py
@@ -11,9 +11,8 @@ import psh.tools.psh as psh
 """
 
 
+@psh.run
 def harness(p):
-    psh.init(p)
-
     header_seen = False
     expected_tasks = ['[idle]', 'init', 'psh']
     ps_header = 'PID PPID PR STATE %CPU WAIT TIME VMEM THR CMD'.split()

--- a/psh/test-pshlogin.py
+++ b/psh/test-pshlogin.py
@@ -39,10 +39,8 @@ def assert_pshlogin(p):
         raise AssertionError('pshlogin does not launch')
 
 
+@psh.run
 def harness(p):
-    # Run psh
-    psh.init(p)
-
     # Run pshlogin
     assert_pshlogin(p)
 
@@ -71,3 +69,6 @@ def harness(p):
     p.send(string.printable + '\n')
     assert p.expect_exact(['Login:', pexpect.TIMEOUT], timeout=2) == 0, 'Long login does not repeat login procedure'
     logintools.assert_login_fail(p, cred_ok.user, string.printable)  # too long password
+
+    # Proper login to go back to psh
+    logintools.assert_login(p, cred_ok_etc.user, cred_ok_etc.passwd)

--- a/psh/tools/README.md
+++ b/psh/tools/README.md
@@ -22,6 +22,8 @@ The python module `psh` makes writing harness tests easier. It provides the foll
 
 * `init(pexpect_proc)` - Runs psh and next, asserts its first prompt.
 
+* `deinit(pexpect_proc)` - Closes spawned psh and asserts its exit.
+
 The `pexpect_proc` argument is the [pexpect](https://pexpect.readthedocs.io/en/stable/api/index.html) process returned by `pexpect.spawn()` method. Each functional test has the spawned process passed in the argument, which is `p`, please see examples below.
 
 ## The usage examples

--- a/psh/tools/README.md
+++ b/psh/tools/README.md
@@ -20,7 +20,7 @@ The python module `psh` makes writing harness tests easier. It provides the foll
 
 * `assert_cmd_passed` - Asserts that the exit code of previously sent command equaled 0.
 
-* `init(pexpect_proc)` - Runs psh and next, asserts the first prompt.
+* `init(pexpect_proc)` - Runs psh and next, asserts its first prompt.
 
 The `pexpect_proc` argument is the [pexpect](https://pexpect.readthedocs.io/en/stable/api/index.html) process returned by `pexpect.spawn()` method. Each functional test has the spawned process passed in the argument, which is `p`, please see examples below.
 

--- a/psh/tools/psh.py
+++ b/psh/tools/psh.py
@@ -132,16 +132,12 @@ def get_commands(pexpect_proc):
     return commands
 
 
-def run(pexpect_proc):
+def init(pexpect_proc):
+    ''' Runs psh and asserts its first prompt'''
     # using runfile/sysexec to spawn a new psh process
     exec_cmd = _get_exec_cmd('psh')
     pexpect_proc.sendline(exec_cmd)
     pexpect_proc.expect(rf'{exec_cmd}(\r+)\n')
-
-
-def init(pexpect_proc):
-    ''' Runs psh and asserts its first prompt'''
-    run(pexpect_proc)
     assert_only_prompt(pexpect_proc)
 
 
@@ -150,3 +146,12 @@ def deinit(pexpect_proc):
 
     pexpect_proc.send(EOT)
     pexpect_proc.expect(r'exit(\r+)\n')
+
+
+def run(harness):
+
+    def wrapper_harness(pexpect_proc):
+        init(pexpect_proc)
+        harness(pexpect_proc)
+        deinit(pexpect_proc)
+    return wrapper_harness

--- a/psh/tools/psh.py
+++ b/psh/tools/psh.py
@@ -19,6 +19,7 @@ import pexpect
 import trunner.config as config
 
 EOL = r'(\r+)\n'
+EOT = '\x04'
 PROMPT = r'(\r+)\x1b\[0J' + r'\(psh\)% '
 
 
@@ -142,3 +143,10 @@ def init(pexpect_proc):
     ''' Runs psh and asserts its first prompt'''
     run(pexpect_proc)
     assert_only_prompt(pexpect_proc)
+
+
+def deinit(pexpect_proc):
+    ''' Close spawned psh '''
+
+    pexpect_proc.send(EOT)
+    pexpect_proc.expect(r'exit(\r+)\n')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

 - psh: apply deinit function in psh tests
 - psh: improve test-kill after last changes
 - psh: provide deinit function in psh test module
 - psh: switch to spawning new psh, when starting each psh test

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

 - There were some issues related to previous implementation (e.g. failing test-auth during ~1/n test runner campaigns).

 - This is necessary to allow running tests in a row without restart (incoming QuickRunners) and for running psh tests in other other shells, like busybox ash (zynq-qemu tests)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (testing on zynq-qemu target, which is not available on CI yet).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
