### PR TITLE
libc: fix setvbuf_fullbuffer_overflow testcase

### DIFF
--- a/libc/stdio/stdio_file.c
+++ b/libc/stdio/stdio_file.c
@@ -980,7 +980,10 @@ TEST(stdio_bufs, setvbuf_fullbuffer_overflow)
 	TEST_ASSERT_EQUAL_INT(0, setvbuf(filep, buf2, _IOFBF, sizeof(buf2)));
 
 	TEST_ASSERT_GREATER_THAN_INT(0, fputs(data, filep));
+	/* Flush is used, because it's possible that overflow data will be written anyway (glibc) */
+	fflush(filep);
 	TEST_ASSERT_NOT_NULL(fgets(buf, sizeof(buf), filep2));
+	TEST_ASSERT_EQUAL_STRING(data, buf);
 	TEST_ASSERT_EQUAL_INT(strlen(data), strlen(buf));
 }
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The test case checks fully buffered mode. Previous implementation required data overflowing the buffer (sending 10 bytes when a buffer is 8 bytes long) to be written to a file at once which is not required by POSIX. The current solution forces flushing the remaining 2 bytes anyway

JIRA: CI-507

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic-qemu with https://github.com/phoenix-rtos/libphoenix/pull/376/commits changes applied, host-pc).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
