### PR TITLE
libc: scanf: re-enable issued cspn_ptr test

### DIFF
--- a/libc/Makefile
+++ b/libc/Makefile
@@ -17,6 +17,7 @@ include $(binary.mk)
 endef
 
 $(eval $(call add_test_libc,printf))
+$(eval $(call add_test_libc,scanf))
 $(eval $(call add_test_libc,pthread, -lpthread))
 $(eval $(call add_test_libc,misc))
 $(eval $(call add_test_libc,stdio))

--- a/libc/scanf/stdio_scanf.c
+++ b/libc/scanf/stdio_scanf.c
@@ -4743,3 +4743,23 @@ TEST_GROUP_RUNNER(stdio_scanf_rest)
 	RUN_TEST_CASE(stdio_scanf_rest, field_width);
 	remove(TESTFILE_PATH);
 }
+
+void runner(void)
+{
+	RUN_TEST_GROUP(stdio_scanf_d);
+	RUN_TEST_GROUP(stdio_scanf_i);
+	RUN_TEST_GROUP(stdio_scanf_u);
+	RUN_TEST_GROUP(stdio_scanf_o);
+	RUN_TEST_GROUP(stdio_scanf_x);
+	RUN_TEST_GROUP(stdio_scanf_aefg);
+	RUN_TEST_GROUP(stdio_scanf_cspn);
+	RUN_TEST_GROUP(stdio_scanf_squareBrackets);
+	RUN_TEST_GROUP(stdio_scanf_rest);
+}
+
+int main(int argc, char *argv[])
+{
+	UnityMain(argc, (const char **)argv, runner);
+
+	return 0;
+}

--- a/libc/stdio/main.c
+++ b/libc/stdio/main.c
@@ -25,15 +25,6 @@ void runner(void)
 	RUN_TEST_GROUP(stdio_fileseek);
 	RUN_TEST_GROUP(stdio_fileop);
 	RUN_TEST_GROUP(stdio_bufs);
-	RUN_TEST_GROUP(stdio_scanf_d);
-	RUN_TEST_GROUP(stdio_scanf_i);
-	RUN_TEST_GROUP(stdio_scanf_u);
-	RUN_TEST_GROUP(stdio_scanf_o);
-	RUN_TEST_GROUP(stdio_scanf_x);
-	RUN_TEST_GROUP(stdio_scanf_aefg);
-	RUN_TEST_GROUP(stdio_scanf_cspn);
-	RUN_TEST_GROUP(stdio_scanf_squareBrackets);
-	RUN_TEST_GROUP(stdio_scanf_rest);
 }
 
 

--- a/libc/stdio/stdio_scanf.c
+++ b/libc/stdio/stdio_scanf.c
@@ -3545,11 +3545,6 @@ TEST(stdio_scanf_cspn, percent)
 
 TEST(stdio_scanf_cspn, ptr)
 {
-	/* Disabled because of issue: https://github.com/phoenix-rtos/phoenix-rtos-project/issues/677 */
-#ifdef __phoenix__
-	TEST_IGNORE();
-#endif
-
 	char buff[BUFF_LEN];
 	char format[] = "%p %p %p %p";
 	void *const expPtr = (void *)0xDEADBEEF;

--- a/libc/test.yaml
+++ b/libc/test.yaml
@@ -15,6 +15,11 @@ test:
       targets:
         value: [armv7m4-stm32l4x6-nucleo]
 
+    - name: scanf
+      execute: test-libc-scanf
+      targets:
+        include: [host-generic-pc]
+
     - name: pthread
       execute: test-libc-pthread
       targets:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
JIRA: CI-356 

## Motivation and Context
Enabled test because of fix :  Scanf doesn't read 0x0 as null pointer #677 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu, armv7a9-zynq7000-zedboard.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
