### PR TITLE
libcache: remove variable declarations from header

### DIFF
--- a/libcache/libcache_utils.c
+++ b/libcache/libcache_utils.c
@@ -23,6 +23,9 @@
 #include <unistd.h>
 
 
+int srcMem; /* File descriptor - simulates cached source memory */
+
+
 int test_genCharFile(void)
 {
 	int i, ret = -1;

--- a/libcache/libcache_utils.h
+++ b/libcache/libcache_utils.h
@@ -51,10 +51,7 @@ struct cache_devCtx_s {
 };
 
 
-int srcMem; /* File descriptor - simulates cached source memory */
-uint8_t offBitsNum;
-uint64_t offMask;
-cache_ops_t ops;
+extern int srcMem; /* File descriptor - simulates cached source memory */
 
 
 /* Generates a file that simulates a cached source memory and fills it with random chars */

--- a/libcache/test_libcache.c
+++ b/libcache/test_libcache.c
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <pthread.h>
+#include <stdint.h>
 #include <fcntl.h>
 
 
@@ -29,6 +30,9 @@
 #define LIBCACHE_ADDR_OFF_27 0x239bULL
 #define LIBCACHE_ADDR_INT    0x23f8ULL /* Address with offset divisible by sizeof(int) for proper integer alignment in cache line */
 
+
+static uint64_t offMask;
+static cache_ops_t ops;
 
 TEST_GROUP(test_init);
 
@@ -134,7 +138,7 @@ TEST_SETUP(test_read_write)
 {
 	ops.readCb = test_readCb;
 	ops.writeCb = test_writeCb;
-	offBitsNum = LOG2(LIBCACHE_LINE_SIZE);
+	uint8_t offBitsNum = LOG2(LIBCACHE_LINE_SIZE);
 	offMask = ((uint64_t)1 << offBitsNum) - 1;
 }
 
@@ -678,7 +682,7 @@ TEST_SETUP(test_flush)
 {
 	ops.readCb = test_readCb;
 	ops.writeCb = test_writeCb;
-	offBitsNum = LOG2(LIBCACHE_LINE_SIZE);
+	uint8_t offBitsNum = LOG2(LIBCACHE_LINE_SIZE);
 	offMask = ((uint64_t)1 << offBitsNum) - 1;
 }
 


### PR DESCRIPTION
needed for https://github.com/phoenix-rtos/phoenix-rtos-build/pull/181
