### PR TITLE
psh: enable touch/exit test on imxrt117x

### DIFF
--- a/psh/test.yaml
+++ b/psh/test.yaml
@@ -73,8 +73,4 @@ test:
           harness: test-help.py
 
         - name: exit
-          targets:
-              # imxrt117x target skipped, because of the following issue
-              # https://github.com/phoenix-rtos/phoenix-rtos-project/issues/866
-              exclude: [armv7m7-imxrt117x-evk]
           harness: test-exit.py

--- a/psh/test.yaml
+++ b/psh/test.yaml
@@ -46,9 +46,6 @@ test:
 
         - name: touch
           harness: test-touch.py
-          # Due to #1097 issue: https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1097
-          targets:
-              exclude: [armv7m7-imxrt117x-evk]
 
         - name: touch-rootfs
           harness: test-touch-rootfs.py


### PR DESCRIPTION
It is enabled due to the following issue resolution: phoenix-rtos/phoenix-rtos-project#1097

JIRA: CI-461<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).:
https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/599
- [ ] I will merge this PR by myself when appropriate.
