### PR TITLE
waitpid: add test for child exit with existing zombies

### DIFF
--- a/waitpid/test_waitpid.c
+++ b/waitpid/test_waitpid.c
@@ -25,102 +25,104 @@
 
 #include "unity_fixture.h"
 
+static char *cmd_name;
+
 TEST_GROUP(test_waitpid);
+
 
 TEST_SETUP(test_waitpid)
 {
 }
 
+
 TEST_TEAR_DOWN(test_waitpid)
 {
 }
 
+
 /* Need to add more test cases */
 TEST(test_waitpid, waitpid_wnohang)
 {
-	int pid[2] = { 0, 0 };
-	int res, i, j;
-	char *const arg[][2] = { { "exec_while_process", NULL }, { "exec_sum_process", NULL } };
-
-	/* 1 iteration for easier problem reproduction, in the future there will be more iterations */
-	for (i = 1; i > 0; i--) {
-		for (j = 0; j < 2; j++) {
-			pid[j] = vfork();
-			if (pid[j] < 0) {
-				fprintf(stderr, "vfork function failed: %s\n", strerror(errno));
-				return;
-			}
-			/* child process j */
-			else if (pid[j] == 0) {
-				execv("/bin/test-waitpid", arg[j]);
-				fprintf(stderr, "exec function failed: %s\n", strerror(errno));
-				_exit(EXIT_FAILURE);
-			}
-		}
-		/* wait for process 1 to become a zombie process */
-		usleep(100000 * 10);
-		res = waitpid(pid[0], NULL, WNOHANG);
-		/* instead of returning 0 at once waitpid function waits for a process state change */
-		TEST_ASSERT_EQUAL_INT(0, res);
-		res = waitpid(pid[1], NULL, WNOHANG);
-		TEST_ASSERT_GREATER_OR_EQUAL_INT(1, res);
-
-		kill(pid[1], SIGKILL);
-		kill(pid[0], SIGKILL);
-	}
-}
-
-TEST(test_waitpid, waitpid_other_zombie)
-{
-	int pid[2] = { 0, 0 };
+	int pid[2];
 	int res, i;
-	char *const arg[][2] = { { "exec_sum_process", NULL }, { "exec_sleep", NULL } };
+	char *const arg[2][2] = { { "exec_while_process", NULL }, { "exec_sum_process", NULL } };
 
 	for (i = 0; i < 2; i++) {
 		pid[i] = vfork();
-		if (pid[i] < 0) {
-			fprintf(stderr, "vfork function failed: %s\n", strerror(errno));
-			return;
-		}
+		TEST_ASSERT_GREATER_OR_EQUAL(0, pid[i]);
 		/* child process i */
-		else if (pid[i] == 0) {
-			execv("/bin/test-waitpid", arg[i]);
-			fprintf(stderr, "exec function failed: %s\n", strerror(errno));
-			_exit(EXIT_FAILURE);
-		}
-	}
-	res = waitpid(pid[1], NULL, 0);
-	TEST_ASSERT_EQUAL_INT(pid[1], res);
-	res = waitpid(pid[0], NULL, 0);
-	TEST_ASSERT_EQUAL_INT(pid[0], res);
-}
-
-TEST(test_waitpid, waitpid_other_zombie_before)
-{
-	int pid[2] = { 0, 0 };
-	int res, i;
-	char *const arg[][2] = { { "exec_sleep", NULL }, { "exec_sum_process", NULL } };
-
-	for (i = 0; i < 2; i++) {
-		pid[i] = vfork();
-		if (pid[i] < 0) {
-			fprintf(stderr, "vfork function failed: %s\n", strerror(errno));
-			return;
-		}
-		/* child process i */
-		else if (pid[i] == 0) {
-			execv("/bin/test-waitpid", arg[i]);
-			fprintf(stderr, "exec function failed: %s\n", strerror(errno));
+		if (pid[i] == 0) {
+			execv(cmd_name, arg[i]);
 			_exit(EXIT_FAILURE);
 		}
 	}
 	/* wait for process 1 to become a zombie process */
-	usleep(10000000 * 10);
-	res = waitpid(pid[0], NULL, 0);
-	TEST_ASSERT_GREATER_OR_EQUAL_INT(1, res);
-	res = waitpid(pid[1], NULL, 0);
-	TEST_ASSERT_GREATER_OR_EQUAL_INT(1, res);
+	sleep(2);
+	res = waitpid(pid[0], NULL, WNOHANG);
+	TEST_ASSERT_EQUAL_INT(0, res);
+	res = waitpid(pid[1], NULL, WNOHANG);
+	TEST_ASSERT_EQUAL_INT(pid[1], res);
+
+	res = kill(pid[0], SIGKILL);
+	TEST_ASSERT_EQUAL_INT(0, res);
 }
+
+
+TEST(test_waitpid, waitpid_other_zombie)
+{
+	int pid[2];
+	int res, i, status;
+	char *const arg[2][2] = { { "exec_sum_process", NULL }, { "exec_sleep", NULL } };
+
+	for (i = 0; i < 2; i++) {
+		pid[i] = vfork();
+		TEST_ASSERT_GREATER_OR_EQUAL(0, pid[i]);
+		/* child process i */
+		if (pid[i] == 0) {
+			execv(cmd_name, arg[i]);
+			_exit(EXIT_FAILURE);
+		}
+	}
+	res = waitpid(pid[1], &status, 0);
+	TEST_ASSERT_EQUAL_INT(pid[1], res);
+	TEST_ASSERT_TRUE(WIFEXITED(status));
+	TEST_ASSERT_EQUAL_INT(EXIT_SUCCESS, WEXITSTATUS(status));
+
+	res = waitpid(pid[0], &status, 0);
+	TEST_ASSERT_EQUAL_INT(pid[0], res);
+	TEST_ASSERT_TRUE(WIFEXITED(status));
+	TEST_ASSERT_EQUAL_INT(EXIT_SUCCESS, WEXITSTATUS(status));
+}
+
+
+TEST(test_waitpid, waitpid_other_zombie_before)
+{
+	int pid[2];
+	int res, i, status;
+	char *const arg[2][2] = { { "exec_sleep", NULL }, { "exec_sum_process", NULL } };
+
+	for (i = 0; i < 2; i++) {
+		pid[i] = vfork();
+		TEST_ASSERT_GREATER_OR_EQUAL(0, pid[i]);
+		/* child process i */
+		if (pid[i] == 0) {
+			execv(cmd_name, arg[i]);
+			_exit(EXIT_FAILURE);
+		}
+	}
+	/* wait for process 1 to become a zombie process */
+	sleep(2);
+	res = waitpid(pid[0], &status, 0);
+	TEST_ASSERT_EQUAL_INT(pid[0], res);
+	TEST_ASSERT_TRUE(WIFEXITED(status));
+	TEST_ASSERT_EQUAL_INT(EXIT_SUCCESS, WEXITSTATUS(status));
+
+	res = waitpid(pid[1], &status, 0);
+	TEST_ASSERT_EQUAL_INT(pid[1], res);
+	TEST_ASSERT_TRUE(WIFEXITED(status));
+	TEST_ASSERT_EQUAL_INT(EXIT_SUCCESS, WEXITSTATUS(status));
+}
+
 
 TEST_GROUP_RUNNER(test_waitpid)
 {
@@ -129,13 +131,16 @@ TEST_GROUP_RUNNER(test_waitpid)
 	RUN_TEST_CASE(test_waitpid, waitpid_other_zombie_before);
 }
 
+
 void runner(void)
 {
 	RUN_TEST_GROUP(test_waitpid);
 }
 
+
 int main(int argc, char *argv[])
 {
+	cmd_name = argv[0];
 	int failures = 0;
 	int sum;
 	if (!strcmp(basename(argv[0]), "exec_while_process")) {
@@ -150,7 +155,7 @@ int main(int argc, char *argv[])
 		}
 	}
 	else if (!strcmp(basename(argv[0]), "exec_sleep")) {
-		usleep(100000 * 20);
+		sleep(1);
 	}
 	else {
 		failures = UnityMain(argc, (const char **)argv, runner);


### PR DESCRIPTION
Test showcasing issue:
https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1304

JIRA: CI-540

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
