### PR TITLE
trunner: host can modify runner context

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -242,6 +242,7 @@ def main():
         return 2
 
     ctx = dataclasses.replace(ctx, target=target)
+    ctx = host.add_to_context(ctx)
 
     # Set global context
     trunner.ctx = ctx

--- a/trunner/config.py
+++ b/trunner/config.py
@@ -94,10 +94,10 @@ class ConfigParser:
         else:
             raise ParserError(f"harness function has not been found in {path}")
 
-        self.test.harness = PyHarness(self.ctx.target.dut, self.ctx, harness_fn)
+        self.test.harness = PyHarness(self.ctx.target.dut, self.ctx, harness_fn, self.test.kwargs)
 
     def _parse_unity(self):
-        self.test.harness = PyHarness(self.ctx.target.dut, self.ctx, unity_harness)
+        self.test.harness = PyHarness(self.ctx.target.dut, self.ctx, unity_harness, self.test.kwargs)
 
     def _parse_load(self, config: dict):
         apps = config.get("load", [])
@@ -222,6 +222,13 @@ class ConfigParser:
 
         self.test.name = f"{test_dir}/{name}"
 
+    def _parse_kwargs(self, config: dict) -> None:
+        kwargs = config.get("kwargs", dict())
+        if not isinstance(kwargs, dict):
+            raise ParserError('"kwargs" must be a dictionary!')
+
+        self.test.kwargs = kwargs
+
     def _parse_config(self, config: dict):
         # Note, the order of parsing is important!
         self.test = TestOptions()
@@ -243,6 +250,7 @@ class ConfigParser:
 
         self._parse_shell_command(config)
         self._parse_load(config)
+        self._parse_kwargs(config)
         self._parse_type(config)
 
     def _load_yaml(self) -> dict:

--- a/trunner/host.py
+++ b/trunner/host.py
@@ -1,6 +1,8 @@
 import importlib
 from abc import ABC, abstractmethod
 
+from trunner.ctx import TestContext
+
 
 class Host(ABC):  # pylint: disable=too-few-public-methods
     """Base class for Host abstraction"""
@@ -13,6 +15,10 @@ class Host(ABC):  # pylint: disable=too-few-public-methods
     @abstractmethod
     def from_context(cls, _):
         pass
+
+    def add_to_context(self, ctx: TestContext) -> TestContext:
+        """Host can use this method to add things to ctx or modify it. A new context is returned."""
+        return ctx
 
 
 class EmulatorHost(Host):

--- a/trunner/types.py
+++ b/trunner/types.py
@@ -6,7 +6,7 @@ import sys
 import traceback
 from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import Callable, List, Optional, Sequence
+from typing import Callable, Dict, List, Optional, Sequence
 
 from trunner.ctx import TestContext
 from trunner.text import bold, green, red, yellow
@@ -211,3 +211,4 @@ class TestOptions:
     should_reboot: bool = True
     ignore: bool = False
     nightly: bool = False
+    kwargs: Dict = field(default_factory=dict)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

Add `add_to_context` method in the Host class to allow to change the runner context by host instance. It can be useful in runner extensions. For example, host can read environment variables and add them to context kwargs that later can be used in tests.

Add new keyword to yaml config named kwargs. Kwargs should be a dict, similar to python **kwargs parameter. It can be useful to define custom values in yaml config that later can be read in tests. Kwargs for test are merged with kwargs passed using `--kwargs` flag. If there is the same key in both kwargs dicts then runner choose one from the context.

Definiton of the harness that uses `**kwargs`:
```
def harness(dut, **kwargs): ....
def harness(dut, ctx, **kwargs): ...
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
