### PR TITLE
psh: fixed tests to allow year printing in `ls -l`

### DIFF
--- a/psh/test-touch-rootfs.py
+++ b/psh/test-touch-rootfs.py
@@ -18,7 +18,12 @@ from psh.tools.common import assert_mtime
 def assert_bin(p):
     ''' Asserts that all files in /bin are able to be touched'''
     dates = {}
-    for file in psh.ls_simple(p, 'bin'):
+    for file_info in psh.ls(p, 'bin'):
+        # If file has multiple links, dates of all linked files will change when one is touched
+        if file_info.n_links > 1:
+            continue
+
+        file = file_info.name
         file_path = f'/bin/{file}'
         dates[file] = psh.date(p)
         msg = f"Prompt hasn't been seen after touching the following file: {file_path}"

--- a/psh/tools/common.py
+++ b/psh/tools/common.py
@@ -49,22 +49,21 @@ def create_testdir(p, dirname):
 def assert_mtime(p, datetimes: Dict[str, datetime], dir=''):
     ''' Asserts that files (keys in datetimes dictionary) have modification time
     equal to corresponding datetime values with 1 min margin.
-    Year and seconds are not checked. All files shall be present in the `dir` directory. '''
+    Seconds are not checked. If file's modification year is different from year
+    currently set on the device, the hours and minutes will not be checked either. '''
 
     dir_files = {file.name: file for file in psh.ls(p, dir)}
 
     for filename, target_datetime in datetimes.items():
         assert filename in dir_files, f'File {filename} is not present in the {dir} directory!'
-        date = dir_files[filename].datetime
+        date: datetime = dir_files[filename].datetime
+        date_resolution: timedelta = dir_files[filename].datetime_resolution
 
-        # we do not want to compare years and seconds (not printed by ls -l)
-        date = date.replace(year=target_datetime.year, second=target_datetime.second)
+        delta = target_datetime - date
 
-        # to prevent failed assertion when typing date in 00:59 and touch in 01:00
-        if date - target_datetime == timedelta(minutes=1):
-            date = target_datetime
-
-        assert date == target_datetime, "".join((
+        # Check if delta is smaller than resolution and allow for file to be up to 1 second
+        # newer (this can happen because `date` is called first, then `touch`)
+        assert delta < date_resolution and delta >= timedelta(seconds=-1), "".join((
             f'The modification time for {filename} is not equal to the target one! ',
             f'file datetime: {date} target datetime: {target_datetime}'))
 


### PR DESCRIPTION
## Description
`ls -l` command currently always prints the modification time in `HH:MM` format. These changes allow for modification year in `YYYY` format to be printed instead of the time if the modification year is different from the current year.

This change is compatible with current version of `psh` and doesn't break existing tests.

## Motivation and Context
Fixing https://github.com/phoenix-rtos/phoenix-rtos-project/issues/552 would result in current tests not passing because `ls -l` would be printing the modification year sometimes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
