### PR TITLE
Fix meterfs tests on imx6ull

### DIFF
--- a/meterfs/common.c
+++ b/meterfs/common.c
@@ -13,7 +13,7 @@
 #include "common.h"
 
 static struct {
-	char buff[40];
+	char buff[128];
 } common;
 
 int common_preallocOpenFile(const char *name, size_t sectors, size_t filesz, size_t recordsz)

--- a/meterfs/file.h
+++ b/meterfs/file.h
@@ -14,6 +14,14 @@
 
 #include <sys/types.h>
 
+typedef struct {
+	size_t sz;
+	size_t sectorsz;
+	size_t fileLimit;
+	size_t filecnt;
+} file_fsInfo_t;
+
+
 int file_lookup(const char *name);
 
 
@@ -39,6 +47,9 @@ int file_getInfo(id_t fid, size_t *sectors, size_t *filesz, size_t *recordsz, si
 
 
 int file_eraseAll(void);
+
+
+int file_devInfo(file_fsInfo_t *fsInfo);
 
 
 int file_init(const char *path);

--- a/meterfs/file.h
+++ b/meterfs/file.h
@@ -3,8 +3,8 @@
  *
  * File abstraction
  *
- * Copyright 2021 Phoenix Systems
- * Author: Tomasz Korniluk
+ * Copyright 2021, 2023 Phoenix Systems
+ * Author: Tomasz Korniluk, Hubert Badocha
  *
  * %LICENSE%
  */
@@ -41,6 +41,6 @@ int file_getInfo(id_t fid, size_t *sectors, size_t *filesz, size_t *recordsz, si
 int file_eraseAll(void);
 
 
-void file_init(const char *path);
+int file_init(const char *path);
 
 #endif

--- a/meterfs/file_pc.c
+++ b/meterfs/file_pc.c
@@ -135,11 +135,15 @@ int file_eraseAll(void)
 }
 
 
-void file_init(const char *path)
+int file_init(const char *path)
 {
 	size_t filesz = FLASHSIZE;
 	size_t sectorsz = SECTORSIZE;
+	int err;
 
-	if (hostflashsrv_init(&filesz, &sectorsz, path) < 0)
+	err = hostflashsrv_init(&filesz, &sectorsz, path);
+	if (err < 0) {
 		printf("hostflashsrv: init failed\n");
+	}
+	return err;
 }

--- a/meterfs/file_pc.c
+++ b/meterfs/file_pc.c
@@ -147,6 +147,28 @@ int file_eraseAll(void)
 }
 
 
+int file_devInfo(file_fsInfo_t *fsInfo)
+{
+	meterfs_i_devctl_t iptr;
+	meterfs_o_devctl_t optr;
+	int err;
+
+	iptr.type = meterfs_fsInfo;
+
+	err = hostflashsrv_devctl(&iptr, &optr);
+	if (err < 0) {
+		return err;
+	}
+
+	fsInfo->filecnt = optr.fsInfo.filecnt;
+	fsInfo->fileLimit = optr.fsInfo.fileLimit;
+	fsInfo->sz = optr.fsInfo.sz;
+	fsInfo->sectorsz = optr.fsInfo.sectorsz;
+
+	return 0;
+}
+
+
 int file_init(const char *path)
 {
 	size_t filesz = FLASHSIZE;

--- a/meterfs/file_pc.c
+++ b/meterfs/file_pc.c
@@ -16,7 +16,7 @@
 
 #include "file.h"
 
-#define FLASHSIZE (4 * 1024 * 1024)
+#define FLASHSIZE  (4 * 1024 * 1024)
 #define SECTORSIZE (4 * 1024)
 
 int file_lookup(const char *name)
@@ -32,16 +32,21 @@ int file_open(const char *name)
 	int err;
 	id_t id;
 
-	if ((err = hostflashsrv_lookup(name, &id)) < 0)
+	err = hostflashsrv_lookup(name, &id);
+	if (err < 0) {
 		return err;
+	}
 
-	if (id > INT_MAX)
+	if (id > INT_MAX) {
 		return -1;
+	}
 
-	if ((err = hostflashsrv_open(&id)) < 0)
+	err = hostflashsrv_open(&id);
+	if (err < 0) {
 		return err;
+	}
 
-	return (int)id; 
+	return (int)id;
 }
 
 
@@ -67,13 +72,14 @@ int file_allocate(const char *name, size_t sectors, size_t filesz, size_t record
 {
 	meterfs_i_devctl_t iptr;
 	meterfs_o_devctl_t optr;
-	int len = 0;
+	size_t len = 0;
 
 	iptr.type = meterfs_allocate;
 	len = strnlen(name, sizeof(iptr.allocate.name));
-	memcpy(iptr.allocate.name, name, len);
-	if (len < sizeof(iptr.allocate.name))
+	(void)memcpy(iptr.allocate.name, name, len);
+	if (len < sizeof(iptr.allocate.name)) {
 		iptr.allocate.name[len] = '\0';
+	}
 	iptr.allocate.sectors = sectors;
 	iptr.allocate.filesz = filesz;
 	iptr.allocate.recordsz = recordsz;
@@ -105,20 +111,26 @@ int file_getInfo(id_t fid, size_t *sectors, size_t *filesz, size_t *recordsz, si
 	iptr.type = meterfs_info;
 	iptr.id = fid;
 
-	if ((err = hostflashsrv_devctl(&iptr, &optr)) < 0)
+	err = hostflashsrv_devctl(&iptr, &optr);
+	if (err < 0) {
 		return err;
+	}
 
-	if (sectors != NULL)
+	if (sectors != NULL) {
 		(*sectors) = optr.info.sectors;
+	}
 
-	if (filesz != NULL)
+	if (filesz != NULL) {
 		(*filesz) = optr.info.filesz;
+	}
 
-	if (recordsz != NULL)
+	if (recordsz != NULL) {
 		(*recordsz) = optr.info.recordsz;
+	}
 
-	if (recordcnt != NULL)
+	if (recordcnt != NULL) {
 		(*recordcnt) = optr.info.recordcnt;
+	}
 
 	return 0;
 }
@@ -143,7 +155,7 @@ int file_init(const char *path)
 
 	err = hostflashsrv_init(&filesz, &sectorsz, path);
 	if (err < 0) {
-		printf("hostflashsrv: init failed\n");
+		(void)printf("hostflashsrv: init failed\n");
 	}
 	return err;
 }

--- a/meterfs/file_phx.c
+++ b/meterfs/file_phx.c
@@ -233,6 +233,27 @@ int file_eraseAll(void)
 }
 
 
+int file_devInfo(file_fsInfo_t *fsInfo)
+{
+	msg_t msg;
+	meterfs_i_devctl_t *iptr = (meterfs_i_devctl_t *)msg.i.raw;
+	meterfs_o_devctl_t *optr = (meterfs_o_devctl_t *)msg.o.raw;
+
+	file_prepareDevCtl(&msg);
+
+	iptr->type = meterfs_fsInfo;
+
+	TEST_ASSERT_EQUAL(0, msgSend(meterfs.port, &msg));
+
+	fsInfo->filecnt = optr->fsInfo.filecnt;
+	fsInfo->fileLimit = optr->fsInfo.fileLimit;
+	fsInfo->sz = optr->fsInfo.sz;
+	fsInfo->sectorsz = optr->fsInfo.sectorsz;
+
+	return optr->err;
+}
+
+
 int file_init(const char *path)
 {
 	pathPrefix = path;

--- a/meterfs/file_phx.c
+++ b/meterfs/file_phx.c
@@ -3,8 +3,8 @@
  *
  * Meterfs test file abstraction
  *
- * Copyright 2021 Phoenix Systems
- * Author: Aleksander Kaminski, Andrzej Glowinski, Tomasz Korniluk
+ * Copyright 2021, 2023 Phoenix Systems
+ * Author: Aleksander Kaminski, Andrzej Glowinski, Tomasz Korniluk, Hubert Badocha
  *
  * %LICENSE%
  */
@@ -19,8 +19,9 @@
 #include "unity_fixture.h"
 
 static oid_t meterfs;
+static const char *pathPrefix;
 
-static inline void file_prepareDevCtl(msg_t* msg)
+static inline void file_prepareDevCtl(msg_t *msg)
 {
 	msg->type = mtDevCtl;
 	msg->i.data = NULL;
@@ -30,11 +31,19 @@ static inline void file_prepareDevCtl(msg_t* msg)
 }
 
 
+static int lookup_rel(const char *name, oid_t *file, oid_t *dev)
+{
+	char buffer[64];
+	(void)snprintf(buffer, sizeof(buffer), "%s/%s", pathPrefix, name);
+	return lookup(buffer, file, dev);
+}
+
+
 int file_lookup(const char *name)
 {
 	oid_t oid;
 
-	return lookup(name, &oid, NULL);
+	return lookup_rel(name, &oid, NULL);
 }
 
 
@@ -44,7 +53,7 @@ int file_open(const char *name)
 	int err;
 	id_t id;
 
-	if ((err = lookup(name, &msg.i.openclose.oid, NULL)) < 0)
+	if ((err = lookup_rel(name, &msg.i.openclose.oid, NULL)) < 0)
 		return err;
 
 	id = msg.i.openclose.oid.id;
@@ -213,10 +222,8 @@ int file_eraseAll(void)
 }
 
 
-void file_init(const char *path)
+int file_init(const char *path)
 {
-	int err;
-
-	if ((err = lookup(path, NULL, &meterfs)) < 0)
-		return err;
+	pathPrefix = path;
+	return lookup(path, NULL, &meterfs);
 }

--- a/meterfs/test_meterfs_allocate.c
+++ b/meterfs/test_meterfs_allocate.c
@@ -3,14 +3,15 @@
  *
  * Meterfs allocating tests group
  *
- * Copyright 2021 Phoenix Systems
- * Author: Tomasz Korniluk
+ * Copyright 2021, 2023 Phoenix Systems
+ * Author: Tomasz Korniluk, Hubert Badocha
  *
  *
  * %LICENSE%
  */
 
 #include "common.h"
+
 
 TEST_GROUP(meterfs_allocate);
 
@@ -110,8 +111,18 @@ void runner(void)
 
 int main(int argc, char *argv[])
 {
-	file_init(argv[1]);
-	TEST_ASSERT_EQUAL(0, file_eraseAll());
+	if (argc != 2) {
+		(void)printf("Usage: %s /meterfs/mount/path\n", argv[0]);
+		return 1;
+	}
+	if (file_init(argv[1]) != 0) {
+		(void)printf("Failed to initialize test\n");
+		return 1;
+	}
+	if (file_eraseAll() != 0) {
+		(void)printf("Failed to format meterfs partition\n");
+		return 1;
+	}
 
 	UnityMain(argc, (const char**)argv, runner);
 

--- a/meterfs/test_meterfs_allocate.c
+++ b/meterfs/test_meterfs_allocate.c
@@ -27,7 +27,7 @@ TEST_TEAR_DOWN(meterfs_allocate)
 }
 
 
-/* 
+/*
  * Test case of allocating file bigger than flash size.
  * NOTE: Not valid for hw target. Now there is no way to obtain/parametrize flash size in test.
  */
@@ -35,7 +35,7 @@ TEST(meterfs_allocate, big_file)
 {
 	uint32_t flashsz = 4 * 1024 * 1024;
 	uint32_t sectorsz = 4096;
-	file_info_t info = { ((flashsz + sectorsz) / sectorsz) + 1, flashsz + sectorsz, 20, 0 };
+	file_info_t info = { ((flashsz + sectorsz) / sectorsz) + 1u, flashsz + sectorsz, 20, 0 };
 
 	TEST_ASSERT_EQUAL(-EINVAL, file_allocate("file0", info.sectors, info.filesz, info.recordsz));
 }
@@ -48,12 +48,14 @@ TEST(meterfs_allocate, many_files)
 	char fileName[9];
 
 	for (i = 0; i < (255 + 10); ++i) {
-		snprintf(fileName, sizeof(fileName), "file%d", i);
-		if (i < 255)
+		(void)snprintf(fileName, sizeof(fileName), "file%d", i);
+		if (i < 255) {
 			TEST_ASSERT_EQUAL_MESSAGE(0, file_allocate(fileName, 2, 2000, 20), fileName);
-		else
+		}
+		else {
 			TEST_ASSERT_EQUAL_MESSAGE(-ENOMEM, file_allocate(fileName, 2, 2000, 20), fileName);
-		memset(fileName, 0, sizeof(fileName));
+		}
+		(void)memset(fileName, 0, sizeof(fileName));
 	}
 }
 
@@ -84,7 +86,7 @@ TEST(meterfs_allocate, var_init_args)
 	TEST_ASSERT_EQUAL(-EINVAL, file_allocate("file4", 3, 2000000, 20));
 	TEST_ASSERT_EQUAL(-EINVAL, file_allocate("file5", 7, 2000, 0));
 
-	TEST_ASSERT_EQUAL(0, file_allocate("file6", 4, 20, 20));	
+	TEST_ASSERT_EQUAL(0, file_allocate("file6", 4, 20, 20));
 	TEST_ASSERT_EQUAL(0, file_allocate("file7", 6, 2000, 20));
 	TEST_ASSERT_EQUAL(0, file_allocate("file8", 8, 10, 5));
 	TEST_ASSERT_EQUAL(0, file_allocate("file9", 12, 10, 5));
@@ -124,7 +126,7 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
-	UnityMain(argc, (const char**)argv, runner);
+	UnityMain(argc, (const char **)argv, runner);
 
 	return 0;
 }

--- a/meterfs/test_meterfs_miscellaneous.c
+++ b/meterfs/test_meterfs_miscellaneous.c
@@ -14,17 +14,17 @@
 
 static struct {
 	int fd;
-	char buffRec[40];
-	char buffMsg[12];
+	char buffRec[64];
+	char buffMsg[32];
 } common;
 
 
 static void writeReadCheck(file_info_t *info)
 {
-	unsigned int i;
+	size_t i;
 
 	for (i = 0; i < (info->filesz / info->recordsz); ++i) {
-		(void)snprintf(common.buffMsg, sizeof(common.buffMsg), "a%04u", i);
+		(void)snprintf(common.buffMsg, sizeof(common.buffMsg), "a%04zu", i);
 		TEST_ASSERT_EQUAL_MESSAGE(info->recordsz, file_write(common.fd, common.buffMsg, strlen(common.buffMsg)), common.buffMsg);
 		common_readContent(common.fd, i * info->recordsz, common.buffRec, info->recordsz, common.buffMsg, strlen(common.buffMsg), common.buffMsg);
 

--- a/meterfs/test_meterfs_openclose.c
+++ b/meterfs/test_meterfs_openclose.c
@@ -17,12 +17,17 @@ static struct {
 	char buff[21];
 } common;
 
+
+static file_fsInfo_t fsInfo;
+
+
 TEST_GROUP(meterfs_openclose);
 
 
 TEST_SETUP(meterfs_openclose)
 {
 	(void)memset(common.buff, 0, sizeof(common.buff));
+	TEST_ASSERT_EQUAL(0, file_devInfo(&fsInfo));
 }
 
 
@@ -49,22 +54,25 @@ TEST(meterfs_openclose, no_files)
 /* Test case of opening and closing existing files. */
 TEST(meterfs_openclose, existing_files)
 {
-	size_t i;
+	size_t i, fileCount = sizeof(common.fds) / sizeof(common.fds[0]);
+	if (fileCount > fsInfo.fileLimit) {
+		fileCount = fsInfo.fileLimit;
+	}
 
-	for (i = 0; i < sizeof(common.fds) / sizeof(common.fds[0]); ++i) {
+	for (i = 0; i < fileCount; ++i) {
 		(void)snprintf(common.buff, sizeof(common.buff), "file%zu", i);
 		TEST_ASSERT_EQUAL_MESSAGE(0, file_allocate(common.buff, 2, 2000, 20), common.buff);
 		(void)memset(common.buff, 0, sizeof(common.buff));
 	}
 
-	for (i = 0; i < sizeof(common.fds) / sizeof(common.fds[0]); ++i) {
+	for (i = 0; i < fileCount; ++i) {
 		(void)snprintf(common.buff, sizeof(common.buff), "/file%zu", i);
 		common.fds[i] = file_open(common.buff);
 		TEST_ASSERT_GREATER_OR_EQUAL_MESSAGE(0, common.fds[i], common.buff);
 		(void)memset(common.buff, 0, sizeof(common.buff));
 	}
 
-	for (i = 0; i < sizeof(common.fds) / sizeof(common.fds[0]); ++i) {
+	for (i = 0; i < fileCount; ++i) {
 		(void)snprintf(common.buff, sizeof(common.buff), "file%zu", i);
 		TEST_ASSERT_EQUAL_MESSAGE(0, file_close(common.fds[i]), common.buff);
 		(void)memset(common.buff, 0, sizeof(common.buff));

--- a/meterfs/test_meterfs_openclose.c
+++ b/meterfs/test_meterfs_openclose.c
@@ -3,8 +3,8 @@
  *
  * Meterfs opening and closing tests group
  *
- * Copyright 2021 Phoenix Systems
- * Author: Tomasz Korniluk
+ * Copyright 2021, 2023 Phoenix Systems
+ * Author: Tomasz Korniluk, Hubert Badocha
  *
  *
  * %LICENSE%
@@ -87,10 +87,20 @@ void runner(void)
 
 int main(int argc, char *argv[])
 {
-	file_init(argv[1]);
-	TEST_ASSERT_EQUAL(0, file_eraseAll());
+	if (argc != 2) {
+		(void)printf("Usage: %s /meterfs/mount/path\n", argv[0]);
+		return 1;
+	}
+	if (file_init(argv[1]) != 0) {
+		(void)printf("Failed to initialize test\n");
+		return 1;
+	}
+	if (file_eraseAll() != 0) {
+		(void)printf("Failed to format meterfs partition\n");
+		return 1;
+	}
 
-	UnityMain(argc, (const char**)argv, runner);
+	UnityMain(argc, (const char **)argv, runner);
 
 	return 0;
 }

--- a/meterfs/test_meterfs_openclose.c
+++ b/meterfs/test_meterfs_openclose.c
@@ -22,7 +22,7 @@ TEST_GROUP(meterfs_openclose);
 
 TEST_SETUP(meterfs_openclose)
 {
-	memset(common.buff, 0, sizeof(common.buff));
+	(void)memset(common.buff, 0, sizeof(common.buff));
 }
 
 
@@ -35,13 +35,13 @@ TEST_TEAR_DOWN(meterfs_openclose)
 /* Test case of opening and closing non existing files. */
 TEST(meterfs_openclose, no_files)
 {
-	int i;
+	size_t i;
 
 	for (i = 0; i < sizeof(common.fds) / sizeof(common.fds[0]); ++i) {
-		snprintf(common.buff, sizeof(common.buff), "/file%d", i);
+		(void)snprintf(common.buff, sizeof(common.buff), "/file%zu", i);
 		TEST_ASSERT_EQUAL_MESSAGE(-ENOENT, file_open(common.buff), common.buff);
 		TEST_ASSERT_EQUAL_MESSAGE(-ENOENT, file_close(i), common.buff);
-		memset(common.buff, 0, sizeof(common.buff));
+		(void)memset(common.buff, 0, sizeof(common.buff));
 	}
 }
 
@@ -49,25 +49,25 @@ TEST(meterfs_openclose, no_files)
 /* Test case of opening and closing existing files. */
 TEST(meterfs_openclose, existing_files)
 {
-	int i;
+	size_t i;
 
 	for (i = 0; i < sizeof(common.fds) / sizeof(common.fds[0]); ++i) {
-		snprintf(common.buff, sizeof(common.buff), "file%d", i);
+		(void)snprintf(common.buff, sizeof(common.buff), "file%zu", i);
 		TEST_ASSERT_EQUAL_MESSAGE(0, file_allocate(common.buff, 2, 2000, 20), common.buff);
-		memset(common.buff, 0, sizeof(common.buff));
+		(void)memset(common.buff, 0, sizeof(common.buff));
 	}
 
 	for (i = 0; i < sizeof(common.fds) / sizeof(common.fds[0]); ++i) {
-		snprintf(common.buff, sizeof(common.buff), "/file%d", i);
+		(void)snprintf(common.buff, sizeof(common.buff), "/file%zu", i);
 		common.fds[i] = file_open(common.buff);
 		TEST_ASSERT_GREATER_OR_EQUAL_MESSAGE(0, common.fds[i], common.buff);
-		memset(common.buff, 0, sizeof(common.buff));
+		(void)memset(common.buff, 0, sizeof(common.buff));
 	}
 
 	for (i = 0; i < sizeof(common.fds) / sizeof(common.fds[0]); ++i) {
-		snprintf(common.buff, sizeof(common.buff), "file%d", i);
+		(void)snprintf(common.buff, sizeof(common.buff), "file%zu", i);
 		TEST_ASSERT_EQUAL_MESSAGE(0, file_close(common.fds[i]), common.buff);
-		memset(common.buff, 0, sizeof(common.buff));
+		(void)memset(common.buff, 0, sizeof(common.buff));
 	}
 }
 

--- a/meterfs/test_meterfs_writeread.c
+++ b/meterfs/test_meterfs_writeread.c
@@ -23,30 +23,31 @@ static struct {
 
 static void cleanBuffs(void)
 {
-	memset(common.pattern, 0, sizeof(common.pattern));
-	memset(common.buffMsg, 0, sizeof(common.buffMsg));
-	memset(common.buffRec, 0, sizeof(common.buffRec));
+	(void)memset(common.pattern, 0, sizeof(common.pattern));
+	(void)memset(common.buffMsg, 0, sizeof(common.buffMsg));
+	(void)memset(common.buffRec, 0, sizeof(common.buffRec));
 }
 
 
 static void turnCheck(int fd, file_info_t *info, char *bufftx, char *buffrx, unsigned int iterNum)
 {
-	int i;
+	unsigned int i;
 
-	if (iterNum >= 10000 || info->recordsz < 5)
+	if ((iterNum >= 10000u) || (info->recordsz < 5u)) {
 		return;
+	}
 
 	for (i = 0; i < iterNum; ++i) {
-		snprintf(bufftx, info->recordsz, "%04d", i);
+		(void)snprintf(bufftx, info->recordsz, "%04u", i);
 		TEST_ASSERT_EQUAL(info->recordsz, file_write(fd, bufftx, info->recordsz));
 
 		TEST_ASSERT_EQUAL(info->recordsz, file_read(fd, 0, buffrx, info->recordsz));
 
 		TEST_ASSERT_EQUAL_HEX8_ARRAY(bufftx, buffrx, info->recordsz);
 
-		if (info->recordsz > 2) {
-			memset(buffrx + 1, 'x', info->recordsz - 2);
-			TEST_ASSERT_EQUAL(info->recordsz - 2, file_read(fd, 1, buffrx + 1, info->recordsz - 2));
+		if (info->recordsz > 2u) {
+			(void)memset(buffrx + 1, 'x', info->recordsz - 2u);
+			TEST_ASSERT_EQUAL(info->recordsz - 2u, file_read(fd, 1, buffrx + 1, info->recordsz - 2u));
 			TEST_ASSERT_EQUAL_HEX8_ARRAY(bufftx, buffrx, info->recordsz);
 		}
 	}
@@ -72,17 +73,17 @@ TEST_TEAR_DOWN(meterfs_writeread)
 /* Test case of writing too small records. */
 TEST(meterfs_writeread, small_records)
 {
-	int i, writeLen;
+	size_t i, writeLen;
 	file_info_t info = { 2, 5 * 255, 5, 0 };
 
 	common.fd = common_preallocOpenFile("file0", info.sectors, info.filesz, info.recordsz);
 
-	for (i = 0; i < 255; ++i) {
-		snprintf(common.buffMsg, sizeof(common.buffMsg), "iter=%d", i);
-		writeLen = i % (info.recordsz + 1);
-		i % 2 ? snprintf(common.pattern, sizeof(common.pattern), "aaaaa") : snprintf(common.pattern, sizeof(common.pattern), "zzzzz");
+	for (i = 0; i < 255u; ++i) {
+		(void)snprintf(common.buffMsg, sizeof(common.buffMsg), "iter=%zu", i);
+		writeLen = i % (info.recordsz + 1u);
+		(i % 2u) ? (void)snprintf(common.pattern, sizeof(common.pattern), "aaaaa") : (void)snprintf(common.pattern, sizeof(common.pattern), "zzzzz");
 
-		if (writeLen) {
+		if (writeLen != 0u) {
 			TEST_ASSERT_EQUAL_MESSAGE(info.recordsz, file_write(common.fd, common.pattern, writeLen), common.buffMsg);
 			common_readContent(common.fd, info.recordcnt * info.recordsz, common.buffRec, info.recordsz, common.pattern, writeLen, common.buffMsg);
 			info.recordcnt++;
@@ -102,23 +103,23 @@ TEST(meterfs_writeread, small_records)
 /* Test case of writing more records than fit in file. */
 TEST(meterfs_writeread, file_overflow)
 {
-	int i;
+	size_t i;
 	file_info_t info = { 2, 10, 5, 0 };
 
 	common.fd = common_preallocOpenFile("file0", info.sectors, info.filesz, info.recordsz);
 
-	for (i = 0; i < 255; ++i) {
-		snprintf(common.buffMsg, sizeof(common.buffMsg), "iter=%d", i);
-		i % 2 ? snprintf(common.pattern, sizeof(common.pattern), "aaaaa") : snprintf(common.pattern, sizeof(common.pattern), "zzzzz");
+	for (i = 0; i < 255u; ++i) {
+		(void)snprintf(common.buffMsg, sizeof(common.buffMsg), "iter=%zu", i);
+		(i % 2u) ? (void)snprintf(common.pattern, sizeof(common.pattern), "aaaaa") : (void)snprintf(common.pattern, sizeof(common.pattern), "zzzzz");
 
 		TEST_ASSERT_EQUAL_MESSAGE(info.recordsz, file_write(common.fd, common.pattern, info.recordsz), common.buffMsg);
 
 		if (i < (info.filesz / info.recordsz)) {
-			snprintf(common.pattern, sizeof(common.pattern), "zzzzz");
+			(void)snprintf(common.pattern, sizeof(common.pattern), "zzzzz");
 			common_readContent(common.fd, 0, common.buffRec, info.recordsz, common.pattern, info.recordsz, common.buffMsg);
 		}
 		else {
-			i % 2 ? snprintf(common.pattern, sizeof(common.pattern), "zzzzz") : snprintf(common.pattern, sizeof(common.pattern), "aaaaa");
+			(i % 2u) ? (void)snprintf(common.pattern, sizeof(common.pattern), "zzzzz") : (void)snprintf(common.pattern, sizeof(common.pattern), "aaaaa");
 			common_readContent(common.fd, 0, common.buffRec, info.recordsz, common.pattern, info.recordsz, common.buffMsg);
 		}
 
@@ -132,22 +133,22 @@ TEST(meterfs_writeread, file_overflow)
 /* Test case of writing too big records. */
 TEST(meterfs_writeread, big_records)
 {
-	int i, writeLen;
+	size_t i, writeLen;
 	file_info_t info = { 2, 2 * 255, 2, 0 };
 
 	common.fd = common_preallocOpenFile("file0", info.sectors, info.filesz, info.recordsz);
 
-	for (i = 0; i < 255; ++i) {
-		snprintf(common.buffMsg, sizeof(common.buffMsg), "iter=%d", i);
-		writeLen = i % 6;
-		i % 2 ? snprintf(common.pattern, sizeof(common.pattern), "aaaaa") : snprintf(common.pattern, sizeof(common.pattern), "zzzzz");
+	for (i = 0; i < 255u; ++i) {
+		(void)snprintf(common.buffMsg, sizeof(common.buffMsg), "iter=%zu", i);
+		writeLen = i % 6u;
+		(i % 2u) ? (void)snprintf(common.pattern, sizeof(common.pattern), "aaaaa") : (void)snprintf(common.pattern, sizeof(common.pattern), "zzzzz");
 
 		if (writeLen > info.recordsz) {
 			TEST_ASSERT_EQUAL_MESSAGE(info.recordsz, file_write(common.fd, common.pattern, writeLen), common.buffMsg);
 			common_readContent(common.fd, info.recordcnt * info.recordsz, common.buffRec, info.recordsz, common.pattern, info.recordsz, common.buffMsg);
 			info.recordcnt++;
 		}
-		else if (writeLen == 0) {
+		else if (writeLen == 0u) {
 			/* Resolving case of writing zero length record. */
 			TEST_ASSERT_EQUAL_MESSAGE(-EINVAL, file_write(common.fd, common.pattern, writeLen), common.buffMsg);
 		}
@@ -170,11 +171,11 @@ TEST(meterfs_writeread, file_end)
 	int i;
 	file_info_t info = { 2, 10, 5, 0 };
 
-	snprintf(common.pattern, sizeof(common.pattern), "a0000");
+	(void)snprintf(common.pattern, sizeof(common.pattern), "a0000");
 	common.fd = common_preallocOpenFile("file0", info.sectors, info.filesz, info.recordsz);
 
 	for (i = 0; i < 255; ++i) {
-		snprintf(common.buffMsg, sizeof(common.buffMsg), "iter=%d", i);
+		(void)snprintf(common.buffMsg, sizeof(common.buffMsg), "iter=%d", i);
 		TEST_ASSERT_EQUAL(info.recordsz, file_write(common.fd, common.pattern, info.recordsz));
 		TEST_ASSERT_EQUAL(0, file_read(common.fd, info.filesz, common.buffRec, info.recordsz));
 
@@ -197,11 +198,11 @@ TEST(meterfs_writeread, many_records)
 	TEST_ASSERT_EQUAL(0, info.recordcnt);
 
 	for (i = 0; i < 4000; ++i) {
-		snprintf(common.buffMsg, sizeof(common.buffMsg), "a0000000%04d", i);
+		(void)snprintf(common.buffMsg, sizeof(common.buffMsg), "a0000000%04d", i);
 		TEST_ASSERT_EQUAL_MESSAGE(info.recordsz, file_write(common.fd, common.buffMsg, info.recordsz), common.buffMsg);
 
 		if (i >= 3000) {
-			snprintf(common.buffMsg, sizeof(common.buffMsg), "a0000000%04d", i - 3000 + 1);
+			(void)snprintf(common.buffMsg, sizeof(common.buffMsg), "a0000000%04d", i - 3000 + 1);
 			common_readContent(common.fd, 0, common.buffRec, info.recordsz, common.buffMsg, info.recordsz, common.buffMsg);
 		}
 


### PR DESCRIPTION
JIRA: RTOS-346

<!--- Provide a general summary of your changes in the Title above -->

## Description
Add path to meterfs prefix to functions.
Add validation to argv[0].
Fix wrong paths.

## Motivation and Context
Tests were assuming that the mount path of meterfs was `/`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imx6ull.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/phoenix-rtos-filesystems/pull/90/files
- [ ] I will merge this PR by myself when appropriate.
