### PR TITLE
libc: Add missing asserts for malloc

### DIFF
--- a/libc/stdio/stdio_file.c
+++ b/libc/stdio/stdio_file.c
@@ -4,7 +4,7 @@
  * libc-tests
  *
  * libphoenix functions tests from stdio/file.c
- * 
+ *
  * TESTED:
  * fopen, fclose, fdopen, freopen,
  * fwrite, fread,
@@ -17,7 +17,7 @@
  * fileno, feof, remove,
  * ferror, clearerr,
  * setvbuf, setbuf, fflush,
- * 
+ *
  * UNTESTED:
  * puts, gets < needs writing to stdin/unimplemented
  * popen, pclose, tmpfile < not usable on all targets
@@ -51,7 +51,7 @@ static FILE *filep, *filep2;
 static const char teststr[] = "test_string_123";
 static char toolongpath[PATH_MAX + 16];
 
-/* 
+/*
 Tets group for:
 fopen, fclose,
 fdopen, freopen
@@ -143,7 +143,7 @@ TEST(stdio_fopenfclose, stdio_fopenfclose_wrongflags)
 	assert_fopen_error(STDIO_TEST_FILENAME, "", EINVAL);
 	assert_fopen_error(STDIO_TEST_FILENAME, "phoenix-rtos", EINVAL);
 	// FIXME: invalid test, function argument defined as nonnull
-	//assert_fopen_error(STDIO_TEST_FILENAME, NULL, EINVAL);
+	// assert_fopen_error(STDIO_TEST_FILENAME, NULL, EINVAL);
 }
 
 TEST(stdio_fopenfclose, stdio_fopenfclose_toolongname)
@@ -213,7 +213,7 @@ TEST_GROUP_RUNNER(stdio_fopenfclose)
 }
 
 
-/* 
+/*
 Tets group for:
 - fwrite, fread
 - putc, fputc,
@@ -374,11 +374,11 @@ TEST(stdio_getput, getsputs_basic)
 
 IGNORE_TEST(stdio_getput, getsputs_readonly)
 {
-	/* 
-	Upon successful completion, fputc() shall return the value it has written. 
-	Otherwise, it shall return EOF, the error indicator for the stream shall be set 
-	and errno shall be set to indicate the error. 
-	
+	/*
+	Upon successful completion, fputc() shall return the value it has written.
+	Otherwise, it shall return EOF, the error indicator for the stream shall be set
+	and errno shall be set to indicate the error.
+
 	https://github.com/phoenix-rtos/phoenix-rtos-project/issues/260
 	*/
 
@@ -420,8 +420,8 @@ TEST(stdio_getput, ungetc_basic)
 	assert_fclosed(&filep);
 
 	/*	EOF pushback test
-		If the value of c equals that of the macro EOF, 
-		the operation shall fail and the input stream shall be left unchanged. 
+		If the value of c equals that of the macro EOF,
+		the operation shall fail and the input stream shall be left unchanged.
 	*/
 	filep = fopen(STDIO_TEST_FILENAME, "r");
 	TEST_ASSERT_NOT_NULL(filep);
@@ -609,7 +609,7 @@ TEST_GROUP_RUNNER(stdio_line)
 }
 
 
-/* 
+/*
 Test group for:
 fseek, fseeko, fsetpos(), rewind()
 ftell, ftello

--- a/libc/stdio/stdio_file.c
+++ b/libc/stdio/stdio_file.c
@@ -558,6 +558,7 @@ TEST(stdio_line, getline_allocated)
 	TEST_ASSERT_NOT_NULL(filep);
 	{
 		line = malloc(len);
+		TEST_ASSERT_NOT_NULL(line);
 		rewind(filep);
 		TEST_ASSERT_EQUAL_INT(6, getline(&line, &len, filep));
 		TEST_ASSERT_EQUAL_INT(50, len);

--- a/libc/string/string_cmp.c
+++ b/libc/string/string_cmp.c
@@ -78,6 +78,8 @@ TEST(string_memcmp, emptyInput)
 	char *asciiSet = testdata_createCharStr(BUFF_SIZE),
 		 separated[] = "\0\0\0\0\0TEST\0\0";
 
+	TEST_ASSERT_NOT_NULL(asciiSet);
+
 	asciiSet[0] = 0;
 
 	TEST_ASSERT_LESS_THAN_INT(0, memcmp(empty, asciiSet, sizeof(empty)));
@@ -95,6 +97,8 @@ TEST(string_memcmp, big)
 {
 	char *hugeStr = testdata_createCharStr(BIG_SIZE),
 		 hugeStr2[BIG_SIZE];
+
+	TEST_ASSERT_NOT_NULL(hugeStr);
 
 	memcpy(hugeStr2, hugeStr, BIG_SIZE);
 
@@ -118,6 +122,8 @@ TEST(string_memcmp, various_sizes)
 
 	char *asciiStr = testdata_createCharStr(BUFF_SIZE),
 		 asciiStr2[BUFF_SIZE];
+
+	TEST_ASSERT_NOT_NULL(asciiStr);
 
 	memcpy(asciiStr2, asciiStr, sizeof(asciiStr2));
 	for (i = 1; i < BUFF_SIZE - 1; i++) {
@@ -205,6 +211,8 @@ TEST(string_strncmp, emptyInput)
 	char *asciiStr = testdata_createCharStr(BUFF_SIZE),
 		 separated[] = "\0\0\0\0\0TEST\0\0";
 
+	TEST_ASSERT_NOT_NULL(asciiStr);
+
 	TEST_ASSERT_EQUAL_INT(0, strncmp(empty, empty, BUFF_SIZE));
 	TEST_ASSERT_LESS_THAN_INT(0, strncmp(empty, asciiStr, BUFF_SIZE));
 	TEST_ASSERT_GREATER_THAN_INT(0, strncmp(asciiStr, empty, BUFF_SIZE));
@@ -220,6 +228,8 @@ TEST(string_strncmp, big)
 {
 	char *hugeStr = testdata_createCharStr(BIG_SIZE),
 		 hugeStr2[BIG_SIZE];
+
+	TEST_ASSERT_NOT_NULL(hugeStr);
 
 	memcpy(hugeStr2, hugeStr, BIG_SIZE);
 
@@ -243,6 +253,8 @@ TEST(string_strncmp, various_sizes)
 
 	char *asciiStr = testdata_createCharStr(BUFF_SIZE),
 		 asciiStr2[BUFF_SIZE];
+
+	TEST_ASSERT_NOT_NULL(asciiStr);
 
 	memcpy(asciiStr2, asciiStr, sizeof(asciiStr2));
 	for (i = 1; i < BUFF_SIZE - 1; i++) {
@@ -332,6 +344,8 @@ TEST(string_strcmp, emptyInput)
 	char *asciiStr = testdata_createCharStr(BUFF_SIZE),
 		 separated[] = "\0\0\0\0\0TEST\0\0";
 
+	TEST_ASSERT_NOT_NULL(asciiStr);
+
 	TEST_ASSERT_LESS_THAN_INT(0, strcmp(empty, asciiStr));
 	TEST_ASSERT_GREATER_THAN_INT(0, strcmp(asciiStr, empty));
 	TEST_ASSERT_EQUAL_INT(0, strcmp(empty, empty));
@@ -347,6 +361,8 @@ TEST(string_strcmp, big)
 {
 	char *hugeStr = testdata_createCharStr(BIG_SIZE),
 		 hugeStr2[BIG_SIZE];
+
+	TEST_ASSERT_NOT_NULL(hugeStr);
 
 	memcpy(hugeStr2, hugeStr, BIG_SIZE);
 
@@ -431,6 +447,8 @@ TEST(string_strcoll, emptyInput)
 	char *asciiStr = testdata_createCharStr(BUFF_SIZE),
 		 separated[] = "\0\0\0\0\0TEST\0\0";
 
+	TEST_ASSERT_NOT_NULL(asciiStr);
+
 	TEST_ASSERT_EQUAL_INT(0, strcoll(empty, empty));
 	TEST_ASSERT_LESS_THAN_INT(0, strcoll(empty, asciiStr));
 	TEST_ASSERT_GREATER_THAN_INT(0, strcoll(asciiStr, empty));
@@ -446,6 +464,8 @@ TEST(string_strcoll, big)
 {
 	char *hugeStr = testdata_createCharStr(BIG_SIZE),
 		 hugeStr2[BIG_SIZE];
+
+	TEST_ASSERT_NOT_NULL(hugeStr);
 
 	memcpy(hugeStr2, hugeStr, BIG_SIZE);
 

--- a/libc/string/string_cpy.c
+++ b/libc/string/string_cpy.c
@@ -282,6 +282,9 @@ TEST(string_memccpy, stop_char_found)
 	int i;
 
 	testStr = testdata_createCharStr(ALL_CHARS_STRING_SIZE);
+
+	TEST_ASSERT_NOT_NULL(testStr);
+
 	/* 1 skipped, because of double one at the beginning of testStr */
 	for (i = 2; i < ALL_CHARS_STRING_SIZE; i++) {
 		TEST_ASSERT_EQUAL_PTR(&bigStrDest[i + 1], memccpy(bigStrDest, testStr, testStr[i], ALL_CHARS_STRING_SIZE));
@@ -310,6 +313,9 @@ TEST(string_memccpy, stop_int_found)
 
 	/* testing all possible chars + 1 byte for NUL term */
 	testStr = testdata_createCharStr(ALL_CHARS_STRING_SIZE);
+
+	TEST_ASSERT_NOT_NULL(testStr);
+
 	for (i = 0; i < intsNr; i++) {
 		if ((unsigned char)bigIntDest[i] != 1) {
 			pos = (unsigned char)bigIntDest[i] + 1;
@@ -497,6 +503,9 @@ TEST(string_memccpy, big)
 
 	/* Checking capability of handling big blocks of data */
 	longStr = testdata_createCharStr(BIG_NUMB);
+
+	TEST_ASSERT_NOT_NULL(longStr);
+
 	TEST_ASSERT_EQUAL_PTR(&buff[sizeof(buff)], memccpy(buff, longStr, 0, BIG_NUMB));
 	TEST_ASSERT_EQUAL_CHAR_ARRAY(buff, longStr, BIG_NUMB);
 
@@ -669,6 +678,8 @@ TEST(string_strncpy, big)
 
 	longStr = testdata_createCharStr(BIG_NUMB);
 
+	TEST_ASSERT_NOT_NULL(longStr);
+
 	/* Ability to copy long string */
 	TEST_ASSERT_EQUAL_PTR(bigBuff, strncpy(bigBuff, longStr, sizeof(bigBuff) - 1));
 	TEST_ASSERT_EQUAL_CHAR_ARRAY(bigBuff, longStr, sizeof(bigBuff));
@@ -685,6 +696,8 @@ TEST(string_strncpy, append_null)
 	int i;
 
 	testStr = testdata_createCharStr(BIG_NUMB);
+
+	TEST_ASSERT_NOT_NULL(testStr);
 
 	/* Creating string without null terminators */
 	for (i = 0; i < BIG_NUMB / 2 - 1; i++) {
@@ -925,6 +938,8 @@ TEST(string_stpncpy, big)
 
 	longStr = testdata_createCharStr(BIG_NUMB);
 
+	TEST_ASSERT_NOT_NULL(longStr);
+
 	/* Ability to copy long string */
 	TEST_ASSERT_EQUAL_PTR(&bigBuff[strlen(longStr)], stpncpy(bigBuff, longStr, sizeof(bigBuff) - 1));
 	TEST_ASSERT_EQUAL_CHAR_ARRAY(bigBuff, longStr, sizeof(bigBuff));
@@ -948,6 +963,8 @@ TEST(string_stpncpy, append_null)
 	int i;
 
 	testStr = testdata_createCharStr(BIG_NUMB);
+
+	TEST_ASSERT_NOT_NULL(testStr);
 
 	/* Creating string without null terminators */
 	for (i = 0; i < BIG_NUMB / 2 - 1; i++) {
@@ -1154,6 +1171,8 @@ TEST(string_strcpy_stpcpy, big)
 	char *longStr;
 
 	longStr = testdata_createCharStr(BIG_NUMB);
+
+	TEST_ASSERT_NOT_NULL(longStr);
 
 	/* Ability to copy long string */
 	TEST_ASSERT_EQUAL_PTR(bigBuff, strcpy(bigBuff, longStr));

--- a/libc/string/string_lenchr.c
+++ b/libc/string/string_lenchr.c
@@ -61,6 +61,8 @@ TEST(string_len, ascii)
 	TEST_ASSERT_EQUAL_INT(0, strlen(""));
 	asciiSet = testdata_createCharStr(BUFF_SIZE + 1);
 
+	TEST_ASSERT_NOT_NULL(asciiSet);
+
 	/* Pangram with a whole alphabet set */
 	len = sizeof(pangram) - 1;
 	TEST_ASSERT_EQUAL_INT(len, strlen(pangram));
@@ -188,6 +190,7 @@ TEST(string_spn, ascii)
 
 	asciiStr = testdata_createCharStr(BUFF_SIZE + 1);
 
+	TEST_ASSERT_NOT_NULL(asciiStr);
 
 	for (i = 1; i < BUFF_SIZE; i++) {
 		supportCharSet[i - 1] = i;
@@ -310,6 +313,8 @@ TEST(string_spn, mixed_order)
 		*testStr;
 
 	testStr = testdata_createCharStr(BUFF_SIZE);
+
+	TEST_ASSERT_NOT_NULL(testStr);
 
 	TEST_ASSERT_NOT_NULL(reversStr);
 
@@ -470,6 +475,9 @@ TEST(string_chr, ascii)
 	char *asciiStr;
 
 	asciiStr = testdata_createCharStr(INT8_MAX + 1);
+
+	TEST_ASSERT_NOT_NULL(asciiStr);
+
 	len = INT8_MAX;
 
 

--- a/libc/string/string_tokpbrkstr.c
+++ b/libc/string/string_tokpbrkstr.c
@@ -39,6 +39,8 @@ static char *create_extAscii_set(void)
 	int i;
 	char *hold = malloc(EXTENDED_ASCII_LENGTH);
 
+	TEST_ASSERT_NOT_NULL(hold);
+
 	for (i = 1; i < EXTENDED_ASCII_LENGTH; i++) {
 		hold[i - 1] = i;
 	}
@@ -136,6 +138,8 @@ TEST(string_tok, multi_call)
 	char multiCallStr[ASCII_LENGTH] = { 0 };
 	char *asciiStr = testdata_createCharStr(ASCII_LENGTH);
 	int i;
+
+	TEST_ASSERT_NOT_NULL(asciiStr);
 
 	/*
 	 * In this case we are checking if it is possible to
@@ -472,6 +476,8 @@ TEST(string_tok_r, multi_call)
 	char *rest;
 	int i;
 
+	TEST_ASSERT_NOT_NULL(asciiStr);
+
 	/*
 	 * In this case we are checking if it is possible to
 	 * pass different stop points in each call to
@@ -643,6 +649,7 @@ TEST(string_tok_r, same_state)
 		 *asciiStr = testdata_createCharStr(ASCII_LENGTH);
 	int i;
 
+	TEST_ASSERT_NOT_NULL(asciiStr);
 
 	for (i = 0; i < ASCII_LENGTH - 1; i++) {
 		TEST_ASSERT_EQUAL_PTR(&asciiStr[1], strtok_r(&asciiStr[1], &asciiStr[i + 2], &rest[i]));
@@ -709,6 +716,8 @@ TEST(string_str, basic)
 	const char loremIpsum[BUFFSIZE] = LOREM_IPSUM;
 	char *asciiStr = testdata_createCharStr(ASCII_LENGTH);
 
+	TEST_ASSERT_NOT_NULL(asciiStr);
+
 	/* Standard use of strstr on arrays */
 	TEST_ASSERT_EQUAL_PTR(loremIpsum, strstr(loremIpsum, "Lorem"));
 	TEST_ASSERT_EQUAL_PTR(&loremIpsum[6], strstr(loremIpsum, "Ipsum"));
@@ -729,8 +738,9 @@ TEST(string_str, empty_args)
 {
 	const char str[] = "Lorem";
 
-
 	char *asciiStr = testdata_createCharStr(ASCII_LENGTH);
+
+	TEST_ASSERT_NOT_NULL(asciiStr);
 
 	/* Different scenarios of using empty input or output*/
 	TEST_ASSERT_EQUAL_PTR(NULL, strstr("", str));
@@ -768,6 +778,7 @@ TEST(string_str, strstr_order)
 	testStr = testdata_createCharStr(ASCII_LENGTH);
 
 	TEST_ASSERT_NOT_NULL(reversStr);
+	TEST_ASSERT_NOT_NULL(testStr);
 
 	for (i = 0; i < ASCII_LENGTH - 1; i++) {
 		reversStr[i] = testStr[ASCII_LENGTH - i - 2];
@@ -832,6 +843,8 @@ TEST(string_pbrk, basic)
 
 	asciiStr = testdata_createCharStr(ASCII_LENGTH);
 
+	TEST_ASSERT_NOT_NULL(asciiStr);
+
 	TEST_ASSERT_EQUAL_PTR(loremIpsum, strpbrk(loremIpsum, "Lorem"));
 
 	/*
@@ -886,7 +899,7 @@ TEST(string_pbrk, strpbrk_order)
 
 	testStr = testdata_createCharStr(ASCII_LENGTH);
 
-	TEST_ASSERT_NOT_NULL(reversStr);
+	TEST_ASSERT_NOT_NULL(testStr);
 
 	for (i = 0; i < ASCII_LENGTH - 1; i++) {
 		reversStr[i] = testStr[ASCII_LENGTH - i - 2];
@@ -953,6 +966,8 @@ TEST(string_pbrk, not_present)
 	int i;
 	char *asciiStr = testdata_createCharStr(ASCII_LENGTH + 1);
 	char holder[2] = { 0 };
+
+	TEST_ASSERT_NOT_NULL(asciiStr);
 
 	for (i = 1; i < ASCII_LENGTH; i++) {
 		holder[0] = i;


### PR DESCRIPTION
JIRA: CI-386

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes: phoenix-rtos/phoenix-rtos-project#920

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: host-generic-pc / ia32-generic-qemu.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
