### PR TITLE
trunner: remove rebooting before each test (imxrt117x)

### DIFF
--- a/trunner/target/armv7m7.py
+++ b/trunner/target/armv7m7.py
@@ -100,9 +100,3 @@ class IMXRT106xEvkTarget(IMXTarget):
 class IMXRT117xEvkTarget(IMXTarget):
     name = "armv7m7-imxrt117x-evk"
     image = PloImageProperty(file="phoenix.disk", source="usb0", memory_bank="flash0")
-
-    def build_test(self, test: TestOptions) -> Callable[[TestResult], TestResult]:
-        # FIXME due to https://github.com/phoenix-rtos/phoenix-rtos-project/issues/580 always reboot
-        test.should_reboot = True
-
-        return super().build_test(test)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

JIRA: CI-341 
https://github.com/phoenix-rtos/phoenix-rtos-project/issues/580 solved 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
