### PR TITLE
psh: restore tests of touch command

### DIFF
--- a/psh/test.yaml
+++ b/psh/test.yaml
@@ -56,8 +56,6 @@ test:
 
         - name: touch-rootfs
           harness: test-touch-rootfs.py
-          # temporary disabled because of the following issue: https://github.com/phoenix-rtos/phoenix-rtos-project/issues/621
-          ignore: true
           targets:
               exclude: [armv7m7-imxrt106x-evk, armv7m7-imxrt117x-evk, armv7m4-stm32l4x6-nucleo, riscv64-generic-qemu]
 


### PR DESCRIPTION
## Description
Restore tests of `touch` command after https://github.com/phoenix-rtos/phoenix-rtos-project/issues/621 has been fixed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.

https://github.com/phoenix-rtos/libphoenix/pull/294 needs to be merged first, because it fixes the bug that causes this test to fail.