### PR TITLE
trunner: remove extra newline + fix prompt detection + bump deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,8 @@ packaging==23.1
 pexpect==4.8.0
 pluggy==0.13.1
 ptyprocess==0.7.0
-py==1.11.0
 pyserial==3.5
-pytest==6.2.3
+pytest==7.4.1
 PyYAML==6.0.1
 RPi.GPIO==0.7.1
 toml==0.10.2

--- a/trunner/harness/psh.py
+++ b/trunner/harness/psh.py
@@ -61,7 +61,6 @@ class ShellHarness(IntermediateHarness):
 
     def __call__(self, result: TestResult) -> TestResult:
         try:
-            self.dut.send("\n")
             self.dut.expect_exact(self.prompt, timeout=self.prompt_timeout)
         except (pexpect.TIMEOUT, pexpect.EOF) as e:
             raise ShellError(

--- a/trunner/test_runner.py
+++ b/trunner/test_runner.py
@@ -35,7 +35,7 @@ class LogWrapper(StringIO):
 
     def write(self, message):
         # skip esc codes intended to clear window when streaming logs
-        stripped_message = message.replace("\033[2J", "").replace("\033c", "").replace("\033[?7l", "")
+        stripped_message = message.replace("\033[2J", "").replace("\033c", "")
         self.stream.write(stripped_message)
 
         return super().write(message)
@@ -262,6 +262,10 @@ class TestRunner:
                 result.skip()
             else:
                 set_logfiles(self.target.dut, self.ctx)
+                if not test.should_reboot:
+                    # if not rebooting - force new prompt to appear
+                    self.target.dut.send("\n")
+
                 harness = self.target.build_test(test)
                 test_result = None
                 assert harness is not None

--- a/trunner/test_runner.py
+++ b/trunner/test_runner.py
@@ -161,8 +161,9 @@ class TestRunner:
 
     def _print_test_header_end(self, test: TestOptions):
         if self.ctx.stream_output:
+            print("")  # add newline as test logs might have not ended with it
             if is_github_actions():
-                print("\n::endgroup::")
+                print("::endgroup::")
 
             # while streaming output highlight each new test with color
             print(f"{magenta(test.name)}: ", end="", flush=True)
@@ -170,7 +171,7 @@ class TestRunner:
     def _print_test_header_begin(self, test: TestOptions):
         if self.ctx.stream_output:
             if is_github_actions():
-                print("\n::group::", end="")
+                print("::group::", end="")
 
             # while streaming output highlight each new test with color
             print(f"{magenta(test.name)}: ...")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- trunner: fix detecting psh prompt after reboot
- trunner: remove extra newline between tests
- trunner: requirements: bump pytest version
  6.2.3 -> 7.4.1

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
