### PR TITLE
trunner: riscv64: enable rootfs

### DIFF
--- a/trunner/target/emulated.py
+++ b/trunner/target/emulated.py
@@ -70,7 +70,7 @@ class IA32GenericQemuTarget(QemuTarget):
 
 class RISCV64GenericQemuTarget(QemuTarget):
     name = "riscv64-generic-qemu"
-    rootfs = False
+    rootfs = True
     experimental = True
 
     def __init__(self):


### PR DESCRIPTION
JIRA: RTOS-734

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Support for rootfs on `riscv64-generic-qemu` has been added.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Test PR: https://github.com/phoenix-rtos/phoenix-rtos-project/pull/987
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `riscv64-generic-qemu`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
