### PR TITLE
test-ls-rootfs improvements

### DIFF
--- a/psh/test-ls-rootfs.py
+++ b/psh/test-ls-rootfs.py
@@ -13,7 +13,7 @@
 #
 
 import psh.tools.psh as psh
-from psh.tools.psh import OPTIONAL_CONTROL_CODE
+from psh.tools.psh import OPTIONAL_CONTROL_CODE, CONTROL_CODE
 from psh.tools.common import SEPARATOR_PATTERN, create_testdir
 
 
@@ -24,7 +24,7 @@ def assert_ls_pshcmds(p, psh_cmds):
     # history and exit symlinks shouldn't be present in bin
     psh_cmds = set(psh_cmds) - {'history', 'exit'}
 
-    psh_cmd_pattern = OPTIONAL_CONTROL_CODE
+    psh_cmd_pattern = CONTROL_CODE
     psh_cmd_pattern += r'(?P<cmd>' + '|'.join(psh_cmds) + r')'
     psh_cmd_pattern += SEPARATOR_PATTERN
 

--- a/psh/tools/common.py
+++ b/psh/tools/common.py
@@ -23,7 +23,7 @@ from psh.tools.psh import CONTROL_CODE
 from psh.tools.randwrapper import TestRandom
 
 # acceptable separators: white spaces (wss) + CC, CC + wss, wss
-SEPARATOR_PATTERN = r'(?:' + CONTROL_CODE + r'|\s)+'
+SEPARATOR_PATTERN = r'(?:' + CONTROL_CODE + r'|\s)+?'
 CHARS = list(set(string.printable) - set(string.whitespace) - set('/'))
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

1. psh: improve pshcmds case in ls-rootfs test
2. psh: improve SEPARATOR_PATTERN regex

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

1. The previous implementation may have parsed binaries that only include searched
 phrase.
    For example stty (busybox applet) was counted as tty binary.
2. Without this improvement it may have skipped some data during parsing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
