### PR TITLE
trunner: change clear_pexpect_buffer expect regex

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,5 +14,8 @@ on:
 
 jobs:
   call-ci:
-    uses: phoenix-rtos/phoenix-rtos-project/.github/workflows/ci-submodule.yml@master
+    uses: phoenix-rtos/phoenix-rtos-project/.github/workflows/ci-project.yml@master
+    with:
+      build_params: all tests
+      nightly: true
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   call-ci:
-    uses: phoenix-rtos/phoenix-rtos-project/.github/workflows/submodule.yml@master
+    uses: phoenix-rtos/phoenix-rtos-project/.github/workflows/ci-submodule.yml@master
     with:
       build_params: all tests
       nightly: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   call-ci:
-    uses: phoenix-rtos/phoenix-rtos-project/.github/workflows/ci-project.yml@master
+    uses: phoenix-rtos/phoenix-rtos-project/.github/workflows/submodule.yml@master
     with:
       build_params: all tests
       nightly: true

--- a/trunner/dut.py
+++ b/trunner/dut.py
@@ -27,7 +27,7 @@ def clear_pexpect_buffer(pexpect_obj):
 
     try:
         while True:
-            pexpect_obj.expect(r".+", timeout=0)
+            pexpect_obj.expect(r".+?", timeout=0)
     except (pexpect.TIMEOUT, pexpect.EOF):
         pass
 


### PR DESCRIPTION
Changing expect regex from greedy to lazy.
This allows for buffer capture to be more complete.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
