### PR TITLE
trunner: escape control characters in results xml

### DIFF
--- a/trunner/text.py
+++ b/trunner/text.py
@@ -1,9 +1,9 @@
 import itertools
 import re
-from colorama import Style, Fore
 
+from colorama import Fore, Style
 
-ANSI_ESCAPE = re.compile(r'(?:\x1B[@-_]|[\x80-\x9F])[0-?]*[ -/]*[@-~]')
+ANSI_ESCAPE = re.compile(r"(?:\x1B[@-_]|[\x80-\x9F])[0-?]*[ -/]*[@-~]")
 
 
 def bold(s: str) -> str:
@@ -31,7 +31,7 @@ def magenta(s: str) -> str:
 
 
 def remove_ansi_sequences(line: str) -> str:
-    return ANSI_ESCAPE.sub('', line)
+    return ANSI_ESCAPE.sub("", line)
 
 
 def escape_invalid_xml_characters(s: str) -> str:

--- a/trunner/types.py
+++ b/trunner/types.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
-from datetime import datetime
-from functools import total_ordering
 
 import os
 import re
 import sys
 import time
 import traceback
-import junitparser
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import Enum, auto
-from typing import Callable, Dict, List, Optional
+from functools import total_ordering
 from pathlib import Path
+from typing import Callable, Dict, List, Optional
+
+import junitparser
 from trunner.text import bold, escape_invalid_xml_characters, green, red, remove_ansi_sequences, yellow
 
 
@@ -21,8 +22,10 @@ def is_github_actions() -> bool:
 
 def get_ci_url() -> str:
     if is_github_actions():
-        return (f"{os.environ['GITHUB_SERVER_URL']}/{os.environ['GITHUB_REPOSITORY']}"
-                f"/actions/runs/{os.environ['GITHUB_RUN_ID']}")
+        return (
+            f"{os.environ['GITHUB_SERVER_URL']}/{os.environ['GITHUB_REPOSITORY']}"
+            f"/actions/runs/{os.environ['GITHUB_RUN_ID']}"
+        )
 
     return ""
 
@@ -64,12 +67,13 @@ class Status(Enum):
 
     def should_print(self, verbosity: int):
         status_for_verbosity = (Status.FAIL, Status.SKIP, Status.OK)
-        return self in status_for_verbosity[:verbosity + 1]
+        return self in status_for_verbosity[: verbosity + 1]
 
 
 @total_ordering
 class TestStage(Enum):
     """Testing stage to timed"""
+
     INIT = auto()
     REBOOT = auto()
     FLASH = auto()


### PR DESCRIPTION
Control characters are not valid in xml, they need to be escaped in output of tests, otherwise the file can't be parsed.

JIRA: CI-563

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
