### PR TITLE
trunner: requirements: install RPi.GPIO only on ARM targets

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,9 @@
-attrs==23.1.0
-colorama==0.4.4
+colorama==0.4.6
 future==0.18.3
-iniconfig==2.0.0
-junitparser==3.1.0
-packaging==23.1
-pexpect==4.8.0
-pluggy==0.13.1
-ptyprocess==0.7.0
+junitparser==3.1.2
+pexpect==4.9.0
 pyserial==3.5
 pytest==7.4.1
 PyYAML==6.0.1
-RPi.GPIO==0.7.1
-toml==0.10.2
 pyusb==1.2.1
+RPi.GPIO==0.7.1; platform_machine == 'armv7l' or platform_machine == 'aarch64'


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Also: remove non-direct dependencies, bump some of the versions.

JIRA: CI-451

## Motivation and Context

We don't want to install `RPi.GPIO` module on host (it's useless and requires other dependencies).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
