### PR TITLE
fix touch tests

### DIFF
--- a/psh/test-touch-rootfs.py
+++ b/psh/test-touch-rootfs.py
@@ -12,7 +12,7 @@
 # %LICENSE%
 
 import psh.tools.psh as psh
-from psh.tools.common import assert_mtime
+from psh.tools.common import assert_dir_mtimes
 
 
 def assert_bin(p):
@@ -29,7 +29,7 @@ def assert_bin(p):
         msg = f"Prompt hasn't been seen after touching the following file: {file_path}"
         psh.assert_cmd(p, f'touch {file_path}', result='success', msg=msg)
 
-    assert_mtime(p, dates, '/bin')
+    assert_dir_mtimes(p, dates, '/bin')
 
 
 @psh.run

--- a/psh/test-touch-rootfs.py
+++ b/psh/test-touch-rootfs.py
@@ -18,7 +18,9 @@ from psh.tools.common import assert_dir_mtimes
 def assert_bin(p):
     ''' Asserts that all files in /bin are able to be touched'''
     dates = {}
-    for file_info in psh.ls(p, 'bin'):
+    # Due to the long execution time on zynq-qemu target (especially during CI) after reboot timeout is increased
+    # https://github.com/phoenix-rtos/phoenix-rtos-project/issues/893
+    for file_info in psh.ls(p, 'bin', timeout=40):
         # If file has multiple links, dates of all linked files will change when one is touched
         if file_info.n_links > 1:
             continue

--- a/psh/tools/psh.py
+++ b/psh/tools/psh.py
@@ -53,7 +53,7 @@ def _check_result(pexpect_proc, result):
                         'Please choose between susccess/fail/dont-check')))
 
 
-def assert_cmd(pexpect_proc, cmd, *, expected='', result='success', msg='', is_regex=False):
+def assert_cmd(pexpect_proc, cmd, *, expected='', result='success', msg='', is_regex=False, timeout=-1):
     ''' Sends specified command and asserts that it's displayed correctly
     with optional expected output and next prompt. Exit status is asserted depending on `result`'''
     pexpect_proc.sendline(cmd)
@@ -72,7 +72,7 @@ def assert_cmd(pexpect_proc, cmd, *, expected='', result='success', msg='', is_r
     exp_readable = _readable(exp_regex)
     msg = f'Expected output regex was: \n---\n{exp_readable}\n---\n' + msg
 
-    assert pexpect_proc.expect([exp_regex, pexpect.TIMEOUT, pexpect.EOF]) == 0, msg
+    assert pexpect_proc.expect([exp_regex, pexpect.TIMEOUT, pexpect.EOF], timeout=timeout) == 0, msg
 
     _check_result(pexpect_proc, result)
 
@@ -180,9 +180,9 @@ def date(pexpect_proc):
     return datetime(*map(int, m.groups()))
 
 
-def ls(pexpect_proc, dir=''):
+def ls(pexpect_proc, dir='', timeout=-1):
     ''' Returns the list with named tuples containing information about files present in the specified directory
-    Alternatively, the list with only 1 file is returned providing file path has been passed.'''
+    Alternatively, the list with only 1 file is returned providing file path has been passed. '''
 
     current_year = date(pexpect_proc).year
     _send(pexpect_proc, f'ls -la {dir}')
@@ -191,7 +191,7 @@ def ls(pexpect_proc, dir=''):
 
     files = []
     while True:
-        idx = pexpect_proc.expect([r'\(psh\)\% ', r'([^\r\n]+(\r+\n))'])
+        idx = pexpect_proc.expect([r'\(psh\)\% ', r'([^\r\n]+(\r+\n))'], timeout=timeout)
         if idx == 0:
             break
 

--- a/psh/tools/psh.py
+++ b/psh/tools/psh.py
@@ -31,6 +31,9 @@ CONTROL_CODE = r'(\x1b\[[\x30-\x3F]*[\x20-\x2F]*[\x40-\x7E])'
 OPTIONAL_CONTROL_CODE = CONTROL_CODE + r'?'
 
 
+File = namedtuple('File', ['name', 'owner', 'is_dir', 'datetime', 'datetime_resolution', 'n_links'])
+
+
 def _readable(exp_regex):
     ''' Gets more readable expected regex with new lines instead of raw string EOL,
     and prompt without raw esc sequences. '''
@@ -178,8 +181,8 @@ def date(pexpect_proc):
 
 
 def ls(pexpect_proc, dir=''):
-    ''' Returns the list with named tuples containing information about files present in the specified directory '''
-    File = namedtuple('File', ['name', 'owner', 'is_dir', 'datetime', 'datetime_resolution', 'n_links'])
+    ''' Returns the list with named tuples containing information about files present in the specified directory
+    Alternatively, the list with only 1 file is returned providing file path has been passed.'''
 
     current_year = date(pexpect_proc).year
     _send(pexpect_proc, f'ls -la {dir}')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

 - psh: assert devs mtimes right after touch in touch tests
 - psh: icrease timeout for ls on bin dir in touch-rootfs test

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

1.
    The mtime of some devices (for example /dev/console) may change.
    The previous approach asserted modification times of the the whole directory after touching all the files, which took some time.
    Within this period of time files could have been accessed by another process.
    
2.
    On zynq7000-qemu target the execution time of ls on this directory right after system startup is increased.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
