### PR TITLE
trunner: fix parsed unity result

### DIFF
--- a/trunner/harness/unity.py
+++ b/trunner/harness/unity.py
@@ -35,7 +35,7 @@ def unity_harness(dut: Dut, ctx: TestContext) -> Optional[TestResult]:
     result_re = r"TEST\((?P<group>\w+), (?P<name>\w+)\) (?P<status>PASS|IGNORE)"
     # Fail need to have its own regex due to greedy matching
     result_final_re = r"TEST\((?P<group>\w+), (?P<name>\w+)\) (?P<status>FAIL) at (?P<path>.*?):(?P<line>\d+)\r"
-    final_re = r"(?P<total>\d+) Tests (?P<fail>\d+) Failures (?P<ignore>\d+) Ignored"
+    final_re = r"(?P<total>\d+) Tests (?P<fail>\d+) Failures (?P<ignore>\d+) Ignored \r+\n(?P<result>OK|FAIL)"
 
     last_fail = {"path": None, "line": None}
     stats = {"FAIL": 0, "IGNORE": 0, "PASS": 0}
@@ -58,7 +58,8 @@ def unity_harness(dut: Dut, ctx: TestContext) -> Optional[TestResult]:
             results.append(parsed)
         elif idx == 3:
             for k, v in parsed.items():
-                parsed[k] = int(v)
+                if k != "result":
+                    parsed[k] = int(v)
 
             assert (
                 parsed["total"] == sum(stats.values())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changed regex to parsed OK or FAIL after word IGNORED
![image](https://user-images.githubusercontent.com/116297248/229505743-4debb84e-1569-40e0-806b-1b40748ddfe3.png)

Parsing before changes:
![image](https://user-images.githubusercontent.com/116297248/229506081-d8c2dbec-b3cd-4cf9-88ad-fe4fb37c8196.png)

Parsing after changes:
![image](https://user-images.githubusercontent.com/116297248/229505968-b7222c69-25e4-4b8a-8642-e4f1691738c6.png)
![image](https://user-images.githubusercontent.com/116297248/229506300-6d6dbe38-d4ae-42be-aa73-63055d058bfc.png)

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [X] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing linter checks and tests passed.
- [X] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
