### PR TITLE
trunner: fix sending extra `\n` on 117x target

### DIFF
--- a/trunner/test_runner.py
+++ b/trunner/test_runner.py
@@ -262,11 +262,12 @@ class TestRunner:
                 result.skip()
             else:
                 set_logfiles(self.target.dut, self.ctx)
-                if not test.should_reboot:
+                harness = self.target.build_test(test)
+
+                if not test.should_reboot:  # WARN: build_test may change TestOptions
                     # if not rebooting - force new prompt to appear
                     self.target.dut.send("\n")
 
-                harness = self.target.build_test(test)
                 test_result = None
                 assert harness is not None
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context

We want CI to work.

JIRA: CI-331

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
