### PR TITLE
introduce sleep afer soft reset

### DIFF
--- a/trunner/harness/base.py
+++ b/trunner/harness/base.py
@@ -82,6 +82,8 @@ class Rebooter:
         time.sleep(0.05)
         self.dut.clear_buffer()
         self.host.set_reset(1)
+        # delay needed for plo usb device to disappear
+        time.sleep(0.25)
 
     def _reboot_hard(self):
         self.host.set_power(False)

--- a/trunner/tools/phoenix.py
+++ b/trunner/tools/phoenix.py
@@ -116,9 +116,6 @@ class Phoenixd:
     def _run(self):
         try:
             self.port = wait_for_vid_pid(self.vid, self.pid, timeout=10)
-            # such wait avoids a following issue with loading an app:
-            # https://github.com/phoenix-rtos/phoenix-rtos-project/issues/545
-            time.sleep(0.5)
         except (TimeoutError, Exception) as exc:
             raise PhoenixdError(str(exc)) from exc
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

 - trunner: apply delay after soft reset
 - trunner: remove workaround with sleep in phoenix.py

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

plo usb device disappears after some time, not at once after the reset, especially on imxrt117x target

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (30 full test campaigns on imxrt117x).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
