### PR TITLE
psh: cat test regex flexibility

### DIFF
--- a/psh/test-cat.py
+++ b/psh/test-cat.py
@@ -17,8 +17,8 @@ import psh.tools.psh as psh
 
 def assert_cat_err(p):
     fname = 'nonexistentFile'
-    statement = f'cat: {fname} no such file'
-    psh.assert_cmd(p, f'cat {fname}', expected=statement, result='fail')
+    statement = rf'cat: {fname}(.+)'
+    psh.assert_cmd(p, f'cat {fname}', expected=statement, result='fail', is_regex=True)
 
 
 def assert_cat_h(p):


### PR DESCRIPTION
Flexible regex to not block merge phoenix-rtos/phoenix-rtos-utils#187.
In a separate PR, the cat tests will be extended due to their currently poor version

JIRA CI-336
 
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
