### PR TITLE
trunner: change style of printing flash output

### DIFF
--- a/trunner/test_runner.py
+++ b/trunner/test_runner.py
@@ -11,7 +11,7 @@ from trunner.config import ConfigParser
 from trunner.ctx import TestContext
 from trunner.dut import Dut
 from trunner.harness import HarnessError, FlashError
-from trunner.text import bold, green, red, yellow, magenta
+from trunner.text import green, red, yellow, magenta
 from trunner.types import Status, TestOptions, TestResult, TestStage, is_github_actions, get_ci_url
 
 
@@ -143,22 +143,22 @@ class TestRunner:
     def flash(self) -> TestResult:
         """Flashes the device under test."""
 
-        print("Flashing an image to device...")
-
         # report flashing as a test result to include in export (especially useful when failed)
         result = TestResult("flash")
+
+        self._print_test_header_begin(result)
 
         try:
             result.set_stage(TestStage.RUN)
             self.target.flash_dut()
             result.set_stage(TestStage.DONE)
         except (FlashError, HarnessError) as exc:
-            # the newline is needed to avoid printing exception in the same line as plo prompt
-            print(bold("\nERROR WHILE FLASHING THE DEVICE"))
-            print(exc)
-            result.fail_harness_exception(exc)
+            result.fail(str(exc))
 
-        print("Done!")
+        self._print_test_header_end(result)
+
+        print(result.to_str(self.ctx.verbosity), end="", flush=True)
+
         return result
 
     def _print_test_header_end(self, test: TestOptions):


### PR DESCRIPTION
## Running with -S option: 
### Before: 
for example: 
- ull
![image](https://github.com/phoenix-rtos/phoenix-rtos-tests/assets/116297248/e026f31e-2d02-4133-9728-b8ca00c104c4)
- imx106x:
![image](https://github.com/phoenix-rtos/phoenix-rtos-tests/assets/116297248/329c0839-357c-4046-853c-8a366ba853dc)

### After (running with -S option) : 
for example: 
- ull
![image](https://github.com/phoenix-rtos/phoenix-rtos-tests/assets/116297248/a3ffddfa-f8e9-4d61-aded-5d4d9d275e8a)

- imx106x:
![image](https://github.com/phoenix-rtos/phoenix-rtos-tests/assets/116297248/04aca6b1-b3cc-4234-8ea2-8fb34499ce5b)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [x] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
