### PR TITLE
libc/misc: disable sock fstat test because of an issue

### DIFF
--- a/libc/misc/stat.c
+++ b/libc/misc/stat.c
@@ -552,10 +552,12 @@ TEST(stat_mode, sock_type)
 
 	TEST_ASSERT_EQUAL_INT(0, lstat(socketPath, &buffer));
 	TEST_ASSERT_TRUE((buffer.st_mode & S_IFMT) == S_IFSOCK);
-#endif
 
 	TEST_ASSERT_EQUAL_INT(0, fstat(sfd, &buffer));
 	TEST_ASSERT_TRUE((buffer.st_mode & S_IFMT) == S_IFSOCK);
+#else
+	(void)buffer;
+#endif
 
 	close(sfd);
 	unlink(socketPath);


### PR DESCRIPTION
JIRA: RTOS-791

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

`fstat` function is being moved to `libphoenix` and now uses the same mechanism to get file info as `(l)stat`, which is not supported on dummyfs and jffs2.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
