### PR TITLE
test_disk: fix format warning on riscv64

### DIFF
--- a/disk/test_disk.c
+++ b/disk/test_disk.c
@@ -609,7 +609,7 @@ static int test_disk_perfone(int fd, uint64_t offs, uint64_t blocksz, uint64_t n
 
 	printf("| %5sB  | %-5" PRIu64 "  | %6sB/s  | %7sB/s  |\n",
 		test_disk_prefix(2, blocksz, 0, 0, bprefix),
-		2000000ULL * n / ((uint64_t)srtime + (uint64_t)swtime),
+		UINT64_C(2000000) * n / ((uint64_t)srtime + (uint64_t)swtime),
 		test_disk_prefix(2, 1000000ULL * n * blocksz / (uint64_t)srtime, 0, 1, srprefix),
 		test_disk_prefix(2, 1000000ULL * n * blocksz / (uint64_t)swtime, 0, 1, swprefix));
 


### PR DESCRIPTION
JIRA: RTOS-747

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
On riscv64, `uint64_t` is defined as `unsigned long`, not `unsigned long long`.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
