### PR TITLE
psh: increase login timeout to 2s + fixes in test-auth

### DIFF
--- a/psh/test-auth.py
+++ b/psh/test-auth.py
@@ -53,18 +53,18 @@ def harness(p):
 
     # Wrong credentials
     assert_auth(p)
-    logintools.assert_login_fail(p, cred_ok.user, cred_bad.passwd, expect_psh_afterwards=True)
+    logintools.assert_auth_fail(p, cred_ok.user, cred_bad.passwd)
 
     assert_auth(p)
-    logintools.assert_login_fail(p, cred_bad.user, cred_ok.passwd, expect_psh_afterwards=True)
+    logintools.assert_auth_fail(p, cred_bad.user, cred_ok.passwd)
     assert_auth(p)
-    logintools.assert_login_fail(p, cred_bad.user, cred_bad.passwd, expect_psh_afterwards=True)
+    logintools.assert_auth_fail(p, cred_bad.user, cred_bad.passwd)
 
     # Empty Credentials
     assert_auth(p)
-    logintools.assert_login_fail(p, cred_ok.user, cred_empty.passwd, expect_psh_afterwards=True)
+    logintools.assert_auth_fail(p, cred_ok.user, cred_empty.passwd)
     assert_auth(p)
-    logintools.assert_login_fail(p, cred_bad.user, cred_empty.passwd, expect_psh_afterwards=True)
+    logintools.assert_auth_fail(p, cred_bad.user, cred_empty.passwd)
     assert_auth(p)
     logintools.assert_login_empty(p, cred_empty.user)
     p.send(EOT)  # assert_login_empty() with empty login does not go back to psh, exit needed
@@ -75,7 +75,7 @@ def harness(p):
     assert_auth(p)
     p.send(printables + '\n')
     assert p.expect_exact(['Login:', pexpect.TIMEOUT]) == 0, 'Long login does not repeat login procedure'
-    logintools.assert_login_fail(p, cred_ok.user, printables)  # too long password
+    logintools.assert_auth_fail(p, cred_ok.user, printables)  # too long password
 
     # Test backspace
     assert_auth(p)
@@ -89,3 +89,4 @@ def harness(p):
         p.send(BACKSPACE)
     p.send(cred_ok.passwd + '\n')
     psh.assert_prompt(p, msg='Login should pass but failed', timeout=1)
+    psh.assert_cmd_successed(p)

--- a/psh/test-pshlogin.py
+++ b/psh/test-pshlogin.py
@@ -45,13 +45,13 @@ def harness(p):
     assert_pshlogin(p)
 
     # Wrong credentials
-    logintools.assert_login_fail(p, cred_ok_etc.user, cred_bad.passwd)  # good login, wrong password
-    logintools.assert_login_fail(p, cred_bad.user, cred_ok_etc.passwd)  # bad login, good password
-    logintools.assert_login_fail(p, cred_bad.user, cred_bad.passwd)  # bad login, bad password
+    logintools.assert_pshlogin_fail(p, cred_ok_etc.user, cred_bad.passwd)  # good login, wrong password
+    logintools.assert_pshlogin_fail(p, cred_bad.user, cred_ok_etc.passwd)  # bad login, good password
+    logintools.assert_pshlogin_fail(p, cred_bad.user, cred_bad.passwd)  # bad login, bad password
 
     # Empty Credentials
-    logintools.assert_login_fail(p, cred_ok_etc.user, cred_empty.passwd)  # good login, empty password
-    logintools.assert_login_fail(p, cred_bad.user, cred_empty.passwd)  # bad login, empty password
+    logintools.assert_pshlogin_fail(p, cred_ok_etc.user, cred_empty.passwd)  # good login, empty password
+    logintools.assert_pshlogin_fail(p, cred_bad.user, cred_empty.passwd)  # bad login, empty password
     logintools.assert_login_empty(p, cred_empty.user)  # empty login, good password
 
     # Good login, new psh is created
@@ -62,7 +62,7 @@ def harness(p):
     psh.assert_prompt(p)
 
     assert_pshlogin(p)
-    logintools.assert_login_fail(p, cred_ok.user, cred_bad.passwd)
+    logintools.assert_pshlogin_fail(p, cred_ok.user, cred_bad.passwd)
     logintools.assert_login(p, cred_ok.user, cred_ok.passwd)
 
     p.send(EOT)
@@ -72,7 +72,7 @@ def harness(p):
     assert_pshlogin(p)
     p.send(string.printable + '\n')
     assert p.expect_exact(['Login:', pexpect.TIMEOUT], timeout=2) == 0, 'Long login does not repeat login procedure'
-    logintools.assert_login_fail(p, cred_ok.user, string.printable)  # too long password
+    logintools.assert_pshlogin_fail(p, cred_ok.user, string.printable)  # too long password
 
     # Proper login to go back to psh
     logintools.assert_login(p, cred_ok_etc.user, cred_ok_etc.passwd)

--- a/psh/test.yaml
+++ b/psh/test.yaml
@@ -12,9 +12,6 @@ test:
 
         - name: auth
           harness: test-auth.py
-          # issue https://github.com/phoenix-rtos/phoenix-rtos-project/issues/860
-          targets:
-              exclude: [riscv64-generic-qemu]
 
         #FIXME - test-pshlogin.py is only for targets with root
         - name: pshlogin

--- a/psh/tools/login.py
+++ b/psh/tools/login.py
@@ -33,13 +33,20 @@ def log_in(p, login, passwd):
 def assert_login(p, login, passwd):
     log_in(p, login, passwd)
     psh.assert_prompt(p, msg='Login should pass but failed (or hasn\'t been completed in 2s)', timeout=2)
+    psh.assert_cmd_successed(p)
 
 
-def assert_login_fail(p, login, passwd, expect_psh_afterwards=False):
+def assert_pshlogin_fail(p, login, passwd):
     log_in(p, login, passwd)
-    psh.assert_prompt_fail(p, msg='Login should fail but passed in 2s', timeout=2)
-    if expect_psh_afterwards:
-        psh.assert_prompt(p, msg='Login should pass but failed')
+    # prompt should not been seen after passing wrong data when logging in using pshapp
+    psh.assert_prompt_fail(p, msg='Login should fail but passed (prompt appeared in 2s)', timeout=2)
+
+
+def assert_auth_fail(p, login, passwd):
+    log_in(p, login, passwd)
+    # prompt should been seen even after passing wrong data when logging in using auth applet
+    psh.assert_prompt(p, 'Prompt not seen after an attempt to log in')
+    psh.assert_cmd_failed(p)
 
 
 def assert_login_empty(p, login):

--- a/psh/tools/login.py
+++ b/psh/tools/login.py
@@ -32,12 +32,12 @@ def log_in(p, login, passwd):
 
 def assert_login(p, login, passwd):
     log_in(p, login, passwd)
-    psh.assert_prompt(p, msg='Login should pass but failed', timeout=1)
+    psh.assert_prompt(p, msg='Login should pass but failed (or hasn\'t been completed in 2s)', timeout=2)
 
 
 def assert_login_fail(p, login, passwd, expect_psh_afterwards=False):
     log_in(p, login, passwd)
-    psh.assert_prompt_fail(p, msg='Login should fail but passed', timeout=1)
+    psh.assert_prompt_fail(p, msg='Login should fail but passed in 2s', timeout=2)
     if expect_psh_afterwards:
         psh.assert_prompt(p, msg='Login should pass but failed')
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As the sleep in psh_run() will be increased, this change is needed.

JIRA: CI-361

https://github.com/phoenix-rtos/phoenix-rtos-project/issues/860

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
