### PR TITLE
trunner: wait for possible plo interruption

### DIFF
--- a/trunner/harness/plo.py
+++ b/trunner/harness/plo.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Callable, Optional, Sequence
+import time
 
 import pexpect
 
@@ -76,6 +77,9 @@ class PloInterface:
             self.dut.expect_exact("Waiting for input", timeout=3)
         except (pexpect.TIMEOUT, pexpect.EOF) as e:
             raise PloError("Failed to go into bootloader mode", output=self.dut.before) from e
+
+        # Temporary fix for [https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1040]
+        time.sleep(0.1)
 
         self.dut.send("\n")
 


### PR DESCRIPTION
JIRA: CI-432

## Description
In case of 'waiting for input' we interrupt PSH loading. We need to wait a bit to be sure that in this case will be able to do this on faster host environments where this can occur a race condition between sending command and non-accessible input collector.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [X] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [X] Tested by hand on: armv7m4-stm32l4x6-nucleo (On host env).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing linter checks and tests passed.
- [X] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
