### PR TITLE
psh, libc: fix tests after trailing slash handling change

### DIFF
--- a/libc/misc/stat.c
+++ b/libc/misc/stat.c
@@ -961,10 +961,6 @@ TEST(stat_errno, enoent)
 
 TEST(stat_errno, enotdir)
 {
-/* Disabled on Phoenix-RTOS because of #682 issue: https://github.com/phoenix-rtos/phoenix-rtos-project/issues/682*/
-#ifdef __phoenix__
-	TEST_IGNORE_MESSAGE("#682 issue");
-#endif
 	struct stat buffer;
 
 	errno = 0;

--- a/psh/test-touch.py
+++ b/psh/test-touch.py
@@ -62,10 +62,9 @@ def assert_multi_arg(p, path, random_wrapper: TestRandom):
 
 
 def assert_file_slash(p):
-    """ in psh touch we do not expect error when touching file/ """
     file_path = f'{ROOT_TEST_DIR}/slash_file/'
     assert_file_created(p, file_path)
-    psh.assert_cmd(p, f'touch {file_path}', result='success')
+    psh.assert_cmd(p, f'touch {file_path}', result='fail', expected=f'psh: failed to touch {file_path}: ENOTDIR')
 
 
 def assert_created_dir(p):


### PR DESCRIPTION
Changes to tests after handling of trailing slashes on files was changed: https://github.com/phoenix-rtos/libphoenix/pull/346

## Description
Currently libphoenix allows for trailing slashes to be at the end of a path when the last component is a file (not a directory). This PR re-enables one of the `libc` tests that previously would fail due to this incorrect behavior and changes one of the `psh` tests that previously expected it.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work: https://github.com/phoenix-rtos/libphoenix/pull/346
- [ ] I will merge this PR by myself when appropriate.
