### PR TITLE
libc: string.h: Fixed lack of test coverage for stop point as INT

### DIFF
--- a/libc/string/string_lenchr.c
+++ b/libc/string/string_lenchr.c
@@ -490,29 +490,52 @@ TEST(string_chr, ascii)
 }
 
 
-TEST(string_chr, not_ascii)
+TEST(string_chr, not_ascii_chars)
 {
-	char charSet[BUFF_SIZE] = { 0 };
-	int len, i;
+	char notAsciiStr[129] = { 0 };
+	int sz, i;
 
-	/* Checking out of ASCII bytes */
-	for (i = sizeof(charSet); i < sizeof(charSet) * 2 - 1; i++) {
-		charSet[i - sizeof(charSet)] = i;
+	/*
+	 * Depending on architecture we will get
+	 * output {128;255} if chars are unsigned or {-128;-1} when chars are signed
+	 */
+
+	notAsciiStr[128] = 0;
+	sz = sizeof(notAsciiStr);
+	for (i = 0; i <= 127; i++) {
+		notAsciiStr[i] = i + 128;
+		/* Testing capability of functions to hold and read not ascii set */
+		TEST_ASSERT_EQUAL_STRING(&notAsciiStr[i], strchr(notAsciiStr, notAsciiStr[i]));
+		TEST_ASSERT_EQUAL_STRING(&notAsciiStr[i], strrchr(notAsciiStr, notAsciiStr[i]));
+		TEST_ASSERT_EQUAL_STRING(&notAsciiStr[i], memchr(notAsciiStr, notAsciiStr[i], sz));
 	}
+}
 
-	/* Testing capability of functions to hold and read not ascii set */
-	len = sizeof(charSet);
-	TEST_ASSERT_EQUAL_PTR(charSet, strchr(charSet, charSet[0]));
-	TEST_ASSERT_EQUAL_PTR(charSet, strrchr(charSet, charSet[0]));
-	TEST_ASSERT_EQUAL_PTR(charSet, memchr(charSet, charSet[0], len));
+TEST(string_chr, int_to_char_cast)
+{
+	char str[2];
+	int intVal[] = {
+		INT_MIN,
+		INT_MIN / 3,
+		-514,
+		-256,
+		-129,
+		129,
+		256,
+		514,
+		INT_MAX / 3,
+		INT_MAX
+	},
+		i;
 
-	TEST_ASSERT_EQUAL_PTR(&charSet[64], strchr(charSet, charSet[64]));
-	TEST_ASSERT_EQUAL_PTR(&charSet[64], strrchr(charSet, charSet[64]));
-	TEST_ASSERT_EQUAL_PTR(&charSet[64], memchr(charSet, charSet[64], len));
+	for (i = 0; i < sizeof(intVal) / sizeof(int); i++) {
+		/* Copy value into first place in array as char*/
+		str[0] = intVal[i];
+		/*Setting up 0 on second place to recognize array as string*/
+		str[1] = 0;
 
-	TEST_ASSERT_EQUAL_PTR(&charSet[len - 1], strchr(charSet, charSet[len - 1]));
-	TEST_ASSERT_EQUAL_PTR(&charSet[len - 1], strrchr(charSet, charSet[len - 1]));
-	TEST_ASSERT_EQUAL_PTR(&charSet[len - 1], memchr(charSet, charSet[len - 1], len));
+		TEST_ASSERT_EQUAL_PTR(&str[0], strrchr(str, intVal[i]));
+	}
 }
 
 
@@ -633,6 +656,7 @@ TEST_GROUP_RUNNER(string_chr)
 	RUN_TEST_CASE(string_chr, whitespaces);
 	RUN_TEST_CASE(string_chr, empty);
 	RUN_TEST_CASE(string_chr, ascii);
-	RUN_TEST_CASE(string_chr, not_ascii);
+	RUN_TEST_CASE(string_chr, not_ascii_chars);
+	RUN_TEST_CASE(string_chr, int_to_char_cast);
 	RUN_TEST_CASE(string_chr, torn);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes shortly -->
 Tests of functions "*chr" needed additional test case for more probability coverage.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
JIRA: CI-211

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [X] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [X] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/libphoenix/pull/254
- [ ] I will merge this PR by myself when appropriate.
