### PR TITLE
trunner: xml export / log streaming improvements

### DIFF
--- a/trunner/dut.py
+++ b/trunner/dut.py
@@ -70,6 +70,29 @@ class Dut(ABC):
             self.pexpect_proc.logfile_send = self._logfiles[1]
             self.pexpect_proc.logfile = self._logfiles[2]
 
+    def read(self, size: int = 512, timeout: float = 0.1) -> str:
+        """read out RAW output from the DUT with configurable timeout"""
+        if not self.pexpect_proc:
+            return ""
+
+        ret = ""
+        abs_timeout = time.time() + timeout
+        remaining_size = size
+        remaining_time = abs_timeout - time.time()
+
+        while remaining_time > 0 and remaining_size > 0:
+            try:
+                ret += self.pexpect_proc.read_nonblocking(size=remaining_size, timeout=remaining_time)
+                remaining_size = size - len(ret)
+            except pexpect.TIMEOUT:
+                pass
+            except EOF:
+                break
+
+            remaining_time = abs_timeout - time.time()
+
+        return ret
+
     def clear_buffer(self):
         """
         Clears the pexpect buffer.

--- a/trunner/harness/psh.py
+++ b/trunner/harness/psh.py
@@ -61,6 +61,7 @@ class ShellHarness(IntermediateHarness):
 
     def __call__(self, result: TestResult) -> TestResult:
         try:
+            self.dut.send("\n")
             self.dut.expect_exact(self.prompt, timeout=self.prompt_timeout)
         except (pexpect.TIMEOUT, pexpect.EOF) as e:
             raise ShellError(

--- a/trunner/test_runner.py
+++ b/trunner/test_runner.py
@@ -278,7 +278,19 @@ class TestRunner:
                 xml.add_testsuite(suite)
 
             xml.update_statistics()
-            xml.write(self.ctx.output + ".xml", pretty=True)  # TODO: remove pretty
+            try:
+                xml.write(self.ctx.output + ".xml", pretty=True)  # TODO: remove pretty
+            except Exception:
+                # in case of XML error - try dumping to stdout to inspect the XML
+                try:
+                    from lxml import etree
+                except ImportError:
+                    from xml.etree import ElementTree as etree
+                with open(self.ctx.output + ".xml", 'wb') as out_xml:
+                    text = etree.tostring(xml._elem)
+                    out_xml.write(text)
+
+                raise
 
             print(f"Test results written to: {self.ctx.output}{{.csv,.xml}}")
 

--- a/trunner/test_runner.py
+++ b/trunner/test_runner.py
@@ -164,7 +164,7 @@ class TestRunner:
     def _print_test_header_begin(self, test: TestOptions):
         if self.ctx.stream_output:
             if is_github_actions():
-                print("::group::", end="")
+                print("\n::group::", end="")
 
             # while streaming output highlight each new test with color
             print(f"{magenta(test.name)}: ...")
@@ -266,6 +266,7 @@ class TestRunner:
                 except HarnessError as e:
                     result.fail(str(e))
 
+            self.target.dut.read(timeout=0.1)  # try to read (pass to logs) remaining test output
             self._print_test_header_end(test)
             print(result.to_str(self.ctx.verbosity), end="", flush=True)
 


### PR DESCRIPTION

## Description

- trunner: treat flashing as a test to include in results export
  - especially useful when failed
  - we can monitor device flashing performance

- trunner: ensure all logs from previous test are read before starting next one
- trunner: move results exporting to separate functions
- trunner: debug dump invalid XML to file on XML encoding error
  Needed to fine-tune XML creation (improve escaping of messages).

## Motivation and Context
JIRA: CI-330

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
