### PR TITLE
trunner: provide traceback for internal exceptions when waiting for plo

### DIFF
--- a/trunner/harness/base.py
+++ b/trunner/harness/base.py
@@ -62,6 +62,11 @@ class ProcessError(HarnessError):
             err.extend([bold("OUTPUT:"), self.output])
 
         err.extend(self._format_additional_info())
+
+        if self.traceback:
+            err.append(bold("TRACEBACK:"))
+            err.extend([self.traceback])
+
         err.append("")
         return "\n".join(err)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

Before:
![Screenshot from 2023-10-16 10-42-39](https://github.com/phoenix-rtos/phoenix-rtos-tests/assets/77304431/55da5b7e-4607-4881-9525-0a0901aa7613)

After:
![Screenshot from 2023-10-25 11-56-48](https://github.com/phoenix-rtos/phoenix-rtos-tests/assets/77304431/58525333-1436-4c84-b406-7fe4ccd4cf64)

The mentioned issue has been described on Confluence in Github Known Issues - point 2.5.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Provide more information about internal serial exceptions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
