### PR TITLE
trunner: fix handling TEST_IGNORE_MESSAGE

### DIFF
--- a/trunner/harness/unity.py
+++ b/trunner/harness/unity.py
@@ -20,6 +20,8 @@ def _format_result_output(results: Sequence[Dict[str, Any]], ctx: TestContext) -
             out += green("OK")
         elif res["status"] == "IGNORE":
             out += yellow("IGNORE")
+            if "msg" in res:
+                out += ": " + res["msg"]
         elif res["status"] == "INFO":
             out += blue("INFO")
 
@@ -31,13 +33,13 @@ def _format_result_output(results: Sequence[Dict[str, Any]], ctx: TestContext) -
 
 
 def unity_harness(dut: Dut, ctx: TestContext) -> Optional[TestResult]:
-    assert_re = r"ASSERTION (?P<path>.*?):(?P<line>\d+):(?P<status>FAIL|INFO|IGNORE): (?P<msg>.*?)\r"
+    assert_re = r"ASSERTION (?P<path>[\S]+):(?P<line>\d+):(?P<status>FAIL|INFO|IGNORE): (?P<msg>.*?)\r"
     result_re = r"TEST\((?P<group>\w+), (?P<name>\w+)\) (?P<status>PASS|IGNORE)"
     # Fail need to have its own regex due to greedy matching
     result_final_re = r"TEST\((?P<group>\w+), (?P<name>\w+)\) (?P<status>FAIL) at (?P<path>.*?):(?P<line>\d+)\r"
     final_re = r"(?P<total>\d+) Tests (?P<fail>\d+) Failures (?P<ignore>\d+) Ignored"
 
-    last_fail = {"path": None, "line": None}
+    last_assertion = {}
     stats = {"FAIL": 0, "IGNORE": 0, "PASS": 0}
     results = []
 
@@ -46,13 +48,13 @@ def unity_harness(dut: Dut, ctx: TestContext) -> Optional[TestResult]:
         parsed = dut.match.groupdict()
 
         if idx == 0:
-            if parsed["status"] == "FAIL":
-                last_fail = parsed
+            if parsed["status"] in ["FAIL", "IGNORE"]:
+                last_assertion = parsed
         elif idx in (1, 2):
-            # TODO we do not consider INFO/IGNORE messages
-            if parsed["status"] == "FAIL":
-                if last_fail["path"] == parsed["path"] and last_fail["line"] == parsed["line"]:
-                    parsed["msg"] = last_fail["msg"]
+            # TODO we do not consider INFO messages
+            if last_assertion and last_assertion["status"] != "INFO":
+                parsed["msg"] = last_assertion["msg"]
+                last_assertion = {}
 
             stats[parsed["status"]] += 1
             results.append(parsed)

--- a/unity/unity.c
+++ b/unity/unity.c
@@ -1823,7 +1823,11 @@ void UnityIgnore(const char* msg, const UNITY_LINE_TYPE line)
         UNITY_OUTPUT_CHAR(' ');
         UnityPrint(msg);
     }
+	/* clang-format off */
+    UNITY_PRINT_EOL();
+    
     UNITY_IGNORE_AND_BAIL;
+	/* clang-format on */
 }
 
 /*-----------------------------------------------*/


### PR DESCRIPTION
JIRA CI-244
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes shortly -->
Fixed TEST_IGNORE_MESSAGE handling

Before changes:
![image](https://user-images.githubusercontent.com/116297248/229530805-8226a94e-c855-4588-b987-9b4aed47cc7a.png)

After changes:
![image](https://user-images.githubusercontent.com/116297248/229531236-2385872a-bcab-4d07-aec7-961ebfd77b7e.png)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
