### PR TITLE
test-libc: correct stdio_file.c to run on host

### DIFF
--- a/libc/main.c
+++ b/libc/main.c
@@ -5,19 +5,22 @@
  *
  * Main entry point.
  *
- * Copyright 2021 Phoenix Systems
- * Author: Marek Bialowas
+ * Copyright 2021, 2022 Phoenix Systems
+ * Author: Marek Bialowas, Damian Loewnau
  *
  * This file is part of Phoenix-RTOS.
  *
  * %LICENSE%
  */
 
+#include <stdlib.h>
 #include "unity_fixture.h"
 
 /* no need for forward declarations, RUN_TEST_GROUP does it by itself */
 void runner(void)
 {
+	setenv("POSIXLY_CORRECT", "y", 1);
+
 	RUN_TEST_GROUP(stdio_fopenfclose);
 	RUN_TEST_GROUP(stdio_line);
 	RUN_TEST_GROUP(stdio_getput);
@@ -35,6 +38,8 @@ void runner(void)
 	RUN_TEST_GROUP(unistd_fsdir);
 	RUN_TEST_GROUP(wchar_wcscmp);
 	RUN_TEST_GROUP(test_pthread_cond);
+
+	unsetenv("POSIXLY_CORRECT");
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Make test-libc host/POSIX compliant.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic-qemu).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (https://github.com/phoenix-rtos/libphoenix/pull/190, https://github.com/phoenix-rtos/libphoenix/pull/222).
- [ ] I will merge this PR by myself when appropriate.
