### PR TITLE
psh: ls-rootfs: add `clear`, `reset` internal commands

### DIFF
--- a/psh/test-ls-rootfs.py
+++ b/psh/test-ls-rootfs.py
@@ -21,8 +21,8 @@ ROOT_TEST_DIR = 'test_ls_rootfs_dir'
 
 
 def assert_ls_pshcmds(p, psh_cmds):
-    # history and exit symlinks shouldn't be present in bin
-    psh_cmds = set(psh_cmds) - {'history', 'exit'}
+    # history, exit, clear and reset symlinks shouldn't be present in bin
+    psh_cmds = set(psh_cmds) - {'history', 'exit', 'clear', 'reset'}
 
     psh_cmd_pattern = CONTROL_CODE
     psh_cmd_pattern += r'(?P<cmd>' + '|'.join(psh_cmds) + r')'


### PR DESCRIPTION
## Description
<!--- Describe your changes shortly -->

Adds `clear` and `reset` commands to pshapp internal commands.

On large targets, these commands should be implemented by alias to [`tset`](https://linux.die.net/man/1/tset) provided by system tools, while on small targets where `psh` is used, there `pshapp` controls the terminal (termios) directly, therefore these commands have been implemented as internal (pshapp builtins) and are be available only in the pShell.

JIRA: RTOS-561

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The reason for the change is due to the pull-request:
https://github.com/phoenix-rtos/phoenix-rtos-utils/pull/185

And these CI errors:
https://github.com/phoenix-rtos/phoenix-rtos-utils/actions/runs/5895710196/job/15992106606?pr=185#step:6:1803
https://github.com/phoenix-rtos/phoenix-rtos-utils/actions/runs/5895710196/job/15992106787?pr=185#step:6:1828

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
