### PR TITLE
Using armv7a9-zynq7000-qemu startup script without qemu control

### DIFF
--- a/trunner/target/emulated.py
+++ b/trunner/target/emulated.py
@@ -99,7 +99,7 @@ class ARMv7A9Zynq7000QemuTarget(QemuTarget):
     shell_prompt = "root@?:~ # "
 
     def __init__(self):
-        super().__init__("armv7a9-zynq7000-qemu.sh")
+        super().__init__("armv7a9-zynq7000-qemu-test.sh")
         # Start of the zynq target take around 45 seconds due to the slow filesystem initialization.
         # Iterate over harness chain to find a ShellHarness to increase prompt_timeout value.
         self.prompt_timeout = 60


### PR DESCRIPTION
JIRA: CI-397
<!--- Provide a general summary of your changes in the Title above -->

## Description
In order to implement tests that check psh control capability, we need to run QEMU without ability to call QEMU controls.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [X] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [X] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing linter checks and tests passed.
- [X] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [X] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/phoenix-rtos-project/pull/997
- [ ] I will merge this PR by myself when appropriate.
