### PR TITLE
trunner: armv7a9: increase timeout for erase

### DIFF
--- a/trunner/target/armv7a9.py
+++ b/trunner/target/armv7a9.py
@@ -132,7 +132,7 @@ class Zynq7000ZedboardTarget(ARMv7A9Target):
             block_size=0x10000,
             cleanmarker_size=0x10,
         ),
-        timeout=140,
+        timeout=210,
     )
     name = "armv7a9-zynq7000-zedboard"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Increase timeout on Jffs2 according to documentation

## Motivation and Context
On our test targets, we can find Spansion s25fl256s1 32 MB nor flash(2.0)

And to erase we use 64/4 kb sector erase, according to documentation on that Spansion chip:
![image](https://github.com/phoenix-rtos/phoenix-rtos-tests/assets/49757239/3aae161c-b8ec-497c-9175-be71003f577c)

After quick calculation (((32768÷64)×0,65)÷60) where we divide space on flash by 64 kb and multiply that by time (max time in secs) and divide again to gain minutes we get ~ 5.54 min to erase whole flash memory (without time passing from sector to sector)

We increased timeout something above half this value to be certain that Jffs2 will have enough time, but also if time will exceed, we will know about some changes in this case.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [X] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing linter checks and tests passed.
- [X] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
