### PR TITLE
Fix parsing unity fail output when using TEST_ASSER_EQUAL_X_ARRAY

### DIFF
--- a/unity/unity.c
+++ b/unity/unity.c
@@ -3,7 +3,7 @@
     Copyright (c) 2007-21 Mike Karlesky, Mark VanderVoord, Greg Williams
     [Released under MIT License. Please refer to license.txt for details]
 ============================================================================ */
-
+/* clang-format off */
 #include "unity.h"
 #include <stddef.h>
 
@@ -801,6 +801,7 @@ void UnityAssertEqualIntArray(UNITY_INTERNAL_PTR expected,
 
     if (UnityIsOneArrayNull(expected, actual, lineNumber, msg))
     {
+        UNITY_PRINT_EOL();
         UNITY_FAIL_AND_BAIL;
     }
 
@@ -931,6 +932,7 @@ void UnityAssertEqualFloatArray(UNITY_PTR_ATTRIBUTE const UNITY_FLOAT* expected,
 
     if (UnityIsOneArrayNull((UNITY_INTERNAL_PTR)expected, (UNITY_INTERNAL_PTR)actual, lineNumber, msg))
     {
+        UNITY_PRINT_EOL();
         UNITY_FAIL_AND_BAIL;
     }
 
@@ -1075,6 +1077,7 @@ void UnityAssertEqualDoubleArray(UNITY_PTR_ATTRIBUTE const UNITY_DOUBLE* expecte
 
     if (UnityIsOneArrayNull((UNITY_INTERNAL_PTR)expected, (UNITY_INTERNAL_PTR)actual, lineNumber, msg))
     {
+        UNITY_PRINT_EOL();
         UNITY_FAIL_AND_BAIL;
     }
 
@@ -1260,6 +1263,7 @@ void UnityAssertNumbersArrayWithin(const UNITY_UINT delta,
 
     if (UnityIsOneArrayNull(expected, actual, lineNumber, msg))
     {
+        UNITY_PRINT_EOL();
         UNITY_FAIL_AND_BAIL;
     }
 
@@ -1462,6 +1466,7 @@ void UnityAssertEqualStringArray(UNITY_INTERNAL_PTR expected,
 
     if (UnityIsOneArrayNull((UNITY_INTERNAL_PTR)expected, (UNITY_INTERNAL_PTR)actual, lineNumber, msg))
     {
+        UNITY_PRINT_EOL();
         UNITY_FAIL_AND_BAIL;
     }
 
@@ -1542,6 +1547,7 @@ void UnityAssertEqualMemory(UNITY_INTERNAL_PTR expected,
 
     if (UnityIsOneArrayNull(expected, actual, lineNumber, msg))
     {
+        UNITY_PRINT_EOL();
         UNITY_FAIL_AND_BAIL;
     }
 
@@ -1823,11 +1829,10 @@ void UnityIgnore(const char* msg, const UNITY_LINE_TYPE line)
         UNITY_OUTPUT_CHAR(' ');
         UnityPrint(msg);
     }
-	/* clang-format off */
+
     UNITY_PRINT_EOL();
     
     UNITY_IGNORE_AND_BAIL;
-	/* clang-format on */
 }
 
 /*-----------------------------------------------*/
@@ -2130,4 +2135,5 @@ int UnityTestMatches(void)
 }
 
 #endif /* UNITY_USE_COMMAND_LINE_ARGS */
+/* clang-format on */
 /*-----------------------------------------------*/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
JIRA CI-271

When  TEST_ASSERT_EQUAL_X_ARRAY  fail in specific cases this was printed on output :
![image](https://user-images.githubusercontent.com/116297248/236223070-c667a840-7713-44e2-a743-05b43c30b4ec.png)
![image](https://user-images.githubusercontent.com/116297248/236224510-72975613-daae-4523-8385-87693a40629f.png)

After changes is:
![image](https://user-images.githubusercontent.com/116297248/236223217-2a45e692-5eda-44f3-8c1a-4db9e57f8c45.png)
![image](https://user-images.githubusercontent.com/116297248/236223276-04797ab0-7116-44d4-a390-185659b36f9f.png)



## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
