### PR TITLE
waitpid: increase wait time

### DIFF
--- a/waitpid/test_waitpid.c
+++ b/waitpid/test_waitpid.c
@@ -42,22 +42,23 @@ TEST(test_waitpid, waitpid_wnohang)
 	int res, i, j;
 	char *const arg[][2] = { { "exec_while_process", NULL }, { "exec_sum_process", NULL } };
 
-	/* 1 iteration for easier problem reproduction, in the future there will be more irerations */
+	/* 1 iteration for easier problem reproduction, in the future there will be more iterations */
 	for (i = 1; i > 0; i--) {
 		for (j = 0; j < 2; j++) {
-			if ((pid[j] = vfork()) < 0) {
+			pid[j] = vfork();
+			if (pid[j] < 0) {
 				fprintf(stderr, "vfork function failed: %s\n", strerror(errno));
 				return;
 			}
 			/* child process j */
-			else if (!pid[j]) {
+			else if (pid[j] == 0) {
 				execv("/bin/test-waitpid", arg[j]);
 				fprintf(stderr, "exec function failed: %s\n", strerror(errno));
 				_exit(EXIT_FAILURE);
 			}
 		}
 		/* wait for process 1 to become a zombie process */
-		usleep(200000);
+		usleep(100000 * 10);
 		res = waitpid(pid[0], NULL, WNOHANG);
 		/* instead of returning 0 at once waitpid function waits for a process state change */
 		TEST_ASSERT_EQUAL_INT(0, res);
@@ -83,17 +84,19 @@ int main(int argc, char *argv[])
 {
 	int sum;
 	if (!strcmp(basename(argv[0]), "exec_while_process")) {
-		while (1)
+		for (;;) {
 			;
+		}
 	}
 	else if (!strcmp(basename(argv[0]), "exec_sum_process")) {
-		if ((sum = 1 + 2) == 3)
+		sum = 1 + 2;
+		if (sum == 3) {
 			usleep(100000);
+		}
 	}
 	else {
-
 		UnityMain(argc, (const char **)argv, runner);
-
-		return 0;
 	}
+
+	return 0;
 }


### PR DESCRIPTION
Dynamically linked binaries take longer to startup hence time increase is needed.
Add missing return to main in exec_sum_process path.

JIRA: RTOS-744

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
