### PR TITLE
trunner: armv7a7-imx6ull: Increase jffs2 command timeout

### DIFF
--- a/trunner/target/armv7a7.py
+++ b/trunner/target/armv7a7.py
@@ -80,11 +80,11 @@ class IMX6ULLEvkTarget(ARMv7A7Target):
         flash_device_id="2.0",
         cleanmarkers_args=PloJffs2CleanmarkerSpec(
             start_block=0x10,
-            number_of_blocks=0x1f0,
+            number_of_blocks=0x1F0,
             block_size=0x10000,
             cleanmarker_size=0x10,
         ),
-        timeout=90,
+        timeout=275,
     )
     name = "armv7a7-imx6ull-evk"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Changed timeout for jffs2 command based on phoenix size after nightly build (~16MB) and MT25QL256 documentation (max 1s/64KB erase)

## Motivation and Context
Our boards are equipped with MT25QL256 NOR 
From manufacturer documentation, we can decode the size of it (32Mb) 

![Screenshot from 2023-09-25 11-42-32](https://github.com/phoenix-rtos/phoenix-rtos-tests/assets/49757239/c2d55d42-4b63-4e4c-b172-54a08a100ade)
 
Manufacturer inform users about `Sector erase time` (This time is given for 64kb of data) 

![Screenshot from 2023-09-25 11-39-57](https://github.com/phoenix-rtos/phoenix-rtos-tests/assets/49757239/63249a2b-6066-4223-9486-cccc0a8a4bb9)
that means in the worst scenario, it will erase 512 seconds(8.5 minutes).
We divided this value in half and add time which is needed for setting up clean markers, because nightly campaign right now weight exactly half of its space.
![Screenshot from 2023-09-22 08-48-02](https://github.com/phoenix-rtos/phoenix-rtos-tests/assets/49757239/9ef3c5c7-15b4-41e7-826b-7eb04f955a6f)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [X] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [X] Tested by hand on: armv7a7-imx6ull-evk.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing linter checks and tests passed.
- [X] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
