### PR TITLE
trunner: Implementing pytest support

### DIFF
--- a/sample/pytest/Makefile
+++ b/sample/pytest/Makefile
@@ -1,0 +1,5 @@
+NAME := test-fake-comm
+LOCAL_SRCS := main.c
+include $(binary.mk)
+
+SAMPLE_TESTS += test-fake-comm

--- a/sample/pytest/conftest.py
+++ b/sample/pytest/conftest.py
@@ -1,0 +1,25 @@
+import pytest
+
+
+@pytest.fixture(scope="session")
+def pexpect_bin(dut):
+    p = dut.pexpect_proc
+    p.expect_exact("[Commence Fake Communication]\r\n")
+
+    yield p
+
+    p.sendline("EXIT")
+    p.expect_exact("[Success!]")
+
+
+@pytest.fixture(scope="session")
+def pexpect_psh(dut, ctx):
+    p = dut.pexpect_proc
+    exec_cmd = "/bin/psh" if ctx.target.rootfs else "sysexec psh"
+    p.sendline(exec_cmd)
+    p.expect(rf"{exec_cmd}(\r+)\n")
+
+    yield p
+
+    p.send("\x04")
+    p.expect("exit(\r+)\n")

--- a/sample/pytest/main.c
+++ b/sample/pytest/main.c
@@ -1,0 +1,71 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Simple C app for simulating serial communication
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Lukasz Kruszynski
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#define BUF_SZ 256U
+
+
+static int main_processCommand(char *input)
+{
+	const char *echoCmd = "echo ";
+
+	if (strcmp(input, "EXIT") == 0) {
+		return 0;
+	}
+	else if (strncmp(input, echoCmd, strlen(echoCmd)) == 0) {
+		(void)printf("%s\n", input + strlen(echoCmd));
+	}
+	else if (strcmp(input, "echo") == 0 || (strcmp(input, "ping") == 0)) {
+		(void)printf("main: [OK]\n");
+	}
+	else if (strlen(input) > 0U) {
+		(void)printf("main: %s [FAIL]\n", input);
+	}
+	return 1;
+}
+
+
+int main(void)
+{
+	char c = '\0';
+	char buffer[BUF_SZ] = { 0 };
+	size_t pos = 0U;
+	int returnCode = 1;
+
+	(void)printf("main: [Commence Fake Communication]\n");
+
+	/* Run the loop until `EXIT` */
+	while (returnCode != 0) {
+		if (read(STDIN_FILENO, &c, 1) != 1) {
+			return -1;
+		}
+
+		if (c == '\n') {
+			buffer[pos] = '\0';
+			returnCode = main_processCommand(buffer);
+			pos = 0U;
+		}
+		else if (pos < BUF_SZ - 1U) {
+			buffer[pos] = c;
+			pos++;
+		}
+		else {
+			(void)printf("main: [Failure!]\n");
+			return -1;
+		}
+	}
+
+	(void)printf("main: [Success!]\n");
+	return 0;
+}

--- a/sample/pytest/test-psh.py
+++ b/sample/pytest/test-psh.py
@@ -1,0 +1,39 @@
+import psh.tools.psh as psh
+import pytest
+
+TEST_DIR = "test_dir"
+
+echo_resp_code_list = [
+    ("", "", "success"),
+    ("hello", "hello", "success"),
+    ("hello world", "hello world", "success"),
+    ("lorem $ipsum dolor$ales", "lorem  dolor", "success"),
+    ("hello > /", ".*EISDIR", "success"),
+    ("-illegal_arg", ".*", "fail"),
+]
+
+
+@pytest.mark.parametrize("msg, resp, exp_res", echo_resp_code_list)
+def test_echo(pexpect_psh, msg, resp, exp_res):
+    psh.assert_cmd(
+        pexpect_psh,
+        f"echo {msg}",
+        expected=rf"{resp}\r+\n",
+        result=exp_res,
+        msg=f'echo "{msg}" failed',
+        is_regex=True,
+    )
+
+
+def is_dir_in_files(dirname: str, files: list[psh.File]) -> bool:
+    return any(file.is_dir and file.name == dirname for file in files)
+
+
+def test_mkdir_rmdir(pexpect_psh):
+    psh.assert_cmd(pexpect_psh, f"mkdir {TEST_DIR}")
+
+    files = psh.ls(pexpect_psh, "/")
+    assert is_dir_in_files(TEST_DIR, files)
+    psh.assert_cmd(pexpect_psh, f"rmdir {TEST_DIR}")
+    files = psh.ls(pexpect_psh, "/")
+    assert not is_dir_in_files(TEST_DIR, files)

--- a/sample/pytest/test.py
+++ b/sample/pytest/test.py
@@ -1,0 +1,44 @@
+import pytest
+
+
+test_data = [
+    ("ping", "[OK]"),
+    ("echo", "[OK]"),
+    ("abcd", "[FAIL]"),
+]
+
+
+def test_ctx(ctx):
+    assert ctx is not None
+
+
+def test_dut(dut):
+    assert dut is not None
+
+
+@pytest.mark.parametrize("cmd, exp", test_data)
+def test_dut_parameterized_commands(pexpect_bin, cmd, exp):
+    pexpect_bin.sendline(cmd)
+    pexpect_bin.expect_exact(f"{exp}\r\n")
+
+
+@pytest.mark.usefixtures("pexpect_bin")
+class TestClass:
+    test_val = 0
+
+    def setup_method(self):
+        self.__class__.test_val = 5
+
+    def teardown_method(self):
+        self.__class__.test_val = 0
+
+    def test_send_hello_from_class(self, pexpect_bin):
+        pexpect_bin.sendline("echo hello from class")
+        pexpect_bin.expect_exact("\r\nhello from class\r\n")
+
+    def test_test_val_value(self):
+        assert self.__class__.test_val == 5
+
+
+def test_class_static_val_is_zero():
+    assert TestClass.test_val == 0

--- a/sample/pytest/test.yaml
+++ b/sample/pytest/test.yaml
@@ -1,0 +1,12 @@
+test:
+    tests:
+        - name: binary
+          type: pytest
+          execute: test-fake-comm
+          script: test.py
+          targets:
+              include: [host-generic-pc]
+
+        - name: psh
+          type: pytest
+          script: test-psh.py

--- a/trunner/config.py
+++ b/trunner/config.py
@@ -6,9 +6,8 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Set
 
 import yaml
-
 from trunner.ctx import TestContext
-from trunner.harness import PyHarness, unity_harness
+from trunner.harness import PyHarness, unity_harness, pytest_harness
 from trunner.types import AppOptions, BootloaderOptions, FileOptions, TestOptions, ShellOptions, TestType
 
 
@@ -59,6 +58,8 @@ class ConfigParser:
 
         if t_type in (TestType.EMPTY, TestType.HARNESS):
             self._parse_pyharness(config)
+        elif t_type is TestType.PYTEST:
+            self._parse_pytest(config)
         elif t_type is TestType.UNITY:
             self._parse_unity()
         else:
@@ -69,13 +70,7 @@ class ConfigParser:
         if path is None:
             raise ParserError("test is of type 'harness' but there is no \"harness\" keyword")
 
-        path = Path(path)
-
-        if not path.is_absolute():
-            # If path is not absolute then it must be relative to the directory of yaml
-            path = self.yaml_path.parent / path
-            if not path.is_absolute():
-                raise ParserError("yml path is not absolute!")
+        path = self._get_absolute_path(path)
 
         spec = importlib.util.spec_from_file_location("harness", path.absolute())
         if not spec:
@@ -94,6 +89,21 @@ class ConfigParser:
             raise ParserError(f"harness function has not been found in {path}")
 
         self.test.harness = PyHarness(self.ctx.target.dut, self.ctx, harness_fn, self.test.kwargs)
+
+    def _parse_pytest(self, config: dict) -> None:
+        script = config.get("script")
+        if not script:
+            raise ParserError("pytest `script` name must be provided!")
+        script_path = self._get_absolute_path(script)
+        if script_path.suffix != ".py":
+            raise ParserError("provided `script` is not a python script!")
+        if not script_path.exists():
+            raise ParserError(f"pytest script not found: {script_path}")
+        # Creating a new kwarg is better than expanding TestContext
+        # with a field required only for this specific case
+        # TODO Think of a better way of parsing special arguments
+        self.test.kwargs["script"] = script_path.absolute()
+        self.test.harness = PyHarness(self.ctx.target.dut, self.ctx, pytest_harness, self.test.kwargs)
 
     def _parse_unity(self):
         self.test.harness = PyHarness(self.ctx.target.dut, self.ctx, unity_harness, self.test.kwargs)
@@ -335,6 +345,10 @@ class ConfigParser:
 
         self.main.ignore = config.get("ignore", False)
         self.main.nightly = config.get("nightly", False)
+
+    def _get_absolute_path(self, path: str) -> Path:
+        p = Path(path)
+        return self.yaml_path.parent / p
 
     def parse(self, path: Path) -> List[TestOptions]:
         self.yaml_path = path

--- a/trunner/config.py
+++ b/trunner/config.py
@@ -6,9 +6,8 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Set
 
 import yaml
-
 from trunner.ctx import TestContext
-from trunner.harness import PyHarness, unity_harness
+from trunner.harness import PyHarness, unity_harness, pytest_harness
 from trunner.types import AppOptions, BootloaderOptions, FileOptions, TestOptions, ShellOptions, TestType
 
 
@@ -59,6 +58,8 @@ class ConfigParser:
 
         if t_type in (TestType.EMPTY, TestType.HARNESS):
             self._parse_pyharness(config)
+        elif t_type is TestType.PYTEST:
+            self._parse_pytest(config)
         elif t_type is TestType.UNITY:
             self._parse_unity()
         else:
@@ -69,13 +70,7 @@ class ConfigParser:
         if path is None:
             raise ParserError("test is of type 'harness' but there is no \"harness\" keyword")
 
-        path = Path(path)
-
-        if not path.is_absolute():
-            # If path is not absolute then it must be relative to the directory of yaml
-            path = self.yaml_path.parent / path
-            if not path.is_absolute():
-                raise ParserError("yml path is not absolute!")
+        path = self._get_absolute_path(path)
 
         spec = importlib.util.spec_from_file_location("harness", path.absolute())
         if not spec:
@@ -94,6 +89,21 @@ class ConfigParser:
             raise ParserError(f"harness function has not been found in {path}")
 
         self.test.harness = PyHarness(self.ctx.target.dut, self.ctx, harness_fn, self.test.kwargs)
+
+    def _parse_pytest(self, config: dict) -> None:
+        script = config.get("script")
+        if not script:
+            raise ParserError("pytest `script` name must be provided!")
+        script_path = self._get_absolute_path(script)
+        if script_path.suffix != ".py":
+            raise ParserError("provided `script` is not a python script!")
+        if not script_path.exists():
+            raise ParserError(f"pytest script not found: {script_path}")
+        # Creating a new kwarg is better than expanding TestContext
+        # with a field required only for this specific case
+        # TODO Think of a better way of parsing special arguments
+        self.test.kwargs["script"] = script_path.absolute()
+        self.test.harness = PyHarness(self.ctx.target.dut, self.ctx, pytest_harness, self.test.kwargs)
 
     def _parse_unity(self):
         self.test.harness = PyHarness(self.ctx.target.dut, self.ctx, unity_harness, self.test.kwargs)
@@ -335,6 +345,14 @@ class ConfigParser:
 
         self.main.ignore = config.get("ignore", False)
         self.main.nightly = config.get("nightly", False)
+
+    def _get_absolute_path(self, path: str) -> Path:
+        resolved_path = self.yaml_path.parent / Path(path)
+
+        if not resolved_path.is_absolute():
+            raise ParserError("yml path is not absolute!")
+
+        return resolved_path
 
     def parse(self, path: Path) -> List[TestOptions]:
         self.yaml_path = path

--- a/trunner/harness/__init__.py
+++ b/trunner/harness/__init__.py
@@ -24,6 +24,7 @@ from .plo import (
 from .psh import ShellHarness
 from .pyharness import PyHarness
 from .unity import unity_harness
+from .pytest import pytest_harness
 
 __all__ = [
     "HarnessBuilder",
@@ -48,4 +49,5 @@ __all__ = [
     "PloImageProperty",
     "PloJffsImageProperty",
     "unity_harness",
+    "pytest_harness",
 ]

--- a/trunner/harness/pytest.py
+++ b/trunner/harness/pytest.py
@@ -1,0 +1,365 @@
+import os
+import re
+import shlex
+import sys
+from collections.abc import Generator
+from io import TextIOWrapper
+from typing import Any
+
+import pexpect
+import pytest
+from pytest import Function, TestReport
+from trunner.ctx import TestContext
+from trunner.dut import Dut
+from trunner.text import bold, green, red, yellow
+from trunner.types import Status, TestResult
+
+
+def extract_reason_from_report(report: TestReport) -> str:
+    """Extracts and formats the skip or xfail reason from a test report"""
+    reason = ""
+    if isinstance(report.longrepr, tuple):
+        reason = report.longrepr[2].replace("Skipped: ", "")
+    elif hasattr(report, "wasxfail"):
+        reason = report.wasxfail
+        reason = f"XFAIL: {reason}" if reason else "XFAIL"
+    return reason.strip()
+
+
+def get_status(report: TestReport) -> str:
+    """Converts a PyTest report status into a formatted trunner status string"""
+    was_xfail = hasattr(report, "wasxfail")
+    if report.failed and report.when != "call":
+        return red("ERROR")
+
+    if report.passed and not was_xfail:
+        return green("PASSED")
+    if report.passed and was_xfail:
+        return yellow("XPASS")
+    if report.failed:
+        return red("FAILED")
+    if report.skipped:
+        return yellow("XFAIL" if was_xfail else "SKIPPED")
+
+    return bold("UNKNOWN")
+
+
+def get_str_attr(obj: object, attribute: str) -> str:
+    """Safely retrieves an object attribute and ensures it is returned as a clean string"""
+    raw_attr = getattr(obj, attribute, "")
+    raw_attr = "" if raw_attr is None else raw_attr
+
+    attribute_str = raw_attr.decode("utf-8", "ignore") if isinstance(raw_attr, bytes) else str(raw_attr)
+    return attribute_str.replace("\r", "")
+
+
+class PytestLogInterceptorPlugin:
+    """Plugin that intercepts and modifies the log output
+
+    It modifies only the raw PyTest output, not the live
+    output coming from the DUT, etc.
+    """
+    def __init__(self, ctx: TestContext) -> None:
+        self._ctx = ctx
+        self._screen_writer = None
+        self._sink: TextIOWrapper | None = None
+        self._last_handled_state: tuple[Any, Any, Any] | None = None
+
+    @pytest.hookimpl(trylast=True)
+    def pytest_configure(self, config: Any) -> None:
+        terminal = config.pluginmanager.get_plugin("terminalreporter")
+        if not terminal:
+            return
+
+        if self._ctx.stream_output:
+            self._screen_writer = type(terminal._tw)(sys.stdout)
+
+        self._sink = open(os.devnull, "w")
+        terminal._tw._file = self._sink
+
+        config.option.disable_warnings = True
+        config.option.no_summary = True
+        terminal.summary_stats = lambda: None
+
+    @pytest.hookimpl(trylast=True)
+    def pytest_unconfigure(self, config: Any) -> None:
+        if self._sink is not None:
+            self._sink.close()
+            self._sink = None
+
+    @pytest.hookimpl(tryfirst=True)
+    def pytest_runtest_logstart(self, nodeid: str) -> None:
+        """Manually print start header to screen"""
+        if self._screen_writer is None:
+            return
+
+        self._flush_and_ensure_newline()
+        self._screen_writer.write(f"\t{bold(nodeid)}...")
+        self._screen_writer.write("\n")
+
+    @pytest.hookimpl(tryfirst=True)
+    def pytest_runtest_logreport(self, report: TestReport) -> None:
+        """Manually print status to screen."""
+        should_print = (report.when == "call") or (not report.passed)
+
+        if not should_print or self._screen_writer is None:
+            return
+
+        status = get_status(report)
+        reason = extract_reason_from_report(report)
+
+        self._flush_and_ensure_newline()
+
+        self._screen_writer.write(f"\t{bold(report.nodeid)} ")
+        self._screen_writer.write(status)
+
+        if reason:
+            self._screen_writer.write(f" ({reason})")
+
+        self._screen_writer.write("\n")
+
+    def _flush_and_get_last_char(self, pexpect_p: Any) -> str:
+        drained_last_char = ""
+        try:
+            while True:
+                chunk = pexpect_p.read_nonblocking(size=4096, timeout=0)
+                if not chunk:
+                    break
+
+                if isinstance(chunk, bytes):
+                    drained_last_char = chunk[-1:].decode("utf-8", "ignore")
+                else:
+                    drained_last_char = chunk[-1:]
+
+                # NOTE: The buffer appending operations below do not cause logfile duplication/
+                # The data is manually placed into the internal pexpect buffer, subsequent expect()
+                # calls omit the OS buffer pull operation that triggers the logfile write.
+                if isinstance(pexpect_p.buffer, bytes) and isinstance(chunk, str):
+                    pexpect_p.buffer += chunk.encode("utf-8", "ignore")
+                elif isinstance(pexpect_p.buffer, str) and isinstance(chunk, bytes):
+                    pexpect_p.buffer += chunk.decode("utf-8", "ignore")
+                else:
+                    pexpect_p.buffer += chunk
+        except (pexpect.TIMEOUT, pexpect.EOF):
+            pass
+
+        return drained_last_char
+
+    def _flush_and_ensure_newline(self) -> None:
+        """Flushes pending OS logs and ensures output ends with a newline.
+
+        This drains pending OS logs so they print continuously, restores them
+        so they can be parsed in the incoming test, and checks the absolute last character
+        to ensure the output ends with a newline for Pytest headers to format correctly.
+        """
+        dut = getattr(self._ctx.target, "dut", None)
+        pexpect_p = getattr(dut, "pexpect_proc", None)
+        if dut is None or pexpect_p is None:
+            return
+
+        drained_last_char = self._flush_and_get_last_char(pexpect_p)
+        last_char = ""
+
+        if drained_last_char:
+            last_char = drained_last_char
+            self._last_handled_state = (
+                getattr(pexpect_p, "before", ""),
+                getattr(pexpect_p, "after", ""),
+                getattr(pexpect_p, "buffer", ""),
+            )
+        else:
+            before = getattr(pexpect_p, "before", "")
+            after = getattr(pexpect_p, "after", "")
+            buffer = getattr(pexpect_p, "buffer", "")
+
+            current_state = (before, after, buffer)
+
+            if self._last_handled_state == current_state:
+                return
+            self._last_handled_state = current_state
+
+            raw_char = None
+
+            if buffer:
+                raw_char = buffer[-1:]
+            elif isinstance(after, (str, bytes)) and after:
+                raw_char = after[-1:]
+            elif isinstance(before, (str, bytes)) and before:
+                raw_char = before[-1:]
+
+            if isinstance(raw_char, bytes):
+                last_char = raw_char.decode("utf-8", "ignore")
+            elif raw_char is not None:
+                last_char = raw_char
+
+        if self._screen_writer and last_char and last_char not in ("\n", "\r"):
+            self._screen_writer.write("\n")
+
+
+class PytestBridgePlugin:
+    """Plugin that bridges the TestRunner and PyTest frameworks.
+
+    Each test case is run as TestRunner's subtest, accurately
+    capturing each subresult's runtime and status.
+    """
+
+    _unknown_fixture_str = "[UNKNOWN FIXTURE]"
+    _common_fast_fail_str = "Requires a previously failing fixture:"
+    _fast_fail_match_re = re.compile(rf"{re.escape(_common_fast_fail_str)} (\w+)")
+    _decorator_match_re = re.compile(r"@pytest\.fixture.*?def\s+(\w+)", re.DOTALL)
+
+    def __init__(self, dut: Dut, ctx: TestContext, result: TestResult, kwargs: dict) -> None:
+        self._dut = dut
+        self._ctx = ctx
+        self._result = result
+        self._kwargs = kwargs
+        self._pending_result = (Status.OK, "")
+        self._broken_fixtures: set[str] = set()
+
+    @pytest.fixture(scope="session")
+    def dut(self) -> Dut:
+        return self._dut
+
+    @pytest.fixture(scope="session")
+    def ctx(self) -> TestContext:
+        return self._ctx
+
+    @pytest.fixture(scope="session")
+    def kwargs(self) -> dict:
+        return self._kwargs
+
+    @pytest.hookimpl(tryfirst=True)
+    def pytest_runtest_setup(self, item: Function) -> None:
+        """Fail current test case immediately, if a required fixture failed
+        during previous test case's setup stage
+        """
+        for fixture in item.fixturenames:
+            if fixture in self._broken_fixtures:
+                pytest.fail(f"{self._common_fast_fail_str} {fixture}", pytrace=False)
+
+    @pytest.hookimpl(wrapper=True)
+    def pytest_runtest_makereport(self, item: Function, call: pytest.CallInfo) -> Generator[None, Any, TestReport]:
+        """Post-process PyTest's report making
+
+        Inject output caught before exception for a more detailed report.
+
+        Currently, TestResult failing methods fail the entire test with the
+        most recent exception, with no regard to individual subresults.
+
+        TODO: Modify TestResult failing methods to support single subresult
+        exceptions and use them here to avoid reimplementation.
+        """
+        report: TestReport = yield
+
+        if not report.failed or not call.excinfo:
+            return report
+
+        exc_instance = call.excinfo.value
+        report_add_info = None
+
+        before = get_str_attr(self._dut, "before")
+
+        if isinstance(exc_instance, (UnicodeDecodeError, pexpect.TIMEOUT, pexpect.EOF)) and before:
+            report_add_info = bold("OUTPUT CAUGHT BEFORE EXCEPTION: ")
+            report_add_info += before
+
+        if report_add_info:
+            report.longrepr = str(report.longrepr) + "\n\n" + report_add_info
+        return report
+
+    @pytest.hookimpl()
+    def pytest_runtest_logreport(self, report: TestReport) -> None:
+        """PyTest hook called after a test phase completion.
+
+        Adds a TestRunner subresult for each PyTest case report
+
+        :param report: PyTest's TestReport object
+        """
+        error_msg = getattr(report, "longreprtext", str(report.longrepr)) if report.longrepr else ""
+
+        if report.when == "setup":
+            self._record_setup_phase(report, error_msg)
+
+        elif report.when == "call":
+            self._record_call_phase(report, error_msg)
+
+        elif report.when == "teardown":
+            self._finalize_and_report(report, error_msg)
+
+    def _record_setup_phase(self, report: TestReport, error_msg: str) -> None:
+        if report.failed:
+            fixture_name = self._extract_broken_fixture(error_msg)
+            self._pending_result = (Status.FAIL, error_msg)
+            if fixture_name != self._unknown_fixture_str:
+                # It is assumed that fixtures failing at startup should
+                # not be re-run, thus marking them as `broken`
+                self._broken_fixtures.add(fixture_name)
+        elif report.skipped:
+            skip_msg = extract_reason_from_report(report)
+            self._pending_result = (Status.SKIP, skip_msg)
+
+    def _record_call_phase(self, report: TestReport, error_msg: str) -> None:
+        status = Status.OK
+        msg = ""
+
+        if report.failed:
+            status = Status.FAIL
+            msg = error_msg
+        elif report.skipped:
+            # XFAIL is treated as SKIP to not confuse it with success but
+            # it is not a FAIL either. XPASS will still be treated as OK
+            status = Status.SKIP
+            msg = extract_reason_from_report(report)
+
+        self._pending_result = (status, msg)
+
+    def _finalize_and_report(self, report: TestReport, error_msg: str) -> None:
+        final_status, final_msg = self._pending_result
+
+        if report.failed:
+            final_status = Status.FAIL
+
+            if final_msg:
+                final_msg = f"{final_msg}\n{error_msg}"
+            else:
+                final_msg = error_msg
+
+        self._result.add_subresult(subname=report.nodeid.split("::")[-1], status=final_status, msg=final_msg)
+
+    @classmethod
+    def _extract_broken_fixture(cls, text: str) -> str:
+        fast_fail_match = cls._fast_fail_match_re.search(text)
+        if fast_fail_match:
+            return fast_fail_match.group(1)
+        decorator_match = cls._decorator_match_re.search(text)
+        if decorator_match:
+            return decorator_match.group(1)
+        return cls._unknown_fixture_str
+
+
+def pytest_harness(dut: Dut, ctx: TestContext, result: TestResult, **kwargs) -> TestResult:
+    test_path = kwargs.get("script")
+
+    if not test_path:
+        result.fail(msg="missing `script` from test configuration!")
+        return result
+
+    options = shlex.split(kwargs.get("options", ""))
+
+    bridge_plugin = PytestBridgePlugin(dut, ctx, result, kwargs)
+    log_plugin = PytestLogInterceptorPlugin(ctx)
+
+    cmd_args = [str(test_path), *options, "-s"]
+
+    try:
+        exit_code = pytest.main(cmd_args, plugins=[bridge_plugin, log_plugin])
+    except Exception:
+        result.fail_unknown_exception()
+        return result
+
+    accepted_codes = (pytest.ExitCode.OK, pytest.ExitCode.TESTS_FAILED, pytest.ExitCode.NO_TESTS_COLLECTED)
+
+    if exit_code not in accepted_codes:
+        result.fail(msg=f"Pytest execution failed (Exit Code {exit_code}).")
+
+    return result

--- a/trunner/harness/pytest.py
+++ b/trunner/harness/pytest.py
@@ -1,0 +1,369 @@
+import os
+import re
+import shlex
+import sys
+from collections.abc import Generator
+from io import TextIOWrapper
+from typing import Any
+
+import pexpect
+import pytest
+from pytest import Function, TestReport
+from trunner.ctx import TestContext
+from trunner.dut import Dut
+from trunner.text import bold, green, red, yellow
+from trunner.types import Status, TestResult
+
+
+def extract_reason_from_report(report: TestReport) -> str:
+    """Extracts and formats the skip or xfail reason from a test report"""
+    reason = ""
+    if isinstance(report.longrepr, tuple):
+        reason = report.longrepr[2].replace("Skipped: ", "")
+    elif hasattr(report, "wasxfail"):
+        reason = report.wasxfail
+        reason = f"XFAIL: {reason}" if reason else "XFAIL"
+    return reason.strip()
+
+
+def get_status(report: TestReport) -> str:
+    """Converts a PyTest report status into a formatted trunner status string"""
+    was_xfail = hasattr(report, "wasxfail")
+    if report.failed and report.when != "call":
+        return red("ERROR")
+
+    if report.passed and not was_xfail:
+        return green("PASSED")
+    if report.passed and was_xfail:
+        return yellow("XPASS")
+    if report.failed:
+        return red("FAILED")
+    if report.skipped:
+        return yellow("XFAIL" if was_xfail else "SKIPPED")
+
+    return bold("UNKNOWN")
+
+
+def get_str_attr(obj: object, attribute: str) -> str:
+    """Safely retrieves an object attribute and ensures it is returned as a clean string"""
+    raw_attr = getattr(obj, attribute, "")
+    raw_attr = "" if raw_attr is None else raw_attr
+
+    attribute_str = raw_attr.decode("utf-8", "ignore") if isinstance(raw_attr, bytes) else str(raw_attr)
+    return attribute_str.replace("\r", "")
+
+
+class PytestLogInterceptorPlugin:
+    """Plugin that intercepts and modifies the log output
+
+    It modifies only the raw PyTest output, not the live
+    output coming from the DUT, etc.
+    """
+
+    def __init__(self, ctx: TestContext) -> None:
+        self._ctx = ctx
+        self._screen_writer = None
+        self._sink: TextIOWrapper | None = None
+        self._last_handled_state: tuple[Any, Any, Any] | None = None
+
+    @pytest.hookimpl(trylast=True)
+    def pytest_configure(self, config: Any) -> None:
+        terminal = config.pluginmanager.get_plugin("terminalreporter")
+        if not terminal:
+            return
+
+        if self._ctx.stream_output:
+            self._screen_writer = type(terminal._tw)(sys.stdout)
+
+        self._sink = open(os.devnull, "w")
+        terminal._tw._file = self._sink
+
+        config.option.disable_warnings = True
+        config.option.no_summary = True
+        terminal.summary_stats = lambda: None
+
+    @pytest.hookimpl(trylast=True)
+    def pytest_unconfigure(self, config: Any) -> None:
+        if self._sink is not None:
+            self._sink.close()
+            self._sink = None
+
+    @pytest.hookimpl(tryfirst=True)
+    def pytest_runtest_logstart(self, nodeid: str) -> None:
+        """Manually print start header to screen"""
+        if self._screen_writer is None:
+            return
+
+        self._flush_and_ensure_newline()
+        self._screen_writer.write(f"\t{bold(nodeid)}...")
+        self._screen_writer.write("\n")
+
+    @pytest.hookimpl(tryfirst=True)
+    def pytest_runtest_logreport(self, report: TestReport) -> None:
+        """Manually print status to screen."""
+        should_print = (report.when == "call") or (not report.passed)
+
+        if not should_print or self._screen_writer is None:
+            return
+
+        status = get_status(report)
+        reason = extract_reason_from_report(report)
+
+        self._flush_and_ensure_newline()
+
+        self._screen_writer.write(f"\t{bold(report.nodeid)} ")
+        self._screen_writer.write(status)
+
+        if reason:
+            self._screen_writer.write(f" ({reason})")
+
+        self._screen_writer.write("\n")
+
+    def _flush_and_get_last_char(self, pexpect_p: Any) -> str:
+        drained_last_char = ""
+        try:
+            while True:
+                chunk = pexpect_p.read_nonblocking(size=4096, timeout=0)
+                if not chunk:
+                    break
+
+                if isinstance(chunk, bytes):
+                    drained_last_char = chunk[-1:].decode("utf-8", "ignore")
+                else:
+                    drained_last_char = chunk[-1:]
+
+                # NOTE: The buffer appending operations below do not cause logfile duplication/
+                # The data is manually placed into the internal pexpect buffer, subsequent expect()
+                # calls omit the OS buffer pull operation that triggers the logfile write.
+                if isinstance(pexpect_p.buffer, bytes) and isinstance(chunk, str):
+                    pexpect_p.buffer += chunk.encode("utf-8", "ignore")
+                elif isinstance(pexpect_p.buffer, str) and isinstance(chunk, bytes):
+                    pexpect_p.buffer += chunk.decode("utf-8", "ignore")
+                else:
+                    pexpect_p.buffer += chunk
+        except (pexpect.TIMEOUT, pexpect.EOF):
+            pass
+
+        return drained_last_char
+
+    def _flush_and_ensure_newline(self) -> None:
+        """Flushes pending OS logs and ensures output ends with a newline.
+
+        This drains pending OS logs so they print continuously, restores them
+        so they can be parsed in the incoming test, and checks the absolute last character
+        to ensure the output ends with a newline for Pytest headers to format correctly.
+        """
+        dut = getattr(self._ctx.target, "dut", None)
+        pexpect_p = getattr(dut, "pexpect_proc", None)
+        if dut is None or pexpect_p is None:
+            return
+
+        drained_last_char = self._flush_and_get_last_char(pexpect_p)
+        last_char = ""
+
+        if drained_last_char:
+            last_char = drained_last_char
+            self._last_handled_state = (
+                getattr(pexpect_p, "before", ""),
+                getattr(pexpect_p, "after", ""),
+                getattr(pexpect_p, "buffer", ""),
+            )
+        else:
+            before = getattr(pexpect_p, "before", "")
+            after = getattr(pexpect_p, "after", "")
+            buffer = getattr(pexpect_p, "buffer", "")
+
+            current_state = (before, after, buffer)
+
+            prev_before, prev_after, prev_buffer = self._last_handled_state or (None, None, None)
+
+            if prev_before is before and prev_after is after and prev_buffer is buffer:
+                return
+
+            self._last_handled_state = current_state
+
+            raw_char = None
+
+            if buffer:
+                raw_char = buffer[-1:]
+            elif isinstance(after, (str, bytes)) and after:
+                raw_char = after[-1:]
+            elif isinstance(before, (str, bytes)) and before:
+                raw_char = before[-1:]
+
+            if isinstance(raw_char, bytes):
+                last_char = raw_char.decode("utf-8", "ignore")
+            elif raw_char is not None:
+                last_char = raw_char
+
+        if self._screen_writer and last_char and last_char not in ("\n", "\r"):
+            self._screen_writer.write("\n")
+
+
+class PytestBridgePlugin:
+    """Plugin that bridges the TestRunner and PyTest frameworks.
+
+    Each test case is run as TestRunner's subtest, accurately
+    capturing each subresult's runtime and status.
+    """
+
+    _unknown_fixture_str = "[UNKNOWN FIXTURE]"
+    _common_fast_fail_str = "Requires a previously failing fixture:"
+    _fast_fail_match_re = re.compile(rf"{re.escape(_common_fast_fail_str)} (\w+)")
+    _decorator_match_re = re.compile(r"@pytest\.fixture.*?def\s+(\w+)", re.DOTALL)
+
+    def __init__(self, dut: Dut, ctx: TestContext, result: TestResult, kwargs: dict) -> None:
+        self._dut = dut
+        self._ctx = ctx
+        self._result = result
+        self._kwargs = kwargs
+        self._pending_result = (Status.OK, "")
+        self._broken_fixtures: set[str] = set()
+
+    @pytest.fixture(scope="session")
+    def dut(self) -> Dut:
+        return self._dut
+
+    @pytest.fixture(scope="session")
+    def ctx(self) -> TestContext:
+        return self._ctx
+
+    @pytest.fixture(scope="session")
+    def kwargs(self) -> dict:
+        return self._kwargs
+
+    @pytest.hookimpl(tryfirst=True)
+    def pytest_runtest_setup(self, item: Function) -> None:
+        """Fail current test case immediately, if a required fixture failed
+        during previous test case's setup stage
+        """
+        for fixture in item.fixturenames:
+            if fixture in self._broken_fixtures:
+                pytest.fail(f"{self._common_fast_fail_str} {fixture}", pytrace=False)
+
+    @pytest.hookimpl(wrapper=True)
+    def pytest_runtest_makereport(self, item: Function, call: pytest.CallInfo) -> Generator[None, Any, TestReport]:
+        """Post-process PyTest's report making
+
+        Inject output caught before exception for a more detailed report.
+
+        Currently, TestResult failing methods fail the entire test with the
+        most recent exception, with no regard to individual subresults.
+
+        TODO: Modify TestResult failing methods to support single subresult
+        exceptions and use them here to avoid reimplementation.
+        """
+        report: TestReport = yield
+
+        if not report.failed or not call.excinfo:
+            return report
+
+        exc_instance = call.excinfo.value
+        report_add_info = None
+
+        before = get_str_attr(self._dut, "before")
+
+        if isinstance(exc_instance, (UnicodeDecodeError, pexpect.TIMEOUT, pexpect.EOF, AssertionError)) and before:
+            report_add_info = bold("OUTPUT CAUGHT BEFORE EXCEPTION:\n")
+            report_add_info += before
+
+        if report_add_info:
+            report.longrepr = str(report.longrepr) + "\n\n" + report_add_info
+        return report
+
+    @pytest.hookimpl()
+    def pytest_runtest_logreport(self, report: TestReport) -> None:
+        """PyTest hook called after a test phase completion.
+
+        Adds a TestRunner subresult for each PyTest case report
+
+        :param report: PyTest's TestReport object
+        """
+        error_msg = getattr(report, "longreprtext", str(report.longrepr)) if report.longrepr else ""
+
+        if report.when == "setup":
+            self._record_setup_phase(report, error_msg)
+
+        elif report.when == "call":
+            self._record_call_phase(report, error_msg)
+
+        elif report.when == "teardown":
+            self._finalize_and_report(report, error_msg)
+
+    def _record_setup_phase(self, report: TestReport, error_msg: str) -> None:
+        if report.failed:
+            fixture_name = self._extract_broken_fixture(error_msg)
+            self._pending_result = (Status.FAIL, error_msg)
+            if fixture_name != self._unknown_fixture_str:
+                # It is assumed that fixtures failing at startup should
+                # not be re-run, thus marking them as `broken`
+                self._broken_fixtures.add(fixture_name)
+        elif report.skipped:
+            skip_msg = extract_reason_from_report(report)
+            self._pending_result = (Status.SKIP, skip_msg)
+
+    def _record_call_phase(self, report: TestReport, error_msg: str) -> None:
+        status = Status.OK
+        msg = ""
+
+        if report.failed:
+            status = Status.FAIL
+            msg = error_msg
+        elif report.skipped:
+            # XFAIL is treated as SKIP to not confuse it with success but
+            # it is not a FAIL either. XPASS will still be treated as OK
+            status = Status.SKIP
+            msg = extract_reason_from_report(report)
+
+        self._pending_result = (status, msg)
+
+    def _finalize_and_report(self, report: TestReport, error_msg: str) -> None:
+        final_status, final_msg = self._pending_result
+
+        if report.failed:
+            final_status = Status.FAIL
+
+            if final_msg:
+                final_msg = f"{final_msg}\n{error_msg}"
+            else:
+                final_msg = error_msg
+
+        self._result.add_subresult(subname=report.nodeid.split("::")[-1], status=final_status, msg=final_msg)
+
+    @classmethod
+    def _extract_broken_fixture(cls, text: str) -> str:
+        fast_fail_match = cls._fast_fail_match_re.search(text)
+        if fast_fail_match:
+            return fast_fail_match.group(1)
+        decorator_match = cls._decorator_match_re.search(text)
+        if decorator_match:
+            return decorator_match.group(1)
+        return cls._unknown_fixture_str
+
+
+def pytest_harness(dut: Dut, ctx: TestContext, result: TestResult, **kwargs) -> TestResult:
+    test_path = kwargs.get("script")
+
+    if not test_path:
+        result.fail(msg="missing `script` from test configuration!")
+        return result
+
+    options = shlex.split(kwargs.get("options", ""))
+
+    bridge_plugin = PytestBridgePlugin(dut, ctx, result, kwargs)
+    log_plugin = PytestLogInterceptorPlugin(ctx)
+
+    cmd_args = [str(test_path), *options, "-s"]
+
+    try:
+        exit_code = pytest.main(cmd_args, plugins=[bridge_plugin, log_plugin])
+    except Exception:
+        result.fail_unknown_exception()
+        return result
+
+    accepted_codes = (pytest.ExitCode.OK, pytest.ExitCode.TESTS_FAILED, pytest.ExitCode.NO_TESTS_COLLECTED)
+
+    if exit_code not in accepted_codes:
+        result.fail(msg=f"Pytest execution failed (Exit Code {exit_code}).")
+
+    return result

--- a/trunner/target/base.py
+++ b/trunner/target/base.py
@@ -101,4 +101,4 @@ class TargetBase(ABC):
 
     @abstractmethod
     def build_test(self, test: TestOptions) -> Callable[[TestResult], TestResult]:
-        """Returns the complete harness to run the test secified in `test` argument"""
+        """Returns the complete harness to run the test specified in `test` argument"""


### PR DESCRIPTION
**PyTest support implementation for our existing testing framework.**

## Description
The implementation includes
- pytest harness
- pytest plugins:
  - plugin for IO Stream control
  - plugin bridging PyTest with our TestRunner (report)
- sample pytest tests with conftest.py
- TestType Enum for simpler and more controllable input validation

## Motivation and Context

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work ([#449](https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/449)).
- [ ] I will merge this PR by myself when appropriate.

## Previous conversation: https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/443