### PR TITLE
trunner: add missing expect during flash procedure

### DIFF
--- a/trunner/test_runner.py
+++ b/trunner/test_runner.py
@@ -244,6 +244,10 @@ class TestRunner:
         # Ensure first test will start with reboot
         last_test_failed = True
 
+        # Unload data before starting tests
+        if self.ctx.should_flash is not False and self.ctx.target.experimental is False:
+            self.target.dut.expect(r".+")
+
         for test in tests:
             # By default we don't want to reboot the entire device to speed up the test execution)
             # if not explicitly required by the test.


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

This change resolves the issue where the flashing process executes a reboot after successful flashing, causing the next test case to receive output from the flash reboot and detect the PSH prompt too early

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [X] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [X] Tested by hand on: armv7a9-zynq7000-zedboard.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing linter checks and tests passed.
- [X] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
