### PR TITLE
Fix and improve meterfs tests

### DIFF
--- a/meterfs/file_pc.c
+++ b/meterfs/file_pc.c
@@ -13,6 +13,7 @@
 #include <limits.h>
 #include <host-flashsrv.h>
 #include <meterfs.h>
+#include <unity.h>
 
 #include "file.h"
 
@@ -22,28 +23,34 @@
 int file_lookup(const char *name)
 {
 	id_t id;
-
-	return hostflashsrv_lookup(name, &id);
-}
-
-
-int file_open(const char *name)
-{
 	int err;
-	id_t id;
 
 	err = hostflashsrv_lookup(name, &id);
 	if (err < 0) {
 		return err;
 	}
 
-	if (id > INT_MAX) {
-		return -1;
+	TEST_ASSERT_LESS_OR_EQUAL_INT_MESSAGE(INT_MAX, id, "TEST ERROR: file ID too big");
+
+	return (int)id;
+}
+
+
+int file_open(const char *name)
+{
+	id_t id;
+	int ret;
+
+	ret = file_lookup(name);
+	if (ret < 0) {
+		return ret;
 	}
 
-	err = hostflashsrv_open(&id);
-	if (err < 0) {
-		return err;
+	id = ret;
+
+	ret = hostflashsrv_open(&id);
+	if (ret < 0) {
+		return ret;
 	}
 
 	return (int)id;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Fix building on phoenix
Remove obsolete FIXME
Improvements:
- Change phoenix abstration to call directly metefs instead of lookup.
    Many flashsrv just create dev for meterfs instaed of mounting it. This
    disallows lookups for files via lookup syscall. As tests is designed to
    test meterfs, not flashsrv implementation, it's desirable to call
    directly to meterfs filesystem, at least until mounting will be fully
    suported in our implementations.
- Returning ID from lookup
    It's needed for better test coverage.
- Make checks in phoenix and pc abstraction similar
    Host abstraction checks for id > INT_MAX. Added similar checks in
    phoenix abstration. Also, change return to errno and debug assert
- Add missing oid initialisation

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This commit fix building tests on pc and improve possibility to run those tests on hardware platforms

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: host-generic-pc, EBRO

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
