### PR TITLE
mbedtls|busybox: fix measuring test duration (trunner API change approach)

### DIFF
--- a/busybox/busybox.py
+++ b/busybox/busybox.py
@@ -17,6 +17,7 @@ EXAMPLE_INPUT = """
 echo -ne '' >input
 echo -ne '' | ./unknown 2>&1
 SKIPPED: busybox --help
+UNTESTED: cp-parents
 PASS: busybox as unknown name
 ---Testcase 'date-@-works' starting---
 FAIL: date-@-works
@@ -36,7 +37,7 @@ def harness(dut: Dut, ctx: TestContext, result: TestResult):
     test_status = Status.OK
 
     START = r"---Testcase '(?P<name>.+?)' starting---\r+\n"
-    RESULT = r"(?P<status>PASS|SKIPPED|FAIL): (?P<name>.+?)\r+\n"
+    RESULT = r"(?P<status>PASS|SKIPPED|UNTESTED|FAIL): (?P<name>.+?)\r+\n"
     FINAL = r"\*\*\*\*(The Busybox Test Suite completed|A single test of the Busybox Test Suite completed)\*\*\*\*\r+\n"
     MESSAGE = r"(?P<line>.*?)\r+\n"
 

--- a/busybox/busybox.py
+++ b/busybox/busybox.py
@@ -9,7 +9,25 @@
 
 from trunner.ctx import TestContext
 from trunner.dut import Dut
-from trunner.types import TestResult, TestSubResult, Status
+from trunner.types import TestResult, Status
+
+
+EXAMPLE_INPUT = """
+---Testcase 'busybox as unknown name' starting---
+echo -ne '' >input
+echo -ne '' | ./unknown 2>&1
+SKIPPED: busybox --help
+PASS: busybox as unknown name
+---Testcase 'date-@-works' starting---
+FAIL: date-@-works
++ TZ=EET-2EEST,M3.5.0/3,M10.5.0/4 busybox date -d @1288486799
++ test xSun Oct 31 03:59:59 EEST 2010 = xSun Oct 31 00:59:59  2010
+---Testcase 'date-R-works' starting---
+PASS: date-R-works
+---Testcase 'bunzip2: doesnt exist' starting---
+- t_actual differ: char 13, line 1
+FAIL: bunzip2: doesnt exist
+"""
 
 
 def harness(dut: Dut, ctx: TestContext, result: TestResult):
@@ -17,31 +35,39 @@ def harness(dut: Dut, ctx: TestContext, result: TestResult):
     msg = []
     test_status = Status.OK
 
+    START = r"---Testcase '(?P<name>.+?)' starting---\r+\n"
     RESULT = r"(?P<status>PASS|SKIPPED|FAIL): (?P<name>.+?)\r+\n"
     FINAL = r"\*\*\*\*(The Busybox Test Suite completed|A single test of the Busybox Test Suite completed)\*\*\*\*\r+\n"
     MESSAGE = r"(?P<line>.*?)\r+\n"
 
     while True:
-        idx = dut.expect([RESULT, FINAL, MESSAGE], timeout=90)
+        idx = dut.expect([START, RESULT, FINAL, MESSAGE], timeout=90)
         parsed = dut.match.groupdict()
 
-        if idx == 2:
-            msg.append("\t\t" + parsed["line"])
+        if idx == 0:
+            subresult = None
             continue
 
-        if subresult:
-            # We ended processing test result and message
-            if msg and subresult.status == Status.FAIL:
+        if idx == 3:
+            # "\n\t\t" used to create more readable multiline message when printed
+            line_msg = "\n\t\t" + parsed["line"]
+            # append extra message to the last test (if available)
+            if subresult and subresult.status == Status.FAIL:
+                subresult.msg += line_msg
+            else:
+                # message may also appear during the test
+                msg.append(line_msg)
+
+        if idx == 1:
+            status = Status.from_str(parsed["status"])
+
+            if status == Status.FAIL:
                 test_status = Status.FAIL
-                subresult.msg = "\n".join(msg)
-                msg = []
 
-            result.add_subresult_obj(subresult)
-            subresult = None
+            subresult = result.add_subresult(subname=parsed["name"], status=status, msg="".join(msg))
+            msg.clear()
 
-        if idx == 0:
-            subresult = TestSubResult(subname=parsed["name"], status=Status.from_str(parsed["status"]))
-        elif idx == 1:
+        elif idx == 2:
             break
 
     return TestResult(status=test_status)

--- a/mbedtls/mbedtls.py
+++ b/mbedtls/mbedtls.py
@@ -4,6 +4,15 @@ from trunner.ctx import TestContext
 from trunner.dut import Dut
 from trunner.types import TestResult, Status
 
+EXAMPLE_INPUT = """
+MPS Reader: Single step, single round, pausing disabled ........... ----
+Context init-free-init-free ....................................... PASS
+net_poll beyond FD_SETSIZE ........................................ FAILED
+  dup2( got_fd, wanted_fd ) >= 0
+  at line 39, suites/test_suite_net.function
+OID get Any Policy certificate policy ............................. PASS
+"""
+
 
 def harness(dut: Dut, ctx: TestContext, result: TestResult):
     subresult = None

--- a/trunner/types.py
+++ b/trunner/types.py
@@ -38,7 +38,7 @@ class Status(Enum):
             return Status.FAIL
         if s in ("OK", "PASS", "PASSED"):
             return Status.OK
-        if s in ("SKIP", "SKIPPED", "IGNORE", "IGNORED"):
+        if s in ("SKIP", "SKIPPED", "IGNORE", "IGNORED", "UNTESTED"):
             return Status.SKIP
 
         raise ValueError(f"Cannot create {cls.__name__} from string {s}")

--- a/trunner/types.py
+++ b/trunner/types.py
@@ -200,7 +200,10 @@ class TestResult:
         self._init_subresult()
 
     def add_subresult(self, subname: str, status: Status, msg: str = ""):
-        """add sub-testcase result (use for composite tests)"""
+        """Add sub-testcase result (use for composite tests).
+
+        Returns subresult object which can be modified at a later time.
+        """
         subresult = self._curr_subresult
         subresult.set_stage(TestStage.DONE)
         subresult.msg = msg
@@ -208,10 +211,7 @@ class TestResult:
         subresult.subname = subname
 
         self._commit_subresult()
-
-    def add_subresult_obj(self, subresult: TestSubResult):
-        """add sub-testcase result by TetSubResult object"""
-        self.add_subresult(subresult.subname, subresult.status, subresult.msg)
+        return subresult
 
     def is_fail(self):
         return self.status == Status.FAIL


### PR DESCRIPTION

## Description
- mbedtls: fix measuring test duration
  The subtest result was incorrectly "finished" (added to result) one line after
  the result (so actually computed the time of the next test).

  Use simplified API to add optional test message to the correct subtest

- trunner: make subresult API more robust
  - remove add_subresult_obj() as it's misleading (doesn't add by reference,
  just by value
  - make add_subresult() return the subresult object which can be updated at a
  later time

## Motivation and Context
phoenix-rtos/phoenix-rtos-project#877

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
