### PR TITLE
libc: fix nightly nucleo fail

### DIFF
--- a/libc/printf/stdio_printf.c
+++ b/libc/printf/stdio_printf.c
@@ -2040,7 +2040,7 @@ TEST(stdio_printf_cspn, c)
 }
 
 
-TEST(stdio_printf_cspn, c_ascii)
+TEST(stdio_printf_cspn, c_ascii_printf)
 {
 	int i;
 	const char *format = "%c";
@@ -2049,14 +2049,24 @@ TEST(stdio_printf_cspn, c_ascii)
 		char *expect = test_intToAscii(i);
 
 		test_assertPrintfs(expect, format, i);
-		test_assertVprintfs(expect, format, i);
-
-		free(expect);
 	}
 }
 
 
-TEST(stdio_printf_cspn, c_non_ascii)
+TEST(stdio_printf_cspn, c_ascii_vprintf)
+{
+	int i;
+	const char *format = "%c";
+
+	for (i = 1; i < 128; i++) {
+		char *expect = test_intToAscii(i);
+
+		test_assertVprintfs(expect, format, i);
+	}
+}
+
+
+TEST(stdio_printf_cspn, c_non_ascii_printf)
 {
 	int i;
 	const char *format = "%c";
@@ -2065,9 +2075,19 @@ TEST(stdio_printf_cspn, c_non_ascii)
 		char *expect = test_intToAscii(i);
 
 		test_assertPrintfs(expect, format, i);
-		test_assertVprintfs(expect, format, i);
+	}
+}
 
-		free(expect);
+
+TEST(stdio_printf_cspn, c_non_ascii_vprintf)
+{
+	int i;
+	const char *format = "%c";
+
+	for (i = 128; i < 256; i++) {
+		char *expect = test_intToAscii(i);
+
+		test_assertVprintfs(expect, format, i);
 	}
 }
 
@@ -2124,7 +2144,7 @@ TEST(stdio_printf_cspn, s_specific)
 }
 
 
-TEST(stdio_printf_cspn, s_ascii)
+TEST(stdio_printf_cspn, s_ascii_printf)
 {
 	int i;
 	const char *format = "%s";
@@ -2137,9 +2157,23 @@ TEST(stdio_printf_cspn, s_ascii)
 		char *expect = test_intToAscii(i);
 
 		test_assertPrintfs(expect, format, expect);
-		test_assertVprintfs(expect, format, expect);
+	}
+}
 
-		free(expect);
+
+TEST(stdio_printf_cspn, s_ascii_vprintf)
+{
+	int i;
+	const char *format = "%s";
+
+	/*
+	 * In ASCII table from number 33 starts printable characters
+	 * in this case we want to dodge terminating ASCII signs
+	 */
+	for (i = 33; i < 128; i++) {
+		char *expect = test_intToAscii(i);
+
+		test_assertVprintfs(expect, format, expect);
 	}
 }
 
@@ -2586,14 +2620,17 @@ TEST_GROUP_RUNNER(stdio_printf_fega)
 TEST_GROUP_RUNNER(stdio_printf_cspn)
 {
 	RUN_TEST_CASE(stdio_printf_cspn, c);
-	RUN_TEST_CASE(stdio_printf_cspn, c_ascii);
-	RUN_TEST_CASE(stdio_printf_cspn, c_non_ascii);
+	RUN_TEST_CASE(stdio_printf_cspn, c_ascii_printf);
+	RUN_TEST_CASE(stdio_printf_cspn, c_ascii_vprintf);
+	RUN_TEST_CASE(stdio_printf_cspn, c_non_ascii_printf);
+	RUN_TEST_CASE(stdio_printf_cspn, c_non_ascii_vprintf);
 	RUN_TEST_CASE(stdio_printf_cspn, lc);
 	RUN_TEST_CASE(stdio_printf_cspn, C);
 	RUN_TEST_CASE(stdio_printf_cspn, s);
 
 	RUN_TEST_CASE(stdio_printf_cspn, s_specific);
-	RUN_TEST_CASE(stdio_printf_cspn, s_ascii);
+	RUN_TEST_CASE(stdio_printf_cspn, s_ascii_printf);
+	RUN_TEST_CASE(stdio_printf_cspn, s_ascii_vprintf);
 	RUN_TEST_CASE(stdio_printf_cspn, s_huge_string);
 	RUN_TEST_CASE(stdio_printf_cspn, ls);
 	RUN_TEST_CASE(stdio_printf_cspn, S);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Issue:
The following test cases have an extended execution time:

TEST(stdio_printf_cspn, c_ascii)
TEST(stdio_printf_cspn, c_non_ascii)
TEST(stdio_printf_cspn, s_ascii)

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
