### PR TITLE
libc: make getpw.c host compatible

### DIFF
--- a/libc/getpw.c
+++ b/libc/getpw.c
@@ -22,6 +22,15 @@
 #include <unity_fixture.h>
 
 
+/* "/" is a root dir and the supported shell is sh on Phoenix-RTOS */
+#ifdef __phoenix__
+#define ROOT_WORKDIR "/"
+#define ROOT_SHELL   "/bin/sh"
+#else
+#define ROOT_WORKDIR "/root"
+#define ROOT_SHELL   "/bin/bash"
+#endif
+
 static unsigned int ispasswdfile;
 
 
@@ -52,8 +61,8 @@ TEST(getpwd, getpwnam_getroot)
 		TEST_ASSERT_EQUAL_INT(0, pw->pw_uid);
 		TEST_ASSERT_EQUAL_INT(0, pw->pw_gid);
 		TEST_ASSERT_EQUAL_STRING("root", pw->pw_gecos);
-		TEST_ASSERT_EQUAL_STRING("/", pw->pw_dir);
-		TEST_ASSERT_EQUAL_STRING("/bin/sh", pw->pw_shell);
+		TEST_ASSERT_EQUAL_STRING(ROOT_WORKDIR, pw->pw_dir);
+		TEST_ASSERT_EQUAL_STRING(ROOT_SHELL, pw->pw_shell);
 	}
 	else {
 		TEST_ASSERT_NULL(pw);
@@ -76,8 +85,8 @@ TEST(getpwd, getpwuid_getroot)
 		TEST_ASSERT_EQUAL_INT(0, pw->pw_uid);
 		TEST_ASSERT_EQUAL_INT(0, pw->pw_gid);
 		TEST_ASSERT_EQUAL_STRING("root", pw->pw_gecos);
-		TEST_ASSERT_EQUAL_STRING("/", pw->pw_dir);
-		TEST_ASSERT_EQUAL_STRING("/bin/sh", pw->pw_shell);
+		TEST_ASSERT_EQUAL_STRING(ROOT_WORKDIR, pw->pw_dir);
+		TEST_ASSERT_EQUAL_STRING(ROOT_SHELL, pw->pw_shell);
 	}
 	else {
 		TEST_ASSERT_NULL(pw);
@@ -147,5 +156,9 @@ TEST_GROUP_RUNNER(getpwd)
 	RUN_TEST_CASE(getpwd, getpwuid_getroot);
 	RUN_TEST_CASE(getpwd, getpwnam_getnull);
 	RUN_TEST_CASE(getpwd, getpwuid_getnull);
+	/* we can't rename/delete the /etc/passwd file on host */
+#ifdef __phoenix__
 	RUN_TEST_CASE(getpwd, getpwnam_nopasswdfile);
+	RUN_TEST_CASE(getpwd, getpwuid_nopasswdfile);
+#endif
 }

--- a/libc/unistd_uids.c
+++ b/libc/unistd_uids.c
@@ -21,15 +21,11 @@
 #include <unity_fixture.h>
 
 
-pid_t child[6], parent[3], pid;
-
-
 TEST_GROUP(unistd_uids);
 
 
 TEST_SETUP(unistd_uids)
 {
-	pid = parent[0] = parent[1] = parent[2] = -1;
 }
 
 
@@ -46,6 +42,8 @@ TEST_TEAR_DOWN(unistd_uids)
 */
 TEST(unistd_uids, getuids_parent)
 {
+	pid_t pid = -1;
+
 	TEST_ASSERT_GREATER_THAN_INT(0, getpid());
 	TEST_ASSERT_GREATER_THAN_INT(0, getppid());
 
@@ -78,7 +76,11 @@ TEST(unistd_uids, setuids_parent)
 
 TEST(unistd_uids, setpuids_setsid)
 {
-	int err, siderr = -1;
+	volatile pid_t child[6], parent[3], pid;
+	int err = -1;
+	volatile int sidret = -1;
+
+	pid = parent[0] = parent[1] = parent[2] = -1;
 
 	parent[0] = getpid();
 	parent[1] = getpgrp();
@@ -90,34 +92,34 @@ TEST(unistd_uids, setpuids_setsid)
 		child[1] = getpgrp();
 		child[2] = getsid(getpid());
 
-		siderr = setsid();
+		sidret = setsid();
 
 		child[3] = getpid();
 		child[4] = getpgrp();
 		child[5] = getsid(getpid());
 
-		_exit(siderr != 0);
+		_exit(0);
 	}
 	else {
 		waitpid(pid, &err, 0);
 	}
 
-	/* assert exit status from child is zero */
-	TEST_ASSERT_EQUAL_INT(0, WEXITSTATUS(err));
+	/* sid return value == sid */
+	TEST_ASSERT_EQUAL_INT(sidret, child[5]);
 
 	/* assert correctness of parent pid, group and session */
 	TEST_ASSERT_GREATER_THAN_INT(0, parent[0]);  /* nonzero pid */
 	TEST_ASSERT_GREATER_THAN_INT(0, parent[1]);  /* nonzero pgid */
 	TEST_ASSERT_GREATER_THAN_INT(0, parent[2]);  /* nonzero sid */
 	TEST_ASSERT_EQUAL_INT(parent[0], parent[1]); /* pid == pgid */
-	TEST_ASSERT_EQUAL_INT(parent[1], parent[2]); /* pgid == sid */
+	/* we don't check parent pgid against sid as we don't know who was parents session leader */
 
 	/* assert correctness of child pid/group/session before setsid */
 	TEST_ASSERT_NOT_EQUAL_INT(parent[0], child[0]); /* parent-child have different pid */
 	TEST_ASSERT_EQUAL_INT(parent[1], child[1]);     /* equal pgrp */
 	TEST_ASSERT_EQUAL_INT(parent[2], child[2]);     /* equal sid */
 
-	/* after sid the pid, group id and session id of child should be equal */
+	/* after setsid the pid, group id and session id of child should be equal */
 	TEST_ASSERT_NOT_EQUAL_INT(parent[0], child[3]); /* parent-child have different pid */
 	TEST_ASSERT_EQUAL_INT(child[3], child[4]);      /* pid == pgrp */
 	TEST_ASSERT_EQUAL_INT(child[4], child[5]);      /* pgrp == sid */
@@ -131,8 +133,11 @@ TEST(unistd_uids, setpuids_setpgid)
 		https://github.com/phoenix-rtos/phoenix-rtos-project/issues/282
 	*/
 	TEST_IGNORE();
+	volatile pid_t child[6], parent[3], pid;
+	int err = -1;
+	volatile int pgrperr = -1;
 
-	int err, pgrperr = -1;
+	pid = parent[0] = parent[1] = parent[2] = -1;
 
 	parent[0] = getpid();
 	parent[1] = getpgrp();
@@ -150,14 +155,14 @@ TEST(unistd_uids, setpuids_setpgid)
 		child[4] = getpgrp();
 		child[5] = getsid(getpid());
 
-		_exit(pgrperr != 0);
+		_exit(0);
 	}
 	else {
 		waitpid(pid, &err, 0);
 	}
 
-	/* assert exit status from child is zero */
-	TEST_ASSERT_EQUAL_INT(0, WEXITSTATUS(err));
+	/* assert setpgid succeeded */
+	TEST_ASSERT_EQUAL_INT(0, pgrperr);
 
 	/* assert correctness of parent pid, group and session */
 	TEST_ASSERT_GREATER_THAN_INT(0, parent[0]);  /* nonzero pid */
@@ -166,12 +171,12 @@ TEST(unistd_uids, setpuids_setpgid)
 	TEST_ASSERT_EQUAL_INT(parent[0], parent[1]); /* pid == pgid */
 	TEST_ASSERT_EQUAL_INT(parent[1], parent[2]); /* pgid == sid */
 
-	/* assert correctness of child pid/group/session before setsid */
+	/* assert correctness of child pid/group/session before setpgid */
 	TEST_ASSERT_NOT_EQUAL_INT(parent[0], child[0]); /* parent-child have different pid */
 	TEST_ASSERT_EQUAL_INT(parent[1], child[1]);     /* equal pgrp */
 	TEST_ASSERT_EQUAL_INT(parent[2], child[2]);     /* equal sid */
 
-	/* after sid the pid, group id and session id of child should be equal */
+	/* after setpgid the pid, group id and session id of child should be equal */
 	TEST_ASSERT_NOT_EQUAL_INT(parent[0], child[3]); /* parent-child have different pid */
 	TEST_ASSERT_NOT_EQUAL_INT(parent[2], child[5]); /* parent-child have different sid */
 	TEST_ASSERT_EQUAL_INT(child[3], child[4]);      /* pid == pgrp */


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

 - libc: make getpw.c host compatible
 - libc: make unistd_uids.c host/POSIX compatible 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

 - JIRA: PD-321
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic-qemu phoenix, host).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/353).
- [ ] I will merge this PR by myself when appropriate.
