### PR TITLE
trunner: make kwargs have test name and cmd by default 

### DIFF
--- a/trunner/config.py
+++ b/trunner/config.py
@@ -152,6 +152,7 @@ class ConfigParser:
 
             execute_binary = False
 
+        self.test.cmd = cmd
         cmd = shlex.split(cmd)
         if not cmd:
             raise ParserError("execute/run attribute cannot be empty")
@@ -243,6 +244,10 @@ class ConfigParser:
         kwargs = config.get("kwargs", dict())
         if not isinstance(kwargs, dict):
             raise ParserError('"kwargs" must be a dictionary!')
+
+        kwargs["name"] = self.test.name
+        if self.test.cmd:
+            kwargs["cmd"] = self.test.cmd
 
         self.test.kwargs = kwargs
 

--- a/trunner/types.py
+++ b/trunner/types.py
@@ -383,6 +383,7 @@ def void_harness_fn(result: TestResult) -> TestResult:
 @dataclass
 class TestOptions:
     name: Optional[str] = None
+    cmd: Optional[str] = None
     harness: Callable[[TestResult], TestResult] = void_harness_fn
     target: Optional[str] = None
     bootloader: Optional[BootloaderOptions] = None


### PR DESCRIPTION
Some tests need to parse the command or its arguments themselves, so the appropriate field has to be passed to the harness.

JIRA: CI-584

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
