### PR TITLE
libc/misc: add tests for libphoenix __safe_read/write functions

### DIFF
--- a/libc/misc/main.c
+++ b/libc/misc/main.c
@@ -26,6 +26,10 @@ void runner(void)
 	RUN_TEST_GROUP(unistd_getopt);
 	RUN_TEST_GROUP(unistd_uids);
 	RUN_TEST_GROUP(unistd_fsdir);
+#ifdef __phoenix__
+	/* tests libphoenix internal functions */
+	RUN_TEST_GROUP(unistd_file_safe);
+#endif
 	RUN_TEST_GROUP(unistd_file);
 	RUN_TEST_GROUP(wchar_wcscmp);
 	RUN_TEST_GROUP(ctype);


### PR DESCRIPTION
JIRA: RTOS-882

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Add simple tests for `libphoenix` internal `__safe_read/write` functions.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work https://github.com/phoenix-rtos/libphoenix/pull/372
- [ ] I will merge this PR by myself when appropriate.
