### PR TITLE
libc/pthread: add tests for pthread_cleanup

### DIFF
--- a/libc/pthread/main.c
+++ b/libc/pthread/main.c
@@ -19,6 +19,7 @@
 void runner(void)
 {
 	RUN_TEST_GROUP(test_pthread_cond);
+	RUN_TEST_GROUP(test_pthread_cleanup);
 }
 
 


### PR DESCRIPTION
JIRA: RTOS-671

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
add tests for `pthread_cleanup`
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work https://github.com/phoenix-rtos/libphoenix/pull/309
- [ ] I will merge this PR by myself when appropriate.
