### PR TITLE
psh: test-touch fixes, enabling psh rootfs-tests on zynq7000-zedboard

### DIFF
--- a/psh/test-touch-rootfs.py
+++ b/psh/test-touch-rootfs.py
@@ -12,19 +12,19 @@
 # %LICENSE%
 
 import psh.tools.psh as psh
-from psh.tools.common import assert_timestamp_change
+from psh.tools.common import assert_mtime
 
 
 def assert_hardlinks(p):
-    uptimes = {}
+    dates = {}
     # all psh commands are hardlinks
-    psh_cmds = psh.get_commands(p)
-    for psh_cmd in psh_cmds:
-        uptimes[psh_cmd] = psh.uptime(p)
-        msg = f"Prompt hasn't been seen after the hardlink touch: /bin/{psh_cmd}"
-        psh.assert_cmd(p, f'touch /bin/{psh_cmd}', '', msg)
+    for hardlink in psh.get_commands(p):
+        hardlink_path = f'/bin/{hardlink}'
+        dates[hardlink] = psh.date(p)
+        msg = f"Prompt hasn't been seen after the hardlink touch: {hardlink_path}"
+        psh.assert_cmd(p, f'touch {hardlink_path}', msg=msg)
 
-    assert_timestamp_change(p, psh_cmds, uptimes, '/bin')
+    assert_mtime(p, dates, '/bin')
 
 
 @psh.run

--- a/psh/test-touch-rootfs.py
+++ b/psh/test-touch-rootfs.py
@@ -1,0 +1,32 @@
+# Phoenix-RTOS
+#
+# phoenix-rtos-tests
+#
+# psh touch command test for rootfs targets
+#
+# Copyright 2022 Phoenix Systems
+# Author: Damian Loewnau
+#
+# This file is part of Phoenix-RTOS.
+#
+# %LICENSE%
+
+import psh.tools.psh as psh
+from psh.tools.common import assert_timestamp_change
+
+
+def assert_hardlinks(p):
+    uptimes = {}
+    # all psh commands are hardlinks
+    psh_cmds = psh.get_commands(p)
+    for psh_cmd in psh_cmds:
+        uptimes[psh_cmd] = psh.uptime(p)
+        msg = f"Prompt hasn't been seen after the hardlink touch: /bin/{psh_cmd}"
+        psh.assert_cmd(p, f'touch /bin/{psh_cmd}', '', msg)
+
+    assert_timestamp_change(p, psh_cmds, uptimes, '/bin')
+
+
+@psh.run
+def harness(p):
+    assert_hardlinks(p)

--- a/psh/test-touch.py
+++ b/psh/test-touch.py
@@ -2,7 +2,7 @@
 #
 # phoenix-rtos-tests
 #
-# psh touch command text
+# psh touch command test
 #
 # Copyright 2022 Phoenix Systems
 # Author: Damian Loewnau
@@ -15,34 +15,16 @@
 import psh.tools.psh as psh
 import trunner.config as config
 from psh.tools.common import (CHARS, assert_present, assert_file_created, assert_dir_created,
-                              assert_random_files, get_rand_strings, create_testdir)
+                              assert_random_files, get_rand_strings, create_testdir, assert_timestamp_change)
 
 ROOT_TEST_DIR = 'test_touch_dir'
 
 
-def assert_timestamp_change(p, touched_files, uptimes, dir=''):
-    files = psh.ls(p, dir)
-    for file in files:
-        if file.name in touched_files:
-            uptime = uptimes[file.name]
-            # uptime has to be got before touch
-            # to prevent failed assertion when typing uptime in 00:59 and touch in 01:00
-            # 1 min margin is applied
-            next_minute = f'{(int(uptime.minute)+1):02d}'
-            if file.date.time == f'{uptime.hour}:{next_minute}':
-                uptime_str = f'{uptime.hour}:{next_minute}'
-            else:
-                uptime_str = f'{uptime.hour}:{uptime.minute}'
-            # when writing test, system date is always set to Jan 01 00:00
-            # so all touched files should have the following timestamp: Jan 01 00:00 + uptime
-            msg = f"The file's timestamp hasn't been changed after touch: {dir}/{file.name}, timestamp = {file.date}"
-            assert file.date == ('Jan', '1', uptime_str), msg
-
-
-def assert_symlinks(p):
+def assert_hardlinks(p):
     uptimes = {}
-    # all psh commands are symlinks
+    # all psh commands are hardlinks
     psh_cmds = psh.get_commands(p)
+    psh_cmds.remove('psh')
     for psh_cmd in psh_cmds:
         uptimes[psh_cmd] = psh.uptime(p)
         msg = f"Prompt hasn't been seen after the symlink touch: /bin/{psh_cmd}"
@@ -130,6 +112,6 @@ def harness(p):
     assert_created_dir(p)
     assert_existing_dirs(p)
 
-    assert_symlinks(p)
+    assert_hardlinks(p)
     assert_devices(p)
     assert_executable(p)

--- a/psh/test-touch.py
+++ b/psh/test-touch.py
@@ -20,19 +20,6 @@ from psh.tools.common import (CHARS, assert_present, assert_file_created, assert
 ROOT_TEST_DIR = 'test_touch_dir'
 
 
-def assert_hardlinks(p):
-    uptimes = {}
-    # all psh commands are hardlinks
-    psh_cmds = psh.get_commands(p)
-    psh_cmds.remove('psh')
-    for psh_cmd in psh_cmds:
-        uptimes[psh_cmd] = psh.uptime(p)
-        msg = f"Prompt hasn't been seen after the symlink touch: /bin/{psh_cmd}"
-        psh.assert_cmd(p, f'touch /bin/{psh_cmd}', '', msg)
-
-    assert_timestamp_change(p, psh_cmds, uptimes, '/bin')
-
-
 def assert_executable(p):
     # psh is the example of executable which exists in file system
     msg = "Prompt hasn't been seen after the executable touch: /usr/bin/hello"
@@ -112,6 +99,5 @@ def harness(p):
     assert_created_dir(p)
     assert_existing_dirs(p)
 
-    assert_hardlinks(p)
     assert_devices(p)
     assert_executable(p)

--- a/psh/test-touch.py
+++ b/psh/test-touch.py
@@ -15,7 +15,7 @@
 import psh.tools.psh as psh
 import trunner.config as config
 from psh.tools.common import (CHARS, assert_present, assert_file_created, assert_dir_created,
-                              assert_random_files, get_rand_strings, create_testdir, assert_timestamp_change)
+                              assert_random_files, get_rand_strings, create_testdir, assert_mtime)
 
 ROOT_TEST_DIR = 'test_touch_dir'
 
@@ -23,24 +23,24 @@ ROOT_TEST_DIR = 'test_touch_dir'
 def assert_executable(p):
     # psh is the example of executable which exists in file system
     msg = "Prompt hasn't been seen after the executable touch: /usr/bin/hello"
-    uptime = psh.uptime(p)
+    date = psh.date(p)
     if config.CURRENT_TARGET in config.SYSEXEC_TARGETS:
-        psh.assert_cmd(p, 'touch /syspage/psh', '', msg)
-        assert_timestamp_change(p, ['psh'], {'psh': uptime}, '/syspage')
+        psh.assert_cmd(p, 'touch /syspage/psh', msg=msg)
+        assert_mtime(p, {'psh': date}, '/syspage')
     else:
-        psh.assert_cmd(p, 'touch /bin/psh', '', msg)
-        assert_timestamp_change(p, ['psh'], {'psh': uptime}, '/bin')
+        psh.assert_cmd(p, 'touch /bin/psh', msg=msg)
+        assert_mtime(p, {'psh': date}, '/bin')
 
 
 def assert_devices(p):
-    uptimes = {}
+    dates = {}
     devices = psh.ls_simple(p, '/dev')
     for dev in devices:
-        uptimes[dev] = psh.uptime(p)
+        dates[dev] = psh.date(p)
         msg = f"Prompt hasn't been seen after the device touch: /dev/{dev}"
-        psh.assert_cmd(p, f'touch /dev/{dev}', '', msg)
+        psh.assert_cmd(p, f'touch /dev/{dev}', msg=msg)
 
-    assert_timestamp_change(p, devices, uptimes, dir='/dev')
+    assert_mtime(p, dates, dir='/dev')
 
 
 def assert_multi_arg(p, path):
@@ -72,13 +72,13 @@ def assert_created_dir(p):
 def assert_existing_dirs(p):
     # we assume that syspage directory exists on syspage targets and bin directory exists on root-fs targets
     msg = "Prompt hasn't been seen after the executable touch: /usr/bin/hello"
-    uptime = psh.uptime(p)
+    date = psh.date(p)
     if config.CURRENT_TARGET in config.SYSEXEC_TARGETS:
-        psh.assert_cmd(p, 'touch /syspage/', '', msg)
-        assert_timestamp_change(p, ['syspage'], {'syspage': uptime}, '/')
+        psh.assert_cmd(p, 'touch /syspage/', msg=msg)
+        assert_mtime(p, {'syspage': date}, '/')
     else:
-        psh.assert_cmd(p, 'touch /bin/', '', msg)
-        assert_timestamp_change(p, ['bin'], {'bin': uptime}, '/')
+        psh.assert_cmd(p, 'touch /bin/', msg=msg)
+        assert_mtime(p, {'bin': date}, '/')
 
 
 @psh.run

--- a/psh/test.yaml
+++ b/psh/test.yaml
@@ -45,14 +45,18 @@ test:
         - name: touch
           harness: test-touch.py
 
+        - name: touch-rootfs
+          harness: test-touch-rootfs.py
+          targets:
+              exclude: [armv7m7-imxrt106x-evk, armv7m7-imxrt117x-evk]
+
         - name: ls
           harness: test-ls.py
 
         - name: ls-rootfs
           harness: test-ls-rootfs.py
           targets:
-              value:
-                  - ia32-generic-qemu
+              exclude: [armv7m7-imxrt106x-evk, armv7m7-imxrt117x-evk]
 
         - name: history
           harness: test-history.py

--- a/psh/test.yaml
+++ b/psh/test.yaml
@@ -14,8 +14,7 @@ test:
         - name: pshlogin
           harness: test-pshlogin.py
           targets:
-              value:
-                  - ia32-generic-qemu
+              exclude: [armv7m7-imxrt106x-evk, armv7m7-imxrt117x-evk]
 
         - name: echo
           harness: test-echo.py
@@ -35,8 +34,7 @@ test:
         - name: cat-shells
           harness: test-cat-shells.py
           targets:
-              value:
-                  - ia32-generic-qemu
+              exclude: [armv7m7-imxrt106x-evk, armv7m7-imxrt117x-evk]
 
         - name: kill
           harness: test-kill.py

--- a/psh/tools/README.md
+++ b/psh/tools/README.md
@@ -28,6 +28,8 @@ The python module `psh` makes writing harness tests easier. It provides the foll
 
 The `pexpect_proc` argument is the [pexpect](https://pexpect.readthedocs.io/en/stable/api/index.html) process returned by `pexpect.spawn()` method. Each functional test has the spawned process passed in the argument, which is `p`, please see examples below.
 
+There are also other utilities helpful when writing psh tests, for example `ls` or `date`. Please go to `psh.py` and check them, descriptions are provided in function's doctrings.
+
 ## The usage examples
 
 * The error statement assertion

--- a/psh/tools/psh.py
+++ b/psh/tools/psh.py
@@ -19,6 +19,7 @@ import pexpect
 import trunner.config as config
 
 from collections import namedtuple
+from datetime import datetime
 
 EOL = r'(\r+)\n'
 EOT = '\x04'
@@ -180,6 +181,22 @@ def uptime(pexpect_proc):
     time = Time(hour, minute, second)
 
     return time
+
+
+def date(pexpect_proc):
+    ''' Returns the system date in a datetime object '''
+    pexpect_proc.sendline('date +%Y:%m:%d:%H:%M:%S')
+    pexpect_proc.expect_exact('date +%Y:%m:%d:%H:%M:%S')
+    pexpect_proc.expect(rf'(?P<year>\d+):(?P<month>\d+):(?P<day>\d+):(?P<hour>\d+):(?P<min>\d+):(?P<sec>\d+){EOL}')
+
+    m = pexpect_proc.match
+    return datetime(
+        int(m.group('year')),
+        int(m.group('month')),
+        int(m.group('day')),
+        int(m.group('hour')),
+        int(m.group('min')),
+        int(m.group('sec')))
 
 
 def ls_simple(pexpect_proc, dir=''):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

 - psh: touch: move rootfs cases to separate test
 - psh: enable psh rootfs tests on zynq7000 target
 - psh: fix naming in test-touch

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

 - The case with hardlinks was named improperly (they were called symlinks)
 - The hardlinks testcase was executed on non-rootfs targets
 - Because of using `value` instead of `exclude` rootfs targets were not executed on `zynq7000-zedboard` target

## Types of changes 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
