### PR TITLE
psh: assert missing prompt in the autocompletion test

### DIFF
--- a/psh/test-autocompletion.py
+++ b/psh/test-autocompletion.py
@@ -46,8 +46,9 @@ def assert_hints(p, path, hints):
     p.send(TAB)
     for h in hints:
         p.expect_exact(h)
+    psh.assert_prompt(p, msg='No prompt after printing hints', timeout=1)
     p.send(ENTER)
-    psh.assert_prompt(p, msg='No prompt after hints test', timeout=1)
+    psh.assert_prompt(p, msg=f'No prompt after sending the following command: {path}', timeout=1)
 
 
 @psh.run


### PR DESCRIPTION
JIRA: CI-352

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When sending TAB after `ls testenv/loremipsum/` the content of directory including prompt is printed, then we send ENTER and it's printed second time. In the previous implementation only the first prompt was asserted and exit (called at the end of test) could have been sent during printing the content (which caused some errors):
![Screenshot from 2023-09-28 12-58-14](https://github.com/phoenix-rtos/phoenix-rtos-tests/assets/77304431/8c58159a-a68d-42f6-bdc8-53b68fbd25b5)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
