### PR TITLE
trunner: improve unity harness

### DIFF
--- a/trunner/harness/unity.py
+++ b/trunner/harness/unity.py
@@ -67,7 +67,11 @@ def unity_harness(dut: Dut, ctx: TestContext) -> Optional[TestResult]:
                 parsed["total"] == sum(stats.values())
                 and parsed["fail"] == stats["FAIL"]
                 and parsed["ignore"] == stats["IGNORE"]
-            ), "There is a mismatch between the number of parsed tests and overall results!"
+            ), "".join(("There is a mismatch between the number of parsed tests and overall results!\n",
+                        "Parsed results from the final Unity message (total, failed, ignored): ",
+                        f"{parsed['total']}, {parsed['fail']}, {parsed['ignore']}\n",
+                        "Found test summary lines (total, failed, ignored): ",
+                        f"{sum(stats.values())}, {stats['FAIL']}, {stats['IGNORE']}"))
 
             # TODO parse last line
             break

--- a/trunner/harness/unity.py
+++ b/trunner/harness/unity.py
@@ -36,7 +36,7 @@ def unity_harness(dut: Dut, ctx: TestContext) -> Optional[TestResult]:
     assert_re = r"ASSERTION (?P<path>[\S]+):(?P<line>\d+):(?P<status>FAIL|INFO|IGNORE): (?P<msg>.*?)\r"
     result_re = r"TEST\((?P<group>\w+), (?P<name>\w+)\) (?P<status>PASS|IGNORE)"
     # Fail need to have its own regex due to greedy matching
-    result_final_re = r"TEST\((?P<group>\w+), (?P<name>\w+)\) (?P<status>FAIL) at (?P<path>.*?):(?P<line>\d+)\r"
+    result_fail_re = r"TEST\((?P<group>\w+), (?P<name>\w+)\) (?P<status>FAIL) at (?P<path>.*?):(?P<line>\d+)\r"
     final_re = r"(?P<total>\d+) Tests (?P<fail>\d+) Failures (?P<ignore>\d+) Ignored \r+\n(?P<result>OK|FAIL)"
 
     last_assertion = {}
@@ -44,7 +44,7 @@ def unity_harness(dut: Dut, ctx: TestContext) -> Optional[TestResult]:
     results = []
 
     while True:
-        idx = dut.expect([assert_re, result_re, result_final_re, final_re])
+        idx = dut.expect([assert_re, result_re, result_fail_re, final_re])
         parsed = dut.match.groupdict()
 
         if idx == 0:
@@ -73,7 +73,6 @@ def unity_harness(dut: Dut, ctx: TestContext) -> Optional[TestResult]:
                         "Found test summary lines (total, failed, ignored): ",
                         f"{sum(stats.values())}, {stats['FAIL']}, {stats['IGNORE']}"))
 
-            # TODO parse last line
             break
 
     status = Status.FAIL if stats["FAIL"] != 0 else Status.OK


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

- trunner: clean unity harness
- trunner: print more details in unity harness error message

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The following error found (hard to reproduce): 

![Screenshot from 2023-04-13 15-59-49](https://user-images.githubusercontent.com/77304431/231822604-b36b9779-385d-48ea-a8f3-4bf3736750b2.png)

Code cleanings

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
