### PR TITLE
port: add tests for register and devs

### DIFF
--- a/port/Makefile
+++ b/port/Makefile
@@ -1,0 +1,10 @@
+#
+# Makefile for libphoenix tests
+#
+# Copyright 2026 Phoenix Systems
+#
+# %LICENSE%
+#
+
+$(eval $(call add_unity_test, test_register))
+$(eval $(call add_unity_test, test_dev))

--- a/port/test.yaml
+++ b/port/test.yaml
@@ -1,0 +1,9 @@
+test:
+    tests:
+        - name: test_register
+          type: unity
+          execute: test_register
+
+        - name: test_dev
+          type: unity
+          execute: test_dev

--- a/port/test_dev.c
+++ b/port/test_dev.c
@@ -1,0 +1,154 @@
+/*
+ * Phoenix-RTOS
+ *
+ * test_dev
+ *
+ * tests for `create_dev()` and `destroy_dev()` utility functions
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Julian Uziembło
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <posix/utils.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/msg.h>
+#include <unistd.h>
+
+#include "unity_fixture.h"
+
+#define DEV_PREFIX      "/dev"
+#define SIMPLE_DEV_NAME "simple"
+#define DIR1            "a"
+#define DIR2            "b"
+#define DIR3            "c"
+#define COMPLEX_PATH    DIR1 "/" DIR2 "/" DIR3
+
+#define TEST_PATH(oid, devpath, fullpath) \
+	do { \
+		oid_t _odev; \
+		TEST_ASSERT_EQUAL_MESSAGE(0, create_dev(&(oid), (devpath)), "create_dev failed"); \
+		TEST_ASSERT_EQUAL_MESSAGE(0, lookup((fullpath), NULL, &_odev), "lookup failed"); \
+		TEST_ASSERT_EQUAL_MEMORY_MESSAGE(&(oid), &_odev, sizeof(_odev), "oid is not the same"); \
+		TEST_ASSERT_EQUAL_MESSAGE(0, destroy_dev((devpath)), "destroy_dev failed"); \
+		TEST_ASSERT_LESS_THAN_MESSAGE(0, lookup((fullpath), NULL, &_odev), "lookup succeeded - should have failed"); \
+	} while (0)
+
+
+static uint32_t port;
+
+
+TEST_GROUP(test_dev);
+
+
+TEST_SETUP(test_dev)
+{
+}
+
+
+TEST_TEAR_DOWN(test_dev)
+{
+}
+
+
+/* TODO: revise these tests for `create_dev` once
+   the function is refactored; YT: RTOS-1262 */
+
+
+TEST(test_dev, simple_relpath)
+{
+	__attribute__((unused)) oid_t tmp;
+	if (lookup("devfs", NULL, &tmp) < 0 && lookup("/dev", NULL, &tmp) < 0) {
+		TEST_IGNORE_MESSAGE("relpath doesn't work on this target");
+	}
+	oid_t oid = { .port = port, .id = 0 };
+	const char *relpath = SIMPLE_DEV_NAME;
+	const char *fullpath = DEV_PREFIX "/" SIMPLE_DEV_NAME;
+
+	/* through only dev name */
+	TEST_PATH(oid, relpath, fullpath);
+}
+
+
+TEST(test_dev, simple_fullpath)
+{
+	oid_t oid = { .port = port, .id = 0 };
+	const char *fullpath = DEV_PREFIX "/" SIMPLE_DEV_NAME;
+
+	/* through full path */
+	TEST_PATH(oid, fullpath, fullpath);
+}
+
+
+TEST(test_dev, complex_relpath)
+{
+	__attribute__((unused)) oid_t tmp;
+	if (lookup("devfs", NULL, &tmp) < 0 && lookup("/dev", NULL, &tmp) < 0) {
+		TEST_IGNORE_MESSAGE("relpath doesn't work on this target");
+	}
+	oid_t oid = { .port = port, .id = 0 };
+	const char *relpath = COMPLEX_PATH "/" SIMPLE_DEV_NAME;
+	const char *fullpath = DEV_PREFIX "/" COMPLEX_PATH "/" SIMPLE_DEV_NAME;
+
+	/* through only dev name */
+	TEST_PATH(oid, relpath, fullpath);
+
+	/* cleanup */
+	TEST_ASSERT_EQUAL(0, rmdir(DEV_PREFIX "/" DIR1 "/" DIR2 "/" DIR3));
+	TEST_ASSERT_LESS_THAN(0, lookup(DEV_PREFIX "/" DIR1 "/" DIR2 "/" DIR3, NULL, &oid));
+	TEST_ASSERT_EQUAL(0, rmdir(DEV_PREFIX "/" DIR1 "/" DIR2));
+	TEST_ASSERT_LESS_THAN(0, lookup(DEV_PREFIX "/" DIR1 "/" DIR2, NULL, &oid));
+	TEST_ASSERT_EQUAL(0, rmdir(DEV_PREFIX "/" DIR1));
+	TEST_ASSERT_LESS_THAN(0, lookup(DEV_PREFIX "/" DIR1, NULL, &oid));
+}
+
+
+TEST(test_dev, complex_fullpath)
+{
+	oid_t oid = { .port = port, .id = 0 };
+	const char *fullpath = DEV_PREFIX "/" COMPLEX_PATH "/" SIMPLE_DEV_NAME;
+
+	/* through full path */
+	TEST_PATH(oid, fullpath, fullpath);
+
+	/* cleanup */
+	TEST_ASSERT_EQUAL(0, rmdir(DEV_PREFIX "/" DIR1 "/" DIR2 "/" DIR3));
+	TEST_ASSERT_LESS_THAN(0, lookup(DEV_PREFIX "/" DIR1 "/" DIR2 "/" DIR3, NULL, &oid));
+	TEST_ASSERT_EQUAL(0, rmdir(DEV_PREFIX "/" DIR1 "/" DIR2));
+	TEST_ASSERT_LESS_THAN(0, lookup(DEV_PREFIX "/" DIR1 "/" DIR2, NULL, &oid));
+	TEST_ASSERT_EQUAL(0, rmdir(DEV_PREFIX "/" DIR1));
+	TEST_ASSERT_LESS_THAN(0, lookup(DEV_PREFIX "/" DIR1, NULL, &oid));
+}
+
+
+TEST_GROUP_RUNNER(test_dev)
+{
+	RUN_TEST_CASE(test_dev, simple_relpath);
+	RUN_TEST_CASE(test_dev, simple_fullpath);
+	RUN_TEST_CASE(test_dev, complex_relpath);
+	RUN_TEST_CASE(test_dev, complex_fullpath);
+}
+
+static void runner(void)
+{
+	RUN_TEST_GROUP(test_dev);
+}
+
+
+int main(int argc, char *argv[])
+{
+	int err = portCreate(&port);
+	if (err < 0) {
+		fprintf(stderr, "Could not create port: %s (%d)\n", strerror(-err), -err);
+		return EXIT_FAILURE;
+	}
+	err = (UnityMain(argc, (const char **)argv, runner) == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+	portDestroy(port);
+	return err;
+}

--- a/port/test_register.c
+++ b/port/test_register.c
@@ -1,0 +1,172 @@
+/*
+ * Phoenix-RTOS
+ *
+ * test_register
+ *
+ * tests for `portRegister` and `portUnregister` syscalls
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Julian Uziembło
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/msg.h>
+#include <unistd.h>
+
+#include "unity_fixture.h"
+
+#define LETTERS_IN_ALPHABET ('z' - 'a' + 1)
+#define NDEVS               (LETTERS_IN_ALPHABET * LETTERS_IN_ALPHABET)
+#define DEVNAMSIZ           2
+
+#define SIMPLE_PORT_NAME "/simple_test"
+
+#define TEST_PORT_REGISTER(name, oid) \
+	do { \
+		uint32_t _port = (oid).port; \
+		id_t _id = (oid).id; \
+		oid_t _odev, _ofil; \
+		TEST_ASSERT_EQUAL_MESSAGE(0, portRegister(_port, (name), &(oid)), (name)); \
+		TEST_ASSERT_EQUAL_MESSAGE(_port, (oid).port, (name)); \
+		TEST_ASSERT_EQUAL_MESSAGE(_id, (oid).id, (name)); \
+		TEST_ASSERT_EQUAL_MESSAGE(0, lookup(name, &_ofil, &_odev), name); \
+	} while (0)
+
+
+static uint32_t port;
+
+
+TEST_GROUP(test_register);
+
+TEST_SETUP(test_register)
+{
+}
+
+TEST_TEAR_DOWN(test_register)
+{
+	/* in any case, unregister the SIMPLE_PORT_NAME */
+	portUnregister(SIMPLE_PORT_NAME);
+}
+
+TEST(test_register, simple)
+{
+	const id_t id = 0;
+	oid_t oid = { .port = port, .id = id }, ofil, odev;
+	TEST_PORT_REGISTER(SIMPLE_PORT_NAME, oid);
+
+	TEST_ASSERT_EQUAL(0, portUnregister(SIMPLE_PORT_NAME));
+
+	TEST_ASSERT_LESS_THAN(0, lookup(SIMPLE_PORT_NAME, &ofil, &odev));
+
+	TEST_ASSERT_EQUAL(-ENOENT, portUnregister(SIMPLE_PORT_NAME));
+}
+
+TEST(test_register, register_existing)
+{
+	const id_t id = 0;
+	oid_t oid = { .port = port, .id = id };
+	TEST_PORT_REGISTER(SIMPLE_PORT_NAME, oid);
+
+	TEST_ASSERT_EQUAL(-EEXIST, portRegister(port, SIMPLE_PORT_NAME, &oid));
+
+	TEST_ASSERT_EQUAL(0, portUnregister(SIMPLE_PORT_NAME));
+
+	TEST_ASSERT_EQUAL(-ENOENT, portUnregister(SIMPLE_PORT_NAME));
+}
+
+TEST(test_register, bad_port)
+{
+	/* check if we can register a port with an invalid oid. */
+	/* TODO: revise if this behavior is the correct one */
+	const id_t id = 0;
+	oid_t oid = { .port = port, .id = id }, odev;
+
+	/* make sure this port doesn't exist by destroying it */
+	portDestroy(port);
+
+	/* port should still be registered */
+	TEST_ASSERT_EQUAL(0, portRegister(port, SIMPLE_PORT_NAME, &oid));
+	TEST_ASSERT_EQUAL(0, lookup(SIMPLE_PORT_NAME, NULL, &odev));
+
+	/* re-create the port */
+	TEST_ASSERT_GREATER_OR_EQUAL(0, portCreate(&port));
+}
+
+
+static struct {
+	char name[DEVNAMSIZ + 1];
+	oid_t oid;
+} devs[NDEVS];
+
+
+TEST_GROUP(test_register_many);
+
+TEST_SETUP(test_register_many)
+{
+	/* prepare names and oids */
+	for (int i = 0; i < NDEVS; i++) {
+		/* names will follow pattern: aa, ab, ..., ba, bb, ... */
+		devs[i].name[0] = 'a' + (i / LETTERS_IN_ALPHABET);
+		devs[i].name[1] = 'a' + (i % LETTERS_IN_ALPHABET);
+		devs[i].name[2] = '\0';
+		devs[i].oid.port = port;
+		devs[i].oid.id = i;
+	}
+}
+
+TEST_TEAR_DOWN(test_register_many)
+{
+	/* unregister if not already unregistered */
+	for (int i = 0; i < NDEVS; i++) {
+		portUnregister(devs[i].name);
+	}
+}
+
+
+TEST(test_register_many, register_many)
+{
+	oid_t ofil, odev;
+
+	for (int i = 0; i < NDEVS; i++) {
+		TEST_PORT_REGISTER(devs[i].name, devs[i].oid);
+		TEST_ASSERT_EQUAL_MESSAGE(0, portUnregister(devs[i].name), devs[i].name);
+		TEST_ASSERT_LESS_THAN_MESSAGE(0, lookup(devs[i].name, &ofil, &odev), devs[i].name);
+	}
+}
+
+TEST_GROUP_RUNNER(test_register)
+{
+	RUN_TEST_CASE(test_register, simple);
+	RUN_TEST_CASE(test_register, register_existing);
+	RUN_TEST_CASE(test_register, bad_port);
+}
+
+TEST_GROUP_RUNNER(test_register_many)
+{
+	RUN_TEST_CASE(test_register_many, register_many);
+}
+
+static void runner(void)
+{
+	RUN_TEST_GROUP(test_register);
+	RUN_TEST_GROUP(test_register_many);
+}
+
+int main(int argc, char *argv[])
+{
+	int err = portCreate(&port);
+	if (err < 0) {
+		fprintf(stderr, "Could not create port: %s (%d)\n", strerror(-err), -err);
+		return EXIT_FAILURE;
+	}
+	err = (UnityMain(argc, (const char **)argv, runner) == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+	portDestroy(port);
+	return err;
+}


### PR DESCRIPTION
Add tests for portRegister and portUnregister syscalls, create_dev() and destroy_dev() functions.

YT: CI-651

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
Depends-On: libphoenix:julianuziemblo/remove_dev
Depends-On: phoenix-rtos-kernel:julianuziemblo/port-unregister

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [x] New test added: *this*
- [x] Tested by hand on: `ia32-generic-qemu`, `armv7m7-imxrt117x-evk`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work:
    - https://github.com/phoenix-rtos/libphoenix/pull/466
    - https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/750
- [ ] I will merge this PR by myself when appropriate.
