### PR TITLE
libc: add dirent tests

### DIFF
--- a/libc/Makefile
+++ b/libc/Makefile
@@ -47,3 +47,7 @@ $(eval $(call add_test_libc,math, -lm, -ffloat-store)) # -ffloat-store - prevent
 $(eval $(call add_test_libc_custom,socket,inet-socket,, -Wno-attribute-warning, inet-socket.c common.c))
 $(eval $(call add_test_libc_custom,socket,unix-socket,, -Wno-attribute-warning, unix-socket.c common.c))
 $(eval $(call add_test_libc,poll))
+$(eval $(call add_test_libc,dirent, -lpthread))
+# -fno-bultin - prevent compiler to replace math funcs with compiler builtins
+# -ffloat-store - prevent extended precision on ia32
+$(eval $(call add_test_libc,math, -lm, -fno-builtin -ffloat-store))

--- a/libc/Makefile
+++ b/libc/Makefile
@@ -48,6 +48,3 @@ $(eval $(call add_test_libc_custom,socket,inet-socket,, -Wno-attribute-warning, 
 $(eval $(call add_test_libc_custom,socket,unix-socket,, -Wno-attribute-warning, unix-socket.c common.c))
 $(eval $(call add_test_libc,poll))
 $(eval $(call add_test_libc,dirent, -lpthread))
-# -fno-bultin - prevent compiler to replace math funcs with compiler builtins
-# -ffloat-store - prevent extended precision on ia32
-$(eval $(call add_test_libc,math, -lm, -fno-builtin -ffloat-store))

--- a/libc/dirent/closedir.c
+++ b/libc/dirent/closedir.c
@@ -1,0 +1,154 @@
+/*
+ * Phoenix-RTOS
+ *
+ * POSIX.1-2017 standard library functions tests
+ * HEADER:
+ *    - dirent.h
+ * TESTED:
+ *    - closedir()
+ *
+ * Copyright 2023 Phoenix Systems
+ * Author: Arkadiusz Kozlowski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <dirent.h>
+#include <errno.h>
+#include <string.h>
+
+#include <unity_fixture.h>
+#include "common.h"
+#include "dirent_helper_functions.h"
+
+#define MAIN_DIR "test_closedir"
+
+TEST_GROUP(dirent_closedir);
+
+
+TEST_SETUP(dirent_closedir)
+{
+	errno = 0;
+	TEST_MKDIR_ASSERTED(MAIN_DIR, S_IRWXU);
+	errno = 0;
+	TEST_MKDIR_ASSERTED(MAIN_DIR "/dir1", S_IRUSR);
+}
+
+
+TEST_TEAR_DOWN(dirent_closedir)
+{
+	rmdir(MAIN_DIR "/dir1");
+	rmdir(MAIN_DIR);
+}
+
+
+TEST(dirent_closedir, closing_empty_dir)
+{
+	DIR *dp = opendir(MAIN_DIR "/dir1");
+
+	TEST_ASSERT_NOT_NULL(dp);
+	TEST_ASSERT_EQUAL_INT(0, closedir(dp));
+}
+
+
+TEST(dirent_closedir, closing_non_empty_dir)
+{
+	DIR *dp = opendir(MAIN_DIR);
+
+	TEST_ASSERT_NOT_NULL(dp);
+	TEST_ASSERT_EQUAL_INT(0, closedir(dp));
+}
+
+
+TEST(dirent_closedir, preserving_content_after_closedir)
+{
+	char dirNames[7][10];
+	ino_t inodes[7];
+	struct dirent *info;
+	DIR *dp1;
+	int result = 0;
+	errno = 0;
+
+
+	TEST_MKDIR_ASSERTED(MAIN_DIR "/test_preserve", S_IRWXU);
+	TEST_MKDIR_ASSERTED(MAIN_DIR "/test_preserve/B", S_IRUSR);
+	TEST_MKDIR_ASSERTED(MAIN_DIR "/test_preserve/CC", S_IRUSR);
+	TEST_MKDIR_ASSERTED(MAIN_DIR "/test_preserve/DDDD", S_IRUSR);
+	TEST_MKDIR_ASSERTED(MAIN_DIR "/test_preserve/EEEEEE", S_IRUSR);
+
+
+	dp1 = opendir(MAIN_DIR "/test_preserve");
+	TEST_ASSERT_NOT_NULL(dp1);
+
+	/*
+	 *Create an array with names of dirs.
+	 *Indexes will be used to associate name of each directory with a bit
+	 */
+
+	{
+		int i = 0;
+		while ((info = readdir(dp1)) != NULL) {
+			inodes[i] = info->d_ino;
+			strcpy(dirNames[i++], info->d_name);
+		}
+	}
+
+	TEST_ASSERT_EQUAL_INT(0, closedir(dp1));
+	DIR *dp2 = opendir(MAIN_DIR "/test_preserve");
+	TEST_ASSERT_NOT_NULL(dp2);
+	rewinddir(dp2);
+
+	/*
+	 * Map each directory to a bit.
+	 * In case of fail set most left bit to 1.
+	 * Assert every bit is high except the first two.
+	 */
+
+	/* Go through each entry */
+
+	while ((info = readdir(dp2)) != NULL) {
+		int found = 0;
+		char name[10];
+		strcpy(name, info->d_name);
+
+		/* determine the index of given name */
+		for (int i = 0; i < 7; ++i) {
+			if (!strcmp(name, dirNames[i])) {
+				TEST_ASSERT_EQUAL_INT64(inodes[i], info->d_ino);
+				/* Set the index bit of found name */
+				result |= 1 << i;
+
+				found = 1;
+			}
+		}
+		/* Name found, time to search for another name */
+		if (found) {
+			continue;
+		}
+
+		TEST_FAIL();
+	}
+
+	/* result variable should be 0b0011 1111, which is 63, or 3f */
+	TEST_ASSERT_EQUAL_INT(0x3f, result);
+
+	closedir(dp2);
+
+	rmdir(MAIN_DIR "/test_preserve/B");
+	rmdir(MAIN_DIR "/test_preserve/CC");
+	rmdir(MAIN_DIR "/test_preserve/DDDD");
+	rmdir(MAIN_DIR "/test_preserve/EEEEEE");
+	rmdir(MAIN_DIR "/test_preserve");
+}
+
+
+TEST_GROUP_RUNNER(dirent_closedir)
+{
+	RUN_TEST_CASE(dirent_closedir, closing_empty_dir);
+	RUN_TEST_CASE(dirent_closedir, closing_non_empty_dir);
+	RUN_TEST_CASE(dirent_closedir, preserving_content_after_closedir);
+}

--- a/libc/dirent/closedir.c
+++ b/libc/dirent/closedir.c
@@ -7,8 +7,8 @@
  * TESTED:
  *    - closedir()
  *
- * Copyright 2023 Phoenix Systems
- * Author: Arkadiusz Kozlowski
+ * Copyright 2023-2026 Phoenix Systems
+ * Authors: Arkadiusz Kozlowski, Lukasz Kruszynski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -20,6 +20,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include <unity_fixture.h>
 #include "common.h"
@@ -32,9 +33,7 @@ TEST_GROUP(dirent_closedir);
 
 TEST_SETUP(dirent_closedir)
 {
-	errno = 0;
 	TEST_MKDIR_ASSERTED(MAIN_DIR, S_IRWXU);
-	errno = 0;
 	TEST_MKDIR_ASSERTED(MAIN_DIR "/dir1", S_IRUSR);
 }
 
@@ -46,97 +45,82 @@ TEST_TEAR_DOWN(dirent_closedir)
 }
 
 
-TEST(dirent_closedir, closing_empty_dir)
+TEST(dirent_closedir, closes_empty_dir)
 {
-	DIR *dp = opendir(MAIN_DIR "/dir1");
+	DIR *dp = TEST_OPENDIR_ASSERTED(MAIN_DIR "/dir1");
 
 	TEST_ASSERT_NOT_NULL(dp);
 	TEST_ASSERT_EQUAL_INT(0, closedir(dp));
 }
 
 
-TEST(dirent_closedir, closing_non_empty_dir)
+TEST(dirent_closedir, closes_non_empty_dir)
 {
-	DIR *dp = opendir(MAIN_DIR);
+	DIR *dp = TEST_OPENDIR_ASSERTED(MAIN_DIR);
 
 	TEST_ASSERT_NOT_NULL(dp);
 	TEST_ASSERT_EQUAL_INT(0, closedir(dp));
 }
 
 
-TEST(dirent_closedir, preserving_content_after_closedir)
+TEST(dirent_closedir, preserves_content_after_use)
 {
-	char dirNames[7][10];
-	ino_t inodes[7];
+	char dirNames[10][NAME_MAX + 1];
+	ino_t inodes[10];
 	struct dirent *info;
-	DIR *dp1;
+	DIR *dp1 = NULL, *dp2 = NULL;
 	int result = 0;
+	int num_entries = 0;
 	errno = 0;
 
+	if (TEST_PROTECT()) {
+		TEST_MKDIR_ASSERTED(MAIN_DIR "/test_preserve", S_IRWXU);
+		TEST_MKDIR_ASSERTED(MAIN_DIR "/test_preserve/B", S_IRUSR);
+		TEST_MKDIR_ASSERTED(MAIN_DIR "/test_preserve/CC", S_IRUSR);
+		TEST_MKDIR_ASSERTED(MAIN_DIR "/test_preserve/DDDD", S_IRUSR);
+		TEST_MKDIR_ASSERTED(MAIN_DIR "/test_preserve/EEEEEE", S_IRUSR);
+		dp1 = opendir(MAIN_DIR "/test_preserve");
+		TEST_ASSERT_NOT_NULL(dp1);
 
-	TEST_MKDIR_ASSERTED(MAIN_DIR "/test_preserve", S_IRWXU);
-	TEST_MKDIR_ASSERTED(MAIN_DIR "/test_preserve/B", S_IRUSR);
-	TEST_MKDIR_ASSERTED(MAIN_DIR "/test_preserve/CC", S_IRUSR);
-	TEST_MKDIR_ASSERTED(MAIN_DIR "/test_preserve/DDDD", S_IRUSR);
-	TEST_MKDIR_ASSERTED(MAIN_DIR "/test_preserve/EEEEEE", S_IRUSR);
-
-
-	dp1 = opendir(MAIN_DIR "/test_preserve");
-	TEST_ASSERT_NOT_NULL(dp1);
-
-	/*
-	 *Create an array with names of dirs.
-	 *Indexes will be used to associate name of each directory with a bit
-	 */
-
-	{
-		int i = 0;
-		while ((info = readdir(dp1)) != NULL) {
-			inodes[i] = info->d_ino;
-			strcpy(dirNames[i++], info->d_name);
+		while ((info = readdir(dp1)) != NULL && num_entries < 10) {
+			inodes[num_entries] = info->d_ino;
+			strcpy(dirNames[num_entries++], info->d_name);
 		}
-	}
 
-	TEST_ASSERT_EQUAL_INT(0, closedir(dp1));
-	DIR *dp2 = opendir(MAIN_DIR "/test_preserve");
-	TEST_ASSERT_NOT_NULL(dp2);
-	rewinddir(dp2);
+		TEST_ASSERT_EQUAL_INT(0, closedir(dp1));
+		dp1 = NULL;
 
-	/*
-	 * Map each directory to a bit.
-	 * In case of fail set most left bit to 1.
-	 * Assert every bit is high except the first two.
-	 */
+		dp2 = opendir(MAIN_DIR "/test_preserve");
+		TEST_ASSERT_NOT_NULL(dp2);
 
-	/* Go through each entry */
+		while ((info = readdir(dp2)) != NULL) {
+			int found = 0;
 
-	while ((info = readdir(dp2)) != NULL) {
-		int found = 0;
-		char name[10];
-		strcpy(name, info->d_name);
-
-		/* determine the index of given name */
-		for (int i = 0; i < 7; ++i) {
-			if (!strcmp(name, dirNames[i])) {
-				TEST_ASSERT_EQUAL_INT64(inodes[i], info->d_ino);
-				/* Set the index bit of found name */
-				result |= 1 << i;
-
-				found = 1;
+			for (int i = 0; i < num_entries; ++i) {
+				if (!strcmp(info->d_name, dirNames[i])) {
+					TEST_ASSERT_EQUAL_INT64(inodes[i], info->d_ino);
+					/* Set the index bit of found name */
+					result |= (1 << i);
+					found = 1;
+					break;
+				}
 			}
-		}
-		/* Name found, time to search for another name */
-		if (found) {
-			continue;
+			TEST_ASSERT_EQUAL_INT(1, found);
 		}
 
-		TEST_FAIL();
+		/* Dynamically calculate the expected bitmask (e.g., 6 entries = (1<<6)-1 = 63 = 0x3f) */
+		int expected_mask = (1 << num_entries) - 1;
+		TEST_ASSERT_EQUAL_INT(expected_mask, result);
+		TEST_ASSERT_EQUAL_INT(0, closedir(dp2));
+		dp2 = NULL;
 	}
 
-	/* result variable should be 0b0011 1111, which is 63, or 3f */
-	TEST_ASSERT_EQUAL_INT(0x3f, result);
-
-	closedir(dp2);
+	if (dp1 != NULL) {
+		closedir(dp1);
+	}
+	if (dp2 != NULL) {
+		closedir(dp2);
+	}
 
 	rmdir(MAIN_DIR "/test_preserve/B");
 	rmdir(MAIN_DIR "/test_preserve/CC");
@@ -146,9 +130,31 @@ TEST(dirent_closedir, preserving_content_after_closedir)
 }
 
 
+TEST(dirent_closedir, releases_file_descriptor)
+{
+	DIR *dp;
+
+	long fd_limit = sysconf(_SC_OPEN_MAX);
+
+	if (fd_limit <= 0) {
+		/* value high enough to cause a potential leak */
+		fd_limit = 2000;
+	}
+
+	long loop_count = fd_limit + 10;
+
+	for (long i = 0; i < loop_count; i++) {
+		dp = opendir(MAIN_DIR);
+		TEST_ASSERT_NOT_NULL(dp);
+		TEST_ASSERT_EQUAL_INT(0, closedir(dp));
+	}
+}
+
+
 TEST_GROUP_RUNNER(dirent_closedir)
 {
-	RUN_TEST_CASE(dirent_closedir, closing_empty_dir);
-	RUN_TEST_CASE(dirent_closedir, closing_non_empty_dir);
-	RUN_TEST_CASE(dirent_closedir, preserving_content_after_closedir);
+	RUN_TEST_CASE(dirent_closedir, closes_empty_dir);
+	RUN_TEST_CASE(dirent_closedir, closes_non_empty_dir);
+	RUN_TEST_CASE(dirent_closedir, preserves_content_after_use);
+	RUN_TEST_CASE(dirent_closedir, releases_file_descriptor);
 }

--- a/libc/dirent/dirent_helper_functions.h
+++ b/libc/dirent/dirent_helper_functions.h
@@ -1,0 +1,19 @@
+#ifndef _DIRENT_HELPER_FUNCTIONS_H
+#define _DIRENT_HELPER_FUNCTIONS_H
+
+#include <dirent.h>
+#include <sys/stat.h>
+#include <string.h>
+
+
+#define TEST_MKDIR_ASSERTED(path, mode) TEST_ASSERT_TRUE_MESSAGE(mkdir(path, mode) != -1 || errno == EEXIST, strerror(errno))
+
+#define TEST_OPENDIR_ASSERTED(path) \
+	({ \
+		DIR *dp = opendir(path); \
+		TEST_ASSERT_NOT_NULL(dp); \
+		dp; \
+	})
+
+
+#endif

--- a/libc/dirent/dirent_helper_functions.h
+++ b/libc/dirent/dirent_helper_functions.h
@@ -1,12 +1,39 @@
-#ifndef _DIRENT_HELPER_FUNCTIONS_H
-#define _DIRENT_HELPER_FUNCTIONS_H
+/*
+ * Phoenix-RTOS
+ *
+ * test-libc-dirent
+ *
+ * Test helper functions.
+ *
+ * Copyright 2023-2026 Phoenix Systems
+ * Author: Arkadiusz Kozlowski, Lukasz Kruszynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#ifndef DIRENT_HELPER_FUNCTIONS_H
+#define DIRENT_HELPER_FUNCTIONS_H
 
 #include <dirent.h>
 #include <sys/stat.h>
 #include <string.h>
+#include <errno.h>
+#include <unity.h>
+#include <stdbool.h>
 
 
-#define TEST_MKDIR_ASSERTED(path, mode) TEST_ASSERT_TRUE_MESSAGE(mkdir(path, mode) != -1 || errno == EEXIST, strerror(errno))
+static inline bool ensure_new_dir_is_made(const char *path, mode_t mode)
+{
+	if (mkdir(path, mode) == 0) {
+		return true;
+	}
+
+	return false;
+}
+
+#define TEST_MKDIR_ASSERTED(path, mode) TEST_ASSERT_TRUE(ensure_new_dir_is_made(path, mode))
 
 #define TEST_OPENDIR_ASSERTED(path) \
 	({ \

--- a/libc/dirent/main.c
+++ b/libc/dirent/main.c
@@ -1,0 +1,33 @@
+/*
+ * Phoenix-RTOS
+ *
+ * test-libc-dirent
+ *
+ * Main entry point.
+ *
+ * Copyright 2023 Phoenix Systems
+ * Author: Arkadiusz Kozlowski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include "unity_fixture.h"
+
+/* No need for forward declarations, RUN_TEST_GROUP does it by itself */
+void runner(void)
+{
+	RUN_TEST_GROUP(dirent_opendir);
+	RUN_TEST_GROUP(dirent_closedir);
+	RUN_TEST_GROUP(dirent_readdir);
+	RUN_TEST_GROUP(dirent_rewinddir);
+}
+
+
+int main(int argc, char *argv[])
+{
+	UnityMain(argc, (const char **)argv, runner);
+
+	return 0;
+}

--- a/libc/dirent/opendir.c
+++ b/libc/dirent/opendir.c
@@ -1,0 +1,369 @@
+/*
+ * Phoenix-RTOS
+ *
+ * POSIX.1-2017 standard library functions tests
+ * HEADER:
+ *    - dirent.h
+ * TESTED:
+ *    - opendir()
+ *
+ * Copyright 2023 Phoenix Systems
+ * Author: Arkadiusz Kozlowski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+
+#include <unity_fixture.h>
+
+#include "common.h"
+#include "dirent_helper_functions.h"
+
+#define MAIN_DIR "test_opendir"
+
+static int test_create_directories(int num_of_dirs)
+{
+
+	char dirPath[40];
+	DIR *dirs[num_of_dirs];
+	int opened_dirs = 0;
+	int result = 0;
+
+	/* Create directories in batch */
+	for (int i = 0; i < num_of_dirs; ++i) {
+
+		sprintf(dirPath, MAIN_DIR "/%d", i);
+
+		TEST_MKDIR_ASSERTED(dirPath, S_IRUSR);
+	}
+
+	/* Open directories one by one, until one of them fails */
+	for (int i = 0; i < num_of_dirs; ++i) {
+
+		sprintf(dirPath, MAIN_DIR "/%d", i);
+
+		/*
+		 * Guard clause that skips current take if dir was opened,
+		 * Upon failing it proceeds to cleanup
+		 */
+		if ((dirs[i] = opendir(dirPath)) != NULL) {
+			opened_dirs = i;
+			continue;
+		}
+
+		result = -1;
+		break;
+	}
+
+	for (int i = 0; i <= opened_dirs; ++i) {
+		TEST_ASSERT_EQUAL_INT(0, closedir(dirs[i]));
+	}
+
+
+	for (int i = 0; i < num_of_dirs; ++i) {
+		sprintf(dirPath, MAIN_DIR "/%d", i);
+		rmdir(dirPath);
+	}
+
+	return result;
+}
+
+
+TEST_GROUP(dirent_opendir);
+
+
+TEST_SETUP(dirent_opendir)
+{
+	TEST_MKDIR_ASSERTED(MAIN_DIR, S_IRWXU);
+}
+
+
+TEST_TEAR_DOWN(dirent_opendir)
+{
+	rmdir(MAIN_DIR);
+}
+
+
+TEST(dirent_opendir, opening_empty_directory)
+{
+	DIR *dp;
+	TEST_MKDIR_ASSERTED(MAIN_DIR "/empty_dir", S_IRUSR);
+	dp = opendir(MAIN_DIR "/empty_dir");
+	TEST_ASSERT_NOT_NULL(dp);
+	closedir(dp);
+	rmdir(MAIN_DIR "/empty_dir");
+}
+
+
+TEST(dirent_opendir, opening_not_empty_directory)
+{
+	DIR *dp;
+	dp = opendir(MAIN_DIR);
+	TEST_ASSERT_NOT_NULL(dp);
+	closedir(dp);
+}
+
+
+TEST(dirent_opendir, no_read_permission)
+{
+	TEST_IGNORE_MESSAGE("#937 issue");
+
+	char unreadable[] = MAIN_DIR "/dir_without_read_perm";
+	char readable[] = MAIN_DIR "/dir_without_read_perm/readable_dir";
+	DIR *dirPtr;
+
+	TEST_MKDIR_ASSERTED(unreadable, 0000);
+
+	chmod(unreadable, S_IRWXU);
+	TEST_MKDIR_ASSERTED(readable, S_IRUSR | S_IWUSR);
+	chmod(unreadable, 0000);
+
+	/* Try to read from locked directory */
+	errno = 0;
+	dirPtr = opendir(unreadable);
+	TEST_ASSERT_EQUAL_INT(EACCES, errno);
+	TEST_ASSERT_NULL(dirPtr);
+
+	/* Try to read from available directory inside locked directory */
+	errno = 0;
+	dirPtr = opendir(readable);
+	TEST_ASSERT_EQUAL_INT(EACCES, errno);
+	TEST_ASSERT_NULL(dirPtr);
+
+	/* No execute permission in parent*/
+	chmod(unreadable, S_IRUSR | S_IWUSR);
+	errno = 0;
+	dirPtr = opendir(readable);
+	TEST_ASSERT_EQUAL_INT(EACCES, errno);
+	TEST_ASSERT_NULL(dirPtr);
+
+	/* No read permission */
+	chmod(unreadable, S_IWUSR | S_IXUSR);
+	errno = 0;
+	dirPtr = opendir(unreadable);
+	TEST_ASSERT_EQUAL_INT(EACCES, errno);
+	TEST_ASSERT_NULL(dirPtr);
+
+
+	errno = 0;
+	chmod(unreadable, S_IRWXU);
+	rmdir(readable);
+	rmdir(unreadable);
+}
+
+
+TEST(dirent_opendir, wrong_directory_name)
+{
+	errno = 0;
+	DIR *dirPtr = opendir(MAIN_DIR "/not_existing_directory");
+	TEST_ASSERT_EQUAL_INT(ENOENT, errno);
+	TEST_ASSERT_NULL(dirPtr);
+
+	errno = 0;
+	dirPtr = opendir("");
+	TEST_ASSERT_NULL(dirPtr);
+	TEST_ASSERT_EQUAL_INT(ENOENT, errno);
+}
+
+
+TEST(dirent_opendir, not_a_directory)
+{
+	close(creat(MAIN_DIR "/notadir.txt", S_IRUSR));
+	errno = 0;
+	DIR *dirPtr = opendir(MAIN_DIR "/notadir.txt");
+	TEST_ASSERT_EQUAL_INT(ENOTDIR, errno);
+	TEST_ASSERT_NULL(dirPtr);
+	remove(MAIN_DIR "/notadir.txt");
+}
+
+
+TEST(dirent_opendir, creating_dirs_in_closed_and_open_directories)
+{
+	/* Create dir in closed directory */
+	DIR *dirs[4];
+	TEST_MKDIR_ASSERTED(MAIN_DIR "/formerDir", S_IRUSR);
+
+	/* Create dir in opened directory, then close opened one */
+	DIR *dp = TEST_OPENDIR_ASSERTED(MAIN_DIR);
+	TEST_ASSERT_NOT_NULL(dirs[0] = opendir(MAIN_DIR "/formerDir"));
+
+	TEST_MKDIR_ASSERTED(MAIN_DIR "/latterDir", S_IRUSR);
+
+	closedir(dp);
+
+	/* Assure that both dirs can be opened without problems */
+	TEST_ASSERT_NOT_NULL(dirs[1] = opendir(MAIN_DIR "/formerDir"));
+	TEST_ASSERT_NOT_NULL(dirs[2] = opendir(MAIN_DIR "/latterDir"));
+
+	dp = opendir(MAIN_DIR);
+	TEST_ASSERT_NOT_NULL(dp);
+
+	TEST_MKDIR_ASSERTED("ToBeDeleted", S_IRUSR);
+	TEST_ASSERT_EQUAL_INT(0, rmdir("ToBeDeleted"));
+	TEST_ASSERT_EQUAL_INT(0, closedir(dp));
+
+	TEST_ASSERT_NULL(opendir("ToBeDeleted"));
+	TEST_MKDIR_ASSERTED(MAIN_DIR "/evenLatterDir", S_IRUSR);
+	TEST_ASSERT_NOT_NULL(dirs[3] = opendir(MAIN_DIR "/evenLatterDir"));
+
+	for (int i = 0; i < 4; ++i) {
+		TEST_ASSERT_NOT_NULL(dirs[i]);
+		closedir(dirs[i]);
+	}
+
+	rmdir(MAIN_DIR "/formerDir");
+	rmdir(MAIN_DIR "/latterDir");
+	rmdir(MAIN_DIR "/evenLatterDir");
+}
+
+
+TEST(dirent_opendir, open_small_enough_number_of_directories)
+{
+	errno = 0;
+
+	TEST_ASSERT_EQUAL_INT(0, test_create_directories(20));
+}
+
+
+TEST(dirent_opendir, open_same_dir_multiple_times)
+{
+	DIR *dp1, *dp2, *dp3;
+
+	dp1 = opendir(MAIN_DIR);
+	dp2 = opendir(MAIN_DIR);
+	dp3 = opendir(MAIN_DIR);
+
+	TEST_ASSERT_NOT_EQUAL(dp1, dp2);
+	TEST_ASSERT_NOT_EQUAL(dp2, dp3);
+	TEST_ASSERT_NOT_EQUAL(dp1, dp3);
+
+	closedir(dp1);
+	closedir(dp2);
+	closedir(dp3);
+}
+
+
+TEST(dirent_opendir, symlink_loop)
+{
+	int symloopMax = 0;
+#if defined(SYMLOOP_MAX)
+	symloopMax = SYMLOOP_MAX;
+#elif defined(_SC_SYMLOOP_MAX)
+	if ((symloopMax = sysconf(_SC_SYMLOOP_MAX)) == -1) {
+		TEST_IGNORE_MESSAGE("sysconf() doesn't recognize _SC_SYMLOOP_MAX");
+	}
+#else
+	TEST_IGNORE_MESSAGE("Neither SYMLOOP_MAX nor sysconf(_SC_SYMLOOP_MAX) is defined");
+#endif
+
+	TEST_MKDIR_ASSERTED("A", S_IRWXU);
+	TEST_MKDIR_ASSERTED("D1", S_IRWXU);
+	TEST_MKDIR_ASSERTED("D2", S_IRWXU);
+
+	/* SYMLOOP_MAX probably won't be bigger than 40*/
+	char selfLoop[40 * 2 + 16];
+	char mutualLoop[40 * 4 + 32];
+
+	TEST_ASSERT_EQUAL_INT(0, symlink("../D2", "D1/S1"));
+	TEST_ASSERT_EQUAL_INT(0, symlink("../D1", "D2/S2"));
+	TEST_ASSERT_EQUAL_INT(0, symlink(".", "A/B"));
+
+	strcpy(selfLoop, "A");
+	strcpy(mutualLoop, "D1");
+
+	/* Create a path to a valid symloop */
+	/* Posix says that symloops up to */
+	for (int i = 0; i < 4; ++i) {
+		strcat(selfLoop, "/B/B");
+		strcat(mutualLoop, "/S1/S2");
+	}
+
+	errno = 0;
+	DIR *selfDP = opendir(selfLoop);
+	DIR *mutualDP = opendir(mutualLoop);
+
+	TEST_ASSERT_NOT_NULL(selfDP);
+	TEST_ASSERT_NOT_NULL(mutualDP);
+
+	closedir(selfDP);
+	closedir(mutualDP);
+
+
+	/* Add a few layers of symloops, so it is too deep (selfLoop is not empty at this point)*/
+	for (int i = 0; i < symloopMax / 2 - 1; ++i) {
+		strcat(selfLoop, "/B/B");
+		strcat(mutualLoop, "/S1/S2");
+	}
+
+	errno = 0;
+	TEST_ASSERT_NULL(opendir(selfLoop));
+	TEST_ASSERT_EQUAL_INT(ELOOP, errno);
+
+	errno = 0;
+	TEST_ASSERT_NULL(opendir(mutualLoop));
+	TEST_ASSERT_EQUAL_INT(ELOOP, errno);
+
+
+	unlink("A/B");
+	unlink("D1/S1");
+	unlink("D2/S2");
+
+	rmdir("A");
+	rmdir("D1");
+	rmdir("D2");
+}
+
+
+TEST(dirent_opendir, opening_inside_open_directory)
+{
+	TEST_MKDIR_ASSERTED(MAIN_DIR "/newdir", S_IRUSR);
+	DIR *dp1, *dp2;
+	dp1 = opendir(MAIN_DIR);
+	TEST_ASSERT_NOT_NULL(dp2 = opendir(MAIN_DIR "/newdir"));
+	closedir(dp1);
+	closedir(dp2);
+	rmdir(MAIN_DIR "/newdir");
+}
+
+
+TEST(dirent_opendir, too_long_path)
+{
+	char filename[PATH_MAX + 1];
+	/* Add 2 for null terminator and slash */
+	char path[PATH_MAX + strlen(MAIN_DIR) + 2];
+
+	memset(filename, 'a', PATH_MAX);
+	filename[PATH_MAX] = '\0';
+	strcpy(path, MAIN_DIR);
+
+	strcat(path, "/");
+	strcat(path, filename);
+
+	errno = 0;
+	TEST_ASSERT_NULL(opendir(path));
+	TEST_ASSERT_EQUAL_INT(ENAMETOOLONG, errno);
+}
+
+
+TEST_GROUP_RUNNER(dirent_opendir)
+{
+	RUN_TEST_CASE(dirent_opendir, opening_empty_directory);
+	RUN_TEST_CASE(dirent_opendir, opening_not_empty_directory);
+	RUN_TEST_CASE(dirent_opendir, no_read_permission);
+	RUN_TEST_CASE(dirent_opendir, wrong_directory_name);
+	RUN_TEST_CASE(dirent_opendir, not_a_directory);
+	RUN_TEST_CASE(dirent_opendir, symlink_loop);
+	RUN_TEST_CASE(dirent_opendir, too_long_path);
+	RUN_TEST_CASE(dirent_opendir, creating_dirs_in_closed_and_open_directories);
+	RUN_TEST_CASE(dirent_opendir, opening_inside_open_directory);
+	RUN_TEST_CASE(dirent_opendir, open_small_enough_number_of_directories);
+	RUN_TEST_CASE(dirent_opendir, open_same_dir_multiple_times);
+}

--- a/libc/dirent/opendir.c
+++ b/libc/dirent/opendir.c
@@ -7,8 +7,8 @@
  * TESTED:
  *    - opendir()
  *
- * Copyright 2023 Phoenix Systems
- * Author: Arkadiusz Kozlowski
+ * Copyright 2023-2026 Phoenix Systems
+ * Authors: Arkadiusz Kozlowski, Lukasz Kruszynski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -21,59 +21,32 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <pthread.h>
 
 #include <unity_fixture.h>
 
 #include "common.h"
 #include "dirent_helper_functions.h"
 
-#define MAIN_DIR "test_opendir"
+#define MAIN_DIR     "test_opendir"
+#define THREAD_COUNT 4
 
-static int test_create_directories(int num_of_dirs)
+typedef struct {
+	char *selfLoop;
+	char *mutualLoop;
+	DIR *dirP;
+	DIR *selfDP;
+	DIR *mutualDP;
+	DIR *dirs[4];
+} test_ctx_t;
+
+static test_ctx_t test_ctx;
+
+
+static void *thread_opendir(void *arg)
 {
-
-	char dirPath[40];
-	DIR *dirs[num_of_dirs];
-	int opened_dirs = 0;
-	int result = 0;
-
-	/* Create directories in batch */
-	for (int i = 0; i < num_of_dirs; ++i) {
-
-		sprintf(dirPath, MAIN_DIR "/%d", i);
-
-		TEST_MKDIR_ASSERTED(dirPath, S_IRUSR);
-	}
-
-	/* Open directories one by one, until one of them fails */
-	for (int i = 0; i < num_of_dirs; ++i) {
-
-		sprintf(dirPath, MAIN_DIR "/%d", i);
-
-		/*
-		 * Guard clause that skips current take if dir was opened,
-		 * Upon failing it proceeds to cleanup
-		 */
-		if ((dirs[i] = opendir(dirPath)) != NULL) {
-			opened_dirs = i;
-			continue;
-		}
-
-		result = -1;
-		break;
-	}
-
-	for (int i = 0; i <= opened_dirs; ++i) {
-		TEST_ASSERT_EQUAL_INT(0, closedir(dirs[i]));
-	}
-
-
-	for (int i = 0; i < num_of_dirs; ++i) {
-		sprintf(dirPath, MAIN_DIR "/%d", i);
-		rmdir(dirPath);
-	}
-
-	return result;
+	DIR *dp = opendir(MAIN_DIR);
+	return (void *)dp;
 }
 
 
@@ -82,274 +55,459 @@ TEST_GROUP(dirent_opendir);
 
 TEST_SETUP(dirent_opendir)
 {
+	memset(&test_ctx, 0, sizeof(test_ctx));
 	TEST_MKDIR_ASSERTED(MAIN_DIR, S_IRWXU);
 }
 
 
 TEST_TEAR_DOWN(dirent_opendir)
 {
+	for (int i = 0; i < 4; i++) {
+		if (test_ctx.dirs[i] != NULL)
+			closedir(test_ctx.dirs[i]);
+	}
+	if (test_ctx.dirP != NULL) {
+		closedir(test_ctx.dirP);
+	}
+	if (test_ctx.selfDP != NULL) {
+		closedir(test_ctx.selfDP);
+	}
+	if (test_ctx.mutualDP != NULL) {
+		closedir(test_ctx.mutualDP);
+	}
+	unlink(MAIN_DIR "/notadir.txt");
+	unlink(MAIN_DIR "/A/B");
+	unlink(MAIN_DIR "/D1/S1");
+	unlink(MAIN_DIR "/D2/S2");
+	unlink(MAIN_DIR "/dangling_link");
+	rmdir(MAIN_DIR "/empty_dir");
+	rmdir(MAIN_DIR "/formerDir");
+	rmdir(MAIN_DIR "/latterDir");
+	rmdir(MAIN_DIR "/evenLatterDir");
+	rmdir(MAIN_DIR "/ToBeDeleted");
+	rmdir(MAIN_DIR "/newdir");
+	rmdir(MAIN_DIR "/A");
+	rmdir(MAIN_DIR "/D1");
+	rmdir(MAIN_DIR "/D2");
+	rmdir(MAIN_DIR "/nested");
+
+	free(test_ctx.selfLoop);
+	free(test_ctx.mutualLoop);
 	rmdir(MAIN_DIR);
 }
 
 
 TEST(dirent_opendir, opening_empty_directory)
 {
-	DIR *dp;
 	TEST_MKDIR_ASSERTED(MAIN_DIR "/empty_dir", S_IRUSR);
-	dp = opendir(MAIN_DIR "/empty_dir");
-	TEST_ASSERT_NOT_NULL(dp);
-	closedir(dp);
-	rmdir(MAIN_DIR "/empty_dir");
+	test_ctx.dirP = opendir(MAIN_DIR "/empty_dir");
+	TEST_ASSERT_NOT_NULL(test_ctx.dirP);
 }
 
 
 TEST(dirent_opendir, opening_not_empty_directory)
 {
-	DIR *dp;
-	dp = opendir(MAIN_DIR);
-	TEST_ASSERT_NOT_NULL(dp);
-	closedir(dp);
-}
-
-
-TEST(dirent_opendir, no_read_permission)
-{
-	TEST_IGNORE_MESSAGE("#937 issue");
-
-	char unreadable[] = MAIN_DIR "/dir_without_read_perm";
-	char readable[] = MAIN_DIR "/dir_without_read_perm/readable_dir";
-	DIR *dirPtr;
-
-	TEST_MKDIR_ASSERTED(unreadable, 0000);
-
-	chmod(unreadable, S_IRWXU);
-	TEST_MKDIR_ASSERTED(readable, S_IRUSR | S_IWUSR);
-	chmod(unreadable, 0000);
-
-	/* Try to read from locked directory */
-	errno = 0;
-	dirPtr = opendir(unreadable);
-	TEST_ASSERT_EQUAL_INT(EACCES, errno);
-	TEST_ASSERT_NULL(dirPtr);
-
-	/* Try to read from available directory inside locked directory */
-	errno = 0;
-	dirPtr = opendir(readable);
-	TEST_ASSERT_EQUAL_INT(EACCES, errno);
-	TEST_ASSERT_NULL(dirPtr);
-
-	/* No execute permission in parent*/
-	chmod(unreadable, S_IRUSR | S_IWUSR);
-	errno = 0;
-	dirPtr = opendir(readable);
-	TEST_ASSERT_EQUAL_INT(EACCES, errno);
-	TEST_ASSERT_NULL(dirPtr);
-
-	/* No read permission */
-	chmod(unreadable, S_IWUSR | S_IXUSR);
-	errno = 0;
-	dirPtr = opendir(unreadable);
-	TEST_ASSERT_EQUAL_INT(EACCES, errno);
-	TEST_ASSERT_NULL(dirPtr);
-
-
-	errno = 0;
-	chmod(unreadable, S_IRWXU);
-	rmdir(readable);
-	rmdir(unreadable);
+	test_ctx.dirP = opendir(MAIN_DIR);
+	TEST_ASSERT_NOT_NULL(test_ctx.dirP);
 }
 
 
 TEST(dirent_opendir, wrong_directory_name)
 {
 	errno = 0;
-	DIR *dirPtr = opendir(MAIN_DIR "/not_existing_directory");
+	test_ctx.dirP = opendir(MAIN_DIR "/not_existing_directory");
 	TEST_ASSERT_EQUAL_INT(ENOENT, errno);
-	TEST_ASSERT_NULL(dirPtr);
+	TEST_ASSERT_NULL(test_ctx.dirP);
 
 	errno = 0;
-	dirPtr = opendir("");
-	TEST_ASSERT_NULL(dirPtr);
+	test_ctx.dirP = opendir("");
+	TEST_ASSERT_NULL(test_ctx.dirP);
 	TEST_ASSERT_EQUAL_INT(ENOENT, errno);
 }
 
 
 TEST(dirent_opendir, not_a_directory)
 {
-	close(creat(MAIN_DIR "/notadir.txt", S_IRUSR));
+	int fd = creat(MAIN_DIR "/notadir.txt", S_IRUSR);
+	TEST_ASSERT_NOT_EQUAL_MESSAGE(-1, fd, "Failed to create notadir.txt");
+	close(fd);
+
 	errno = 0;
-	DIR *dirPtr = opendir(MAIN_DIR "/notadir.txt");
+	test_ctx.dirP = opendir(MAIN_DIR "/notadir.txt");
+
+	TEST_ASSERT_NULL(test_ctx.dirP);
 	TEST_ASSERT_EQUAL_INT(ENOTDIR, errno);
-	TEST_ASSERT_NULL(dirPtr);
-	remove(MAIN_DIR "/notadir.txt");
 }
 
 
 TEST(dirent_opendir, creating_dirs_in_closed_and_open_directories)
 {
 	/* Create dir in closed directory */
-	DIR *dirs[4];
 	TEST_MKDIR_ASSERTED(MAIN_DIR "/formerDir", S_IRUSR);
 
 	/* Create dir in opened directory, then close opened one */
-	DIR *dp = TEST_OPENDIR_ASSERTED(MAIN_DIR);
-	TEST_ASSERT_NOT_NULL(dirs[0] = opendir(MAIN_DIR "/formerDir"));
+	test_ctx.dirP = TEST_OPENDIR_ASSERTED(MAIN_DIR);
+	test_ctx.dirs[0] = opendir(MAIN_DIR "/formerDir");
+	TEST_ASSERT_NOT_NULL(test_ctx.dirs[0]);
 
 	TEST_MKDIR_ASSERTED(MAIN_DIR "/latterDir", S_IRUSR);
 
-	closedir(dp);
+	closedir(test_ctx.dirP);
 
 	/* Assure that both dirs can be opened without problems */
-	TEST_ASSERT_NOT_NULL(dirs[1] = opendir(MAIN_DIR "/formerDir"));
-	TEST_ASSERT_NOT_NULL(dirs[2] = opendir(MAIN_DIR "/latterDir"));
+	test_ctx.dirs[1] = opendir(MAIN_DIR "/formerDir");
+	test_ctx.dirs[2] = opendir(MAIN_DIR "/latterDir");
+	TEST_ASSERT_NOT_NULL(test_ctx.dirs[1]);
+	TEST_ASSERT_NOT_NULL(test_ctx.dirs[2]);
 
-	dp = opendir(MAIN_DIR);
-	TEST_ASSERT_NOT_NULL(dp);
+	test_ctx.dirP = opendir(MAIN_DIR);
+	TEST_ASSERT_NOT_NULL(test_ctx.dirP);
 
-	TEST_MKDIR_ASSERTED("ToBeDeleted", S_IRUSR);
-	TEST_ASSERT_EQUAL_INT(0, rmdir("ToBeDeleted"));
-	TEST_ASSERT_EQUAL_INT(0, closedir(dp));
+	TEST_MKDIR_ASSERTED(MAIN_DIR "/ToBeDeleted", S_IRUSR);
+	TEST_ASSERT_EQUAL_INT(0, rmdir(MAIN_DIR "/ToBeDeleted"));
+	TEST_ASSERT_EQUAL_INT(0, closedir(test_ctx.dirP));
+	test_ctx.dirP = NULL;
 
-	TEST_ASSERT_NULL(opendir("ToBeDeleted"));
+	TEST_ASSERT_NULL(opendir(MAIN_DIR "/ToBeDeleted"));
 	TEST_MKDIR_ASSERTED(MAIN_DIR "/evenLatterDir", S_IRUSR);
-	TEST_ASSERT_NOT_NULL(dirs[3] = opendir(MAIN_DIR "/evenLatterDir"));
+	test_ctx.dirs[3] = opendir(MAIN_DIR "/evenLatterDir");
+	TEST_ASSERT_NOT_NULL(test_ctx.dirs[3]);
 
 	for (int i = 0; i < 4; ++i) {
-		TEST_ASSERT_NOT_NULL(dirs[i]);
-		closedir(dirs[i]);
+		TEST_ASSERT_NOT_NULL(test_ctx.dirs[i]);
 	}
-
-	rmdir(MAIN_DIR "/formerDir");
-	rmdir(MAIN_DIR "/latterDir");
-	rmdir(MAIN_DIR "/evenLatterDir");
 }
 
 
 TEST(dirent_opendir, open_small_enough_number_of_directories)
 {
 	errno = 0;
+	size_t num_of_dirs = 20;
+	char dirPath[40];
+	DIR *dirs[num_of_dirs];
 
-	TEST_ASSERT_EQUAL_INT(0, test_create_directories(20));
+	memset((void *)dirs, 0, sizeof(dirs));
+
+	if (TEST_PROTECT()) {
+		/* Create directories in batch */
+		for (size_t i = 0; i < num_of_dirs; ++i) {
+			snprintf(dirPath, sizeof(dirPath), MAIN_DIR "/%zu", i);
+			TEST_MKDIR_ASSERTED(dirPath, S_IRUSR);
+		}
+
+		/* Open directories one by one */
+		for (size_t i = 0; i < num_of_dirs; ++i) {
+			snprintf(dirPath, sizeof(dirPath), MAIN_DIR "/%zu", i);
+
+			dirs[i] = opendir(dirPath);
+			TEST_ASSERT_NOT_NULL_MESSAGE(dirs[i], "Failed to open directory");
+		}
+	}
+
+	for (size_t i = 0; i < num_of_dirs; ++i) {
+		if (dirs[i] != NULL) {
+			closedir(dirs[i]);
+		}
+		snprintf(dirPath, sizeof(dirPath), MAIN_DIR "/%zu", i);
+		rmdir(dirPath);
+	}
+}
+
+
+TEST(dirent_opendir, open_enough_dirs_to_force_error)
+{
+	/*issue #1610: https://github.com/issues/created?issue=phoenix-rtos%7Cphoenix-rtos-project%7C1610 */
+	TEST_IGNORE_MESSAGE("#1610 issue");
+
+	const int FD_OVER_LIMIT_MARGIN = 10;
+	long max_open_dirs = 0;
+	long max_fds = 0;
+	char err_msg_buff[128];
+
+#if defined(_SC_OPEN_MAX)
+	max_fds = sysconf(_SC_OPEN_MAX);
+#endif
+
+	TEST_ASSERT_GREATER_THAN(0, max_fds);
+
+	long max_fds_over_limit = max_fds + FD_OVER_LIMIT_MARGIN;
+
+	DIR **dirs = (DIR **)calloc(max_fds_over_limit + 1, sizeof(DIR *));
+	TEST_ASSERT_NOT_NULL(dirs);
+
+	errno = 0;
+
+	if (TEST_PROTECT()) {
+		while (max_open_dirs < max_fds_over_limit) {
+			dirs[max_open_dirs] = opendir(MAIN_DIR);
+			if (dirs[max_open_dirs] == NULL) {
+				break;
+			}
+			max_open_dirs++;
+		}
+
+		snprintf(err_msg_buff, sizeof(err_msg_buff), "Managed to open %ld dirs despite the %ld file descriptors limit", max_open_dirs, max_fds);
+		TEST_ASSERT_LESS_OR_EQUAL_MESSAGE(max_fds, max_open_dirs, err_msg_buff);
+		TEST_ASSERT_NULL(dirs[max_open_dirs]);
+		TEST_ASSERT_TRUE_MESSAGE(errno == EMFILE || errno == ENFILE, "Expected errno to be EMFILE or ENFILE upon exhausting file descriptors");
+	}
+
+	for (long i = 0; i < max_open_dirs; ++i) {
+		if (dirs[i] != NULL) {
+			closedir(dirs[i]);
+		}
+	}
+
+	free((void *)dirs);
 }
 
 
 TEST(dirent_opendir, open_same_dir_multiple_times)
 {
-	DIR *dp1, *dp2, *dp3;
+	test_ctx.dirs[0] = opendir(MAIN_DIR);
+	test_ctx.dirs[1] = opendir(MAIN_DIR);
+	test_ctx.dirs[2] = opendir(MAIN_DIR);
 
-	dp1 = opendir(MAIN_DIR);
-	dp2 = opendir(MAIN_DIR);
-	dp3 = opendir(MAIN_DIR);
+	TEST_ASSERT_NOT_NULL(test_ctx.dirs[0]);
+	TEST_ASSERT_NOT_NULL(test_ctx.dirs[1]);
+	TEST_ASSERT_NOT_NULL(test_ctx.dirs[2]);
 
-	TEST_ASSERT_NOT_EQUAL(dp1, dp2);
-	TEST_ASSERT_NOT_EQUAL(dp2, dp3);
-	TEST_ASSERT_NOT_EQUAL(dp1, dp3);
+	TEST_ASSERT_NOT_EQUAL(test_ctx.dirs[0], test_ctx.dirs[1]);
+	TEST_ASSERT_NOT_EQUAL(test_ctx.dirs[1], test_ctx.dirs[2]);
+	TEST_ASSERT_NOT_EQUAL(test_ctx.dirs[0], test_ctx.dirs[2]);
+}
 
-	closedir(dp1);
-	closedir(dp2);
-	closedir(dp3);
+
+TEST(dirent_opendir, open_inside_open_directory)
+{
+	TEST_MKDIR_ASSERTED(MAIN_DIR "/newdir", S_IRUSR);
+	test_ctx.dirs[0] = opendir(MAIN_DIR);
+	TEST_ASSERT_NOT_NULL(test_ctx.dirs[0]);
+
+	test_ctx.dirs[1] = opendir(MAIN_DIR "/newdir");
+	TEST_ASSERT_NOT_NULL(test_ctx.dirs[1]);
 }
 
 
 TEST(dirent_opendir, symlink_loop)
 {
-	int symloopMax = 0;
+	const size_t PATH_BUFFER_SAFE_MARGIN = 10;
+	long symloopMax = 0;
 #if defined(SYMLOOP_MAX)
 	symloopMax = SYMLOOP_MAX;
 #elif defined(_SC_SYMLOOP_MAX)
-	if ((symloopMax = sysconf(_SC_SYMLOOP_MAX)) == -1) {
-		TEST_IGNORE_MESSAGE("sysconf() doesn't recognize _SC_SYMLOOP_MAX");
+	symloopMax = sysconf(_SC_SYMLOOP_MAX);
+	if (symloopMax == -1) {
+		/* symloopMax on linux is likely to be hardcoded to 40 */
+		symloopMax = 40;
 	}
 #else
 	TEST_IGNORE_MESSAGE("Neither SYMLOOP_MAX nor sysconf(_SC_SYMLOOP_MAX) is defined");
 #endif
 
-	TEST_MKDIR_ASSERTED("A", S_IRWXU);
-	TEST_MKDIR_ASSERTED("D1", S_IRWXU);
-	TEST_MKDIR_ASSERTED("D2", S_IRWXU);
+	TEST_MKDIR_ASSERTED(MAIN_DIR "/A", S_IRWXU);
+	TEST_MKDIR_ASSERTED(MAIN_DIR "/D1", S_IRWXU);
+	TEST_MKDIR_ASSERTED(MAIN_DIR "/D2", S_IRWXU);
 
-	/* SYMLOOP_MAX probably won't be bigger than 40*/
-	char selfLoop[40 * 2 + 16];
-	char mutualLoop[40 * 4 + 32];
+	test_ctx.selfLoop = malloc(PATH_MAX);
+	test_ctx.mutualLoop = malloc(PATH_MAX);
+	char *selfLoop = test_ctx.selfLoop;
+	char *mutualLoop = test_ctx.mutualLoop;
 
-	TEST_ASSERT_EQUAL_INT(0, symlink("../D2", "D1/S1"));
-	TEST_ASSERT_EQUAL_INT(0, symlink("../D1", "D2/S2"));
-	TEST_ASSERT_EQUAL_INT(0, symlink(".", "A/B"));
+	TEST_ASSERT_NOT_NULL(selfLoop);
+	TEST_ASSERT_NOT_NULL(mutualLoop);
 
-	strcpy(selfLoop, "A");
-	strcpy(mutualLoop, "D1");
+	TEST_ASSERT_EQUAL_INT(0, symlink("../D2", MAIN_DIR "/D1/S1"));
+	TEST_ASSERT_EQUAL_INT(0, symlink("../D1", MAIN_DIR "/D2/S2"));
+	TEST_ASSERT_EQUAL_INT(0, symlink(".", MAIN_DIR "/A/B"));
 
-	/* Create a path to a valid symloop */
-	/* Posix says that symloops up to */
+	strcpy(selfLoop, MAIN_DIR "/A");
+	strcpy(mutualLoop, MAIN_DIR "/D1");
+
+	/* Create a path to a valid symloop; POSIX dictates loops up to SYMLOOP_MAX must succeed */
 	for (int i = 0; i < 4; ++i) {
 		strcat(selfLoop, "/B/B");
 		strcat(mutualLoop, "/S1/S2");
 	}
 
 	errno = 0;
-	DIR *selfDP = opendir(selfLoop);
-	DIR *mutualDP = opendir(mutualLoop);
+	test_ctx.selfDP = opendir(selfLoop);
+	test_ctx.mutualDP = opendir(mutualLoop);
+	DIR *selfDP = test_ctx.selfDP;
+	DIR *mutualDP = test_ctx.mutualDP;
 
 	TEST_ASSERT_NOT_NULL(selfDP);
 	TEST_ASSERT_NOT_NULL(mutualDP);
 
-	closedir(selfDP);
-	closedir(mutualDP);
+	closedir(test_ctx.selfDP);
+	test_ctx.selfDP = NULL;
+	closedir(test_ctx.mutualDP);
+	test_ctx.mutualDP = NULL;
 
-
-	/* Add a few layers of symloops, so it is too deep (selfLoop is not empty at this point)*/
+	/* Add layers until path resolution depth forces an ELOOP error */
 	for (int i = 0; i < symloopMax / 2 - 1; ++i) {
+		if (strlen(selfLoop) + PATH_BUFFER_SAFE_MARGIN >= PATH_MAX ||
+				strlen(mutualLoop) + PATH_BUFFER_SAFE_MARGIN >= PATH_MAX) {
+			break;
+		}
 		strcat(selfLoop, "/B/B");
 		strcat(mutualLoop, "/S1/S2");
 	}
 
 	errno = 0;
-	TEST_ASSERT_NULL(opendir(selfLoop));
+	test_ctx.selfDP = opendir(selfLoop);
+	TEST_ASSERT_NULL(test_ctx.selfDP);
 	TEST_ASSERT_EQUAL_INT(ELOOP, errno);
+	test_ctx.selfDP = NULL;
 
 	errno = 0;
-	TEST_ASSERT_NULL(opendir(mutualLoop));
+	test_ctx.mutualDP = opendir(mutualLoop);
+	TEST_ASSERT_NULL(test_ctx.mutualDP);
 	TEST_ASSERT_EQUAL_INT(ELOOP, errno);
-
-
-	unlink("A/B");
-	unlink("D1/S1");
-	unlink("D2/S2");
-
-	rmdir("A");
-	rmdir("D1");
-	rmdir("D2");
+	test_ctx.mutualDP = NULL;
 }
 
 
-TEST(dirent_opendir, opening_inside_open_directory)
+TEST(dirent_opendir, symlink_leading_nowhere)
 {
-	TEST_MKDIR_ASSERTED(MAIN_DIR "/newdir", S_IRUSR);
-	DIR *dp1, *dp2;
-	dp1 = opendir(MAIN_DIR);
-	TEST_ASSERT_NOT_NULL(dp2 = opendir(MAIN_DIR "/newdir"));
-	closedir(dp1);
-	closedir(dp2);
-	rmdir(MAIN_DIR "/newdir");
+	TEST_ASSERT_EQUAL_INT(0, symlink(MAIN_DIR "/does_not_exist", MAIN_DIR "/dangling_link"));
+
+	errno = 0;
+	test_ctx.dirP = opendir(MAIN_DIR "/dangling_link");
+
+	TEST_ASSERT_NULL(test_ctx.dirP);
+	TEST_ASSERT_EQUAL_INT(ENOENT, errno);
+
+	unlink(MAIN_DIR "/dangling_link");
+}
+
+
+TEST(dirent_opendir, symlink_to_file)
+{
+	int fd = -1;
+	int created = 0;
+	int linked = 0;
+
+	if (TEST_PROTECT()) {
+		fd = creat(MAIN_DIR "/target_file.txt", S_IRUSR);
+		TEST_ASSERT_NOT_EQUAL_MESSAGE(-1, fd, "Failed to create target_file.txt");
+		created = 1;
+		close(fd);
+		fd = -1;
+
+		TEST_ASSERT_EQUAL_INT(0, symlink("target_file.txt", MAIN_DIR "/file_link"));
+		linked = 1;
+
+		errno = 0;
+		test_ctx.dirP = opendir(MAIN_DIR "/file_link");
+
+		TEST_ASSERT_NULL(test_ctx.dirP);
+		TEST_ASSERT_EQUAL_INT(ENOTDIR, errno);
+	}
+
+	if (fd != -1) {
+		close(fd);
+	}
+	if (linked) {
+		unlink(MAIN_DIR "/file_link");
+	}
+	if (created) {
+		remove(MAIN_DIR "/target_file.txt");
+	}
+}
+
+
+TEST(dirent_opendir, trailing_slashes)
+{
+	errno = 0;
+	test_ctx.dirP = opendir(MAIN_DIR "///");
+	TEST_ASSERT_NOT_NULL(test_ctx.dirP);
+	TEST_ASSERT_EQUAL_INT(0, closedir(test_ctx.dirP));
+
+
+	TEST_MKDIR_ASSERTED(MAIN_DIR "/nested", S_IRWXU);
+	errno = 0;
+	test_ctx.dirP = opendir(MAIN_DIR "///nested///");
+	TEST_ASSERT_NOT_NULL(test_ctx.dirP);
+	TEST_ASSERT_EQUAL_INT(0, closedir(test_ctx.dirP));
+	test_ctx.dirP = NULL;
+}
+
+
+TEST(dirent_opendir, traverse_path)
+{
+	TEST_MKDIR_ASSERTED(MAIN_DIR "/nested", S_IRWXU);
+
+	errno = 0;
+	test_ctx.dirP = opendir(MAIN_DIR "/nested/../nested/.");
+
+	TEST_ASSERT_NOT_NULL(test_ctx.dirP);
+	TEST_ASSERT_EQUAL_INT(0, closedir(test_ctx.dirP));
+	test_ctx.dirP = NULL;
 }
 
 
 TEST(dirent_opendir, too_long_path)
 {
-	char filename[PATH_MAX + 1];
+	char *filename = malloc(PATH_MAX + 1);
 	/* Add 2 for null terminator and slash */
-	char path[PATH_MAX + strlen(MAIN_DIR) + 2];
+	char *path = malloc(PATH_MAX + sizeof(MAIN_DIR) + 2);
 
-	memset(filename, 'a', PATH_MAX);
-	filename[PATH_MAX] = '\0';
-	strcpy(path, MAIN_DIR);
+	if (TEST_PROTECT()) {
+		TEST_ASSERT_NOT_NULL(filename);
+		TEST_ASSERT_NOT_NULL(path);
 
-	strcat(path, "/");
-	strcat(path, filename);
+		memset(filename, 'a', PATH_MAX);
+		filename[PATH_MAX] = '\0';
+		strcpy(path, MAIN_DIR);
 
-	errno = 0;
-	TEST_ASSERT_NULL(opendir(path));
-	TEST_ASSERT_EQUAL_INT(ENAMETOOLONG, errno);
+		strcat(path, "/");
+		strcat(path, filename);
+
+		errno = 0;
+		TEST_ASSERT_NULL(opendir(path));
+		TEST_ASSERT_EQUAL_INT(ENAMETOOLONG, errno);
+	}
+	free(filename);
+	free(path);
+}
+
+
+TEST(dirent_opendir, thread_safety)
+{
+	pthread_t threads[THREAD_COUNT];
+	DIR *results[THREAD_COUNT];
+	pthread_attr_t attr;
+
+	size_t safe_stack_size = 8192;
+#ifdef PTHREAD_STACK_MIN
+	if (safe_stack_size < PTHREAD_STACK_MIN) {
+		safe_stack_size = PTHREAD_STACK_MIN;
+	}
+#endif
+
+	TEST_ASSERT_EQUAL_INT(0, pthread_attr_init(&attr));
+	TEST_ASSERT_EQUAL_INT(0, pthread_attr_setstacksize(&attr, safe_stack_size));
+
+	for (int i = 0; i < THREAD_COUNT; ++i) {
+		TEST_ASSERT_EQUAL_INT(0, pthread_create(&threads[i], &attr, thread_opendir, NULL));
+	}
+
+	pthread_attr_destroy(&attr);
+
+	for (int i = 0; i < THREAD_COUNT; ++i) {
+		TEST_ASSERT_EQUAL_INT(0, pthread_join(threads[i], (void **)&results[i]));
+	}
+
+	for (int i = 0; i < THREAD_COUNT; ++i) {
+		TEST_ASSERT_NOT_NULL(results[i]);
+
+		for (int j = i + 1; j < THREAD_COUNT; ++j) {
+			TEST_ASSERT_NOT_EQUAL(results[i], results[j]);
+		}
+
+		TEST_ASSERT_EQUAL_INT(0, closedir(results[i]));
+	}
 }
 
 
@@ -357,13 +515,18 @@ TEST_GROUP_RUNNER(dirent_opendir)
 {
 	RUN_TEST_CASE(dirent_opendir, opening_empty_directory);
 	RUN_TEST_CASE(dirent_opendir, opening_not_empty_directory);
-	RUN_TEST_CASE(dirent_opendir, no_read_permission);
 	RUN_TEST_CASE(dirent_opendir, wrong_directory_name);
 	RUN_TEST_CASE(dirent_opendir, not_a_directory);
-	RUN_TEST_CASE(dirent_opendir, symlink_loop);
-	RUN_TEST_CASE(dirent_opendir, too_long_path);
 	RUN_TEST_CASE(dirent_opendir, creating_dirs_in_closed_and_open_directories);
-	RUN_TEST_CASE(dirent_opendir, opening_inside_open_directory);
 	RUN_TEST_CASE(dirent_opendir, open_small_enough_number_of_directories);
+	RUN_TEST_CASE(dirent_opendir, open_enough_dirs_to_force_error);
 	RUN_TEST_CASE(dirent_opendir, open_same_dir_multiple_times);
+	RUN_TEST_CASE(dirent_opendir, open_inside_open_directory);
+	RUN_TEST_CASE(dirent_opendir, symlink_loop);
+	RUN_TEST_CASE(dirent_opendir, symlink_leading_nowhere);
+	RUN_TEST_CASE(dirent_opendir, symlink_to_file);
+	RUN_TEST_CASE(dirent_opendir, too_long_path);
+	RUN_TEST_CASE(dirent_opendir, trailing_slashes);
+	RUN_TEST_CASE(dirent_opendir, traverse_path);
+	RUN_TEST_CASE(dirent_opendir, thread_safety);
 }

--- a/libc/dirent/readdir.c
+++ b/libc/dirent/readdir.c
@@ -1,0 +1,324 @@
+/*
+ * Phoenix-RTOS
+ *
+ * POSIX.1-2017 standard library functions tests
+ * HEADER:
+ *    - dirent.h
+ * TESTED:
+ *    - readdir()
+ *
+ * Copyright 2023 Phoenix Systems
+ * Author: Arkadiusz Kozlowski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <dirent.h>
+#include <signal.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <string.h>
+#include <fcntl.h>
+
+#include <unity_fixture.h>
+
+#include "common.h"
+#include "dirent_helper_functions.h"
+
+#define MAIN_DIR            "test_readdir"
+#define INO_T_TEST_MAX_DIRS 10
+
+
+int d_ino_in(ino_t arg, ino_t *arr)
+{
+	for (int i = 0; i < INO_T_TEST_MAX_DIRS; ++i) {
+		if (arg == arr[i]) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+
+TEST_GROUP(dirent_readdir);
+
+TEST_SETUP(dirent_readdir)
+{
+	mkdir(MAIN_DIR, 0700);
+
+	mkdir(MAIN_DIR "/dir1", S_IRUSR | S_IWUSR | S_IXUSR);
+	mkdir(MAIN_DIR "/dir2", S_IRUSR | S_IWUSR | S_IXUSR);
+
+	mkdir(MAIN_DIR "/dir1/nest1", S_IRUSR);
+	mkdir(MAIN_DIR "/dir1/nest2", S_IRUSR);
+
+	mkdir(MAIN_DIR "/dir2/nest1", S_IRUSR);
+	mkdir(MAIN_DIR "/dir2/nest2", S_IRUSR);
+
+	int files[] = {
+		creat(MAIN_DIR "/file1.txt", S_IRUSR),
+		creat(MAIN_DIR "/file2.dat", S_IRUSR),
+		creat(MAIN_DIR "/file3.json", S_IRUSR)
+	};
+
+	close(files[0]);
+	close(files[1]);
+	close(files[2]);
+}
+
+
+TEST_TEAR_DOWN(dirent_readdir)
+{
+	rmdir(MAIN_DIR "/dir1/nest1");
+	rmdir(MAIN_DIR "/dir1/nest2");
+
+	rmdir(MAIN_DIR "/dir2/nest1");
+	rmdir(MAIN_DIR "/dir2/nest2");
+
+	rmdir(MAIN_DIR "/dir1");
+	rmdir(MAIN_DIR "/dir2");
+
+	remove(MAIN_DIR "/file1.txt");
+	remove(MAIN_DIR "/file2.dat");
+	remove(MAIN_DIR "/file3.json");
+
+	rmdir(MAIN_DIR);
+}
+
+
+TEST(dirent_readdir, long_name_directory_check)
+{
+	DIR *dp = TEST_OPENDIR_ASSERTED(MAIN_DIR);
+	struct dirent *info;
+	char longDirName[NAME_MAX + 1];
+	char longDirPath[NAME_MAX + 2 + sizeof(MAIN_DIR)];
+
+
+	TEST_ASSERT_NOT_NULL(dp);
+
+	memset(longDirName, 'a', NAME_MAX);
+	longDirName[NAME_MAX] = '\0';
+	sprintf(longDirPath, MAIN_DIR "/%s", longDirName);
+
+	errno = 0;
+	TEST_MKDIR_ASSERTED(longDirPath, S_IRUSR);
+
+	while ((info = readdir(dp)) != NULL) {
+		if (!strcmp(longDirName, info->d_name)) {
+			TEST_ASSERT_EQUAL_INT(NAME_MAX, strlen(info->d_name));
+			closedir(dp);
+			rmdir(longDirPath);
+			TEST_PASS();
+		}
+	}
+
+	closedir(dp);
+	TEST_FAIL();
+}
+
+
+TEST(dirent_readdir, basic_listing_count)
+{
+	DIR *dp = TEST_OPENDIR_ASSERTED(MAIN_DIR);
+	int entry_counter = 0;
+	struct dirent *info;
+
+	while ((info = readdir(dp)) != NULL) {
+		entry_counter++;
+	}
+
+	/* 5 files from setup, and both . and .. directories */
+	TEST_ASSERT_EQUAL_INT(7, entry_counter);
+
+	closedir(dp);
+}
+
+
+TEST(dirent_readdir, reading_in_parent_and_child)
+{
+	DIR *dp1, *dp2;
+
+	dp1 = TEST_OPENDIR_ASSERTED(MAIN_DIR "/dir1");
+	dp2 = TEST_OPENDIR_ASSERTED(MAIN_DIR "/dir2");
+
+	TEST_ASSERT_NOT_NULL(readdir(dp1));
+	TEST_ASSERT_NOT_NULL(readdir(dp2));
+
+	pid_t pid = fork();
+
+	if (pid == -1) {
+		TEST_IGNORE_MESSAGE("Fork failed");
+	}
+
+	/* Since there are two different dir streams, there is no reading from the same stream in two processes */
+	if (pid) {
+		int cresult;
+		/* Check for parent */
+		TEST_ASSERT_NOT_NULL(readdir(dp1));
+		rewinddir(dp1);
+		TEST_ASSERT_NOT_NULL(readdir(dp1));
+		closedir(dp1);
+		closedir(dp2);
+		wait(&cresult);
+		TEST_ASSERT_EQUAL_INT(EXIT_SUCCESS, cresult);
+	}
+
+	else {
+		/* Check for child */
+		int status = EXIT_SUCCESS;
+		if (!readdir(dp2)) {
+			status = EXIT_FAILURE;
+		}
+
+		rewinddir(dp2);
+
+		if (!readdir(dp2)) {
+			status = EXIT_FAILURE;
+		}
+
+		closedir(dp1);
+		closedir(dp2);
+		exit(status);
+	}
+}
+
+
+TEST(dirent_readdir, hardlink_inode_correct_number)
+{
+	const char *originalFilePath = MAIN_DIR "/original_file.txt";
+	const char *linkFilePath = MAIN_DIR "/linked_file.txt";
+
+	fclose(fopen(originalFilePath, "w+"));
+
+	TEST_ASSERT_EQUAL_INT(0, link(originalFilePath, linkFilePath));
+
+	struct stat originalFileStat, linkFileStat;
+
+	TEST_ASSERT_EQUAL_INT(0, stat(originalFilePath, &originalFileStat));
+	TEST_ASSERT_EQUAL_INT(0, stat(linkFilePath, &linkFileStat));
+
+	TEST_ASSERT_EQUAL_UINT64(originalFileStat.st_ino, linkFileStat.st_ino);
+
+	remove(originalFilePath);
+	unlink(linkFilePath);
+}
+
+
+TEST(dirent_readdir, distinct_inode_nums)
+{
+	ino_t inode_arr[INO_T_TEST_MAX_DIRS];
+	DIR *dp = TEST_OPENDIR_ASSERTED(MAIN_DIR);
+	struct dirent *info;
+	int inode_counter = 0;
+
+	/* Set all array members to -1 since all inode id's are positive */
+	for (int i = 0; i < INO_T_TEST_MAX_DIRS; ++i) {
+		inode_arr[i] = -1;
+	}
+
+	/* Assert distinct inodes */
+	while ((info = readdir(dp)) != NULL) {
+		TEST_ASSERT_EQUAL_INT(-1, d_ino_in(info->d_ino, inode_arr));
+		inode_arr[inode_counter++] = info->d_ino;
+	}
+
+	closedir(dp);
+}
+
+
+TEST(dirent_readdir, same_file_reading_by_two_pointers)
+{
+	DIR *dp1, *dp2;
+	dp1 = TEST_OPENDIR_ASSERTED(MAIN_DIR);
+	dp2 = TEST_OPENDIR_ASSERTED(MAIN_DIR);
+
+	int counter = 2;
+
+	readdir(dp1);
+	readdir(dp1);
+
+	errno = 0;
+
+	while (readdir(dp2) != NULL) {
+		continue;
+	}
+
+	TEST_ASSERT_EQUAL_INT(0, errno);
+
+	while (readdir(dp1) != NULL) {
+		counter++;
+	}
+
+	TEST_ASSERT_EQUAL_INT(0, errno);
+
+	TEST_ASSERT_EQUAL_INT(7, counter);
+
+	closedir(dp1);
+	closedir(dp2);
+}
+
+
+TEST(dirent_readdir, correct_dirent_names)
+{
+	struct dirent *info;
+	int filename_bits = 0;
+	DIR *dp = TEST_OPENDIR_ASSERTED(MAIN_DIR);
+
+	while ((info = readdir(dp)) != NULL) {
+
+		/* Set corresponding bit of filename_bits each time info->d_name is encountered */
+		if (!strcmp(info->d_name, "dir1")) {
+
+			filename_bits |= 1;
+		}
+
+		else if (!strcmp(info->d_name, "file1.txt")) {
+			filename_bits |= 2;
+		}
+
+		else if (!strcmp(info->d_name, "file2.dat")) {
+			filename_bits |= 4;
+		}
+
+		else if (!strcmp(info->d_name, ".")) {
+			filename_bits |= 8;
+		}
+
+		else if (!strcmp(info->d_name, "file3.json")) {
+			filename_bits |= 16;
+		}
+
+		else if (!strcmp(info->d_name, "..")) {
+			filename_bits |= 32;
+		}
+
+		else if (!strcmp(info->d_name, "dir2")) {
+			filename_bits |= 64;
+		}
+
+		else
+			TEST_FAIL_MESSAGE(info->d_name);
+	}
+
+	TEST_ASSERT_EQUAL_INT(0x7f, filename_bits);
+	closedir(dp);
+}
+
+
+TEST_GROUP_RUNNER(dirent_readdir)
+{
+	RUN_TEST_CASE(dirent_readdir, basic_listing_count);
+	RUN_TEST_CASE(dirent_readdir, correct_dirent_names);
+	RUN_TEST_CASE(dirent_readdir, distinct_inode_nums);
+	RUN_TEST_CASE(dirent_readdir, hardlink_inode_correct_number);
+	RUN_TEST_CASE(dirent_readdir, same_file_reading_by_two_pointers);
+	RUN_TEST_CASE(dirent_readdir, reading_in_parent_and_child);
+	RUN_TEST_CASE(dirent_readdir, long_name_directory_check);
+}

--- a/libc/dirent/readdir.c
+++ b/libc/dirent/readdir.c
@@ -7,8 +7,8 @@
  * TESTED:
  *    - readdir()
  *
- * Copyright 2023 Phoenix Systems
- * Author: Arkadiusz Kozlowski
+ * Copyright 2023-2026 Phoenix Systems
+ * Authors: Arkadiusz Kozlowski, Lukasz Kruszynski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -21,7 +21,6 @@
 #include <dirent.h>
 #include <signal.h>
 
-#include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <string.h>
@@ -35,10 +34,9 @@
 #define MAIN_DIR            "test_readdir"
 #define INO_T_TEST_MAX_DIRS 10
 
-
-int d_ino_in(ino_t arg, ino_t *arr)
+int d_ino_in(ino_t arg, ino_t *arr, int n)
 {
-	for (int i = 0; i < INO_T_TEST_MAX_DIRS; ++i) {
+	for (int i = 0; i < n; ++i) {
 		if (arg == arr[i]) {
 			return i;
 		}
@@ -51,26 +49,30 @@ TEST_GROUP(dirent_readdir);
 
 TEST_SETUP(dirent_readdir)
 {
-	mkdir(MAIN_DIR, 0700);
+	TEST_MKDIR_ASSERTED(MAIN_DIR, 0700);
 
-	mkdir(MAIN_DIR "/dir1", S_IRUSR | S_IWUSR | S_IXUSR);
-	mkdir(MAIN_DIR "/dir2", S_IRUSR | S_IWUSR | S_IXUSR);
+	TEST_MKDIR_ASSERTED(MAIN_DIR "/dir1", S_IRUSR | S_IWUSR | S_IXUSR);
+	TEST_MKDIR_ASSERTED(MAIN_DIR "/dir2", S_IRUSR | S_IWUSR | S_IXUSR);
 
-	mkdir(MAIN_DIR "/dir1/nest1", S_IRUSR);
-	mkdir(MAIN_DIR "/dir1/nest2", S_IRUSR);
+	TEST_MKDIR_ASSERTED(MAIN_DIR "/dir1/nest1", S_IRUSR);
+	TEST_MKDIR_ASSERTED(MAIN_DIR "/dir1/nest2", S_IRUSR);
 
-	mkdir(MAIN_DIR "/dir2/nest1", S_IRUSR);
-	mkdir(MAIN_DIR "/dir2/nest2", S_IRUSR);
+	TEST_MKDIR_ASSERTED(MAIN_DIR "/dir2/nest1", S_IRUSR);
+	TEST_MKDIR_ASSERTED(MAIN_DIR "/dir2/nest2", S_IRUSR);
 
-	int files[] = {
-		creat(MAIN_DIR "/file1.txt", S_IRUSR),
-		creat(MAIN_DIR "/file2.dat", S_IRUSR),
-		creat(MAIN_DIR "/file3.json", S_IRUSR)
-	};
+	int fd;
 
-	close(files[0]);
-	close(files[1]);
-	close(files[2]);
+	fd = creat(MAIN_DIR "/file1.txt", S_IRUSR);
+	TEST_ASSERT_GREATER_OR_EQUAL_INT(0, fd);
+	TEST_ASSERT_EQUAL_INT(0, close(fd));
+
+	fd = creat(MAIN_DIR "/file2.dat", S_IRUSR);
+	TEST_ASSERT_GREATER_OR_EQUAL_INT(0, fd);
+	TEST_ASSERT_EQUAL_INT(0, close(fd));
+
+	fd = creat(MAIN_DIR "/file3.json", S_IRUSR);
+	TEST_ASSERT_GREATER_OR_EQUAL_INT(0, fd);
+	TEST_ASSERT_EQUAL_INT(0, close(fd));
 }
 
 
@@ -95,32 +97,40 @@ TEST_TEAR_DOWN(dirent_readdir)
 
 TEST(dirent_readdir, long_name_directory_check)
 {
-	DIR *dp = TEST_OPENDIR_ASSERTED(MAIN_DIR);
+	/* issue #1615: https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1615 */
+	TEST_IGNORE_MESSAGE("#1615 issue");
+	DIR *dp = NULL;
 	struct dirent *info;
 	char longDirName[NAME_MAX + 1];
 	char longDirPath[NAME_MAX + 2 + sizeof(MAIN_DIR)];
-
-
-	TEST_ASSERT_NOT_NULL(dp);
+	int dir_created = 0;
+	int found = 0;
 
 	memset(longDirName, 'a', NAME_MAX);
 	longDirName[NAME_MAX] = '\0';
-	sprintf(longDirPath, MAIN_DIR "/%s", longDirName);
+	snprintf(longDirPath, sizeof(longDirPath), MAIN_DIR "/%s", longDirName);
 
-	errno = 0;
-	TEST_MKDIR_ASSERTED(longDirPath, S_IRUSR);
+	if (TEST_PROTECT()) {
+		TEST_MKDIR_ASSERTED(longDirPath, S_IRUSR);
+		dir_created = 1;
 
-	while ((info = readdir(dp)) != NULL) {
-		if (!strcmp(longDirName, info->d_name)) {
-			TEST_ASSERT_EQUAL_INT(NAME_MAX, strlen(info->d_name));
-			closedir(dp);
-			rmdir(longDirPath);
-			TEST_PASS();
+		dp = TEST_OPENDIR_ASSERTED(MAIN_DIR);
+
+		while ((info = readdir(dp)) != NULL) {
+			if (info->d_name[0] == 'a') {
+				TEST_ASSERT_EQUAL_STRING(longDirName, info->d_name);
+				TEST_ASSERT_EQUAL_INT(NAME_MAX, strlen(info->d_name));
+				found = 1;
+				break;
+			}
 		}
+		TEST_ASSERT_TRUE_MESSAGE(found, "Long directory name not found");
 	}
 
-	closedir(dp);
-	TEST_FAIL();
+	if (dp != NULL)
+		closedir(dp);
+	if (dir_created)
+		rmdir(longDirPath);
 }
 
 
@@ -134,58 +144,67 @@ TEST(dirent_readdir, basic_listing_count)
 		entry_counter++;
 	}
 
+	closedir(dp);
+
 	/* 5 files from setup, and both . and .. directories */
 	TEST_ASSERT_EQUAL_INT(7, entry_counter);
-
-	closedir(dp);
 }
 
 
 TEST(dirent_readdir, reading_in_parent_and_child)
 {
-	DIR *dp1, *dp2;
+	DIR *dp1 = NULL, *dp2 = NULL;
+	pid_t pid = -1;
+	int status;
 
-	dp1 = TEST_OPENDIR_ASSERTED(MAIN_DIR "/dir1");
-	dp2 = TEST_OPENDIR_ASSERTED(MAIN_DIR "/dir2");
+	if (TEST_PROTECT()) {
+		dp1 = TEST_OPENDIR_ASSERTED(MAIN_DIR "/dir1");
+		dp2 = TEST_OPENDIR_ASSERTED(MAIN_DIR "/dir2");
 
-	TEST_ASSERT_NOT_NULL(readdir(dp1));
-	TEST_ASSERT_NOT_NULL(readdir(dp2));
-
-	pid_t pid = fork();
-
-	if (pid == -1) {
-		TEST_IGNORE_MESSAGE("Fork failed");
-	}
-
-	/* Since there are two different dir streams, there is no reading from the same stream in two processes */
-	if (pid) {
-		int cresult;
-		/* Check for parent */
 		TEST_ASSERT_NOT_NULL(readdir(dp1));
-		rewinddir(dp1);
-		TEST_ASSERT_NOT_NULL(readdir(dp1));
-		closedir(dp1);
-		closedir(dp2);
-		wait(&cresult);
-		TEST_ASSERT_EQUAL_INT(EXIT_SUCCESS, cresult);
-	}
+		TEST_ASSERT_NOT_NULL(readdir(dp2));
 
-	else {
-		/* Check for child */
-		int status = EXIT_SUCCESS;
-		if (!readdir(dp2)) {
-			status = EXIT_FAILURE;
+		pid = fork();
+
+		if (pid == -1) {
+			TEST_IGNORE_MESSAGE("Fork failed");
 		}
 
-		rewinddir(dp2);
-
-		if (!readdir(dp2)) {
-			status = EXIT_FAILURE;
+		/* Since there are two different dir streams, there is no reading from the same stream in two processes */
+		if (pid > 0) {
+			/* Check for parent */
+			TEST_ASSERT_NOT_NULL(readdir(dp1));
+			rewinddir(dp1);
+			TEST_ASSERT_NOT_NULL(readdir(dp1));
+			wait(&status);
+			TEST_ASSERT_TRUE(WIFEXITED(status));
+			TEST_ASSERT_EQUAL_INT(EXIT_SUCCESS, WEXITSTATUS(status));
 		}
 
+		else {
+			/* Check for child */
+			status = EXIT_SUCCESS;
+			if (!readdir(dp2)) {
+				status = EXIT_FAILURE;
+			}
+
+			rewinddir(dp2);
+
+			if (!readdir(dp2)) {
+				status = EXIT_FAILURE;
+			}
+
+
+			closedir(dp1);
+			closedir(dp2);
+			_exit(status);
+		}
+	}
+	if (dp1 != NULL) {
 		closedir(dp1);
+	}
+	if (dp2 != NULL) {
 		closedir(dp2);
-		exit(status);
 	}
 }
 
@@ -194,74 +213,110 @@ TEST(dirent_readdir, hardlink_inode_correct_number)
 {
 	const char *originalFilePath = MAIN_DIR "/original_file.txt";
 	const char *linkFilePath = MAIN_DIR "/linked_file.txt";
+	int created = 0;
+	int linked = 0;
+	DIR *dp = NULL;
+	FILE *f = NULL;
 
-	fclose(fopen(originalFilePath, "w+"));
+	if (TEST_PROTECT()) {
+		f = fopen(originalFilePath, "w+");
+		TEST_ASSERT_NOT_NULL(f);
+		fclose(f);
+		created = 1;
 
-	TEST_ASSERT_EQUAL_INT(0, link(originalFilePath, linkFilePath));
+		TEST_ASSERT_EQUAL_INT(0, link(originalFilePath, linkFilePath));
+		linked = 1;
 
-	struct stat originalFileStat, linkFileStat;
+		dp = TEST_OPENDIR_ASSERTED(MAIN_DIR);
+		struct dirent *info;
+		ino_t orig_ino = 0;
+		ino_t link_ino = 0;
+		int files_found = 0;
 
-	TEST_ASSERT_EQUAL_INT(0, stat(originalFilePath, &originalFileStat));
-	TEST_ASSERT_EQUAL_INT(0, stat(linkFilePath, &linkFileStat));
+		while ((info = readdir(dp)) != NULL) {
+			if (!strcmp(info->d_name, "original_file.txt")) {
+				orig_ino = info->d_ino;
+				files_found++;
+			}
+			else if (!strcmp(info->d_name, "linked_file.txt")) {
+				link_ino = info->d_ino;
+				files_found++;
+			}
+		}
 
-	TEST_ASSERT_EQUAL_UINT64(originalFileStat.st_ino, linkFileStat.st_ino);
+		TEST_ASSERT_EQUAL_INT(2, files_found);
+		TEST_ASSERT_EQUAL_UINT64(orig_ino, link_ino);
+	}
 
-	remove(originalFilePath);
-	unlink(linkFilePath);
+	if (dp != NULL)
+		closedir(dp);
+	if (created) {
+		unlink(linkFilePath);
+	}
+	if (linked) {
+		remove(originalFilePath);
+	}
 }
 
 
 TEST(dirent_readdir, distinct_inode_nums)
 {
 	ino_t inode_arr[INO_T_TEST_MAX_DIRS];
-	DIR *dp = TEST_OPENDIR_ASSERTED(MAIN_DIR);
-	struct dirent *info;
+	DIR *dp = NULL;
 	int inode_counter = 0;
+	struct dirent *info;
 
-	/* Set all array members to -1 since all inode id's are positive */
-	for (int i = 0; i < INO_T_TEST_MAX_DIRS; ++i) {
-		inode_arr[i] = -1;
+	if (TEST_PROTECT()) {
+		dp = TEST_OPENDIR_ASSERTED(MAIN_DIR);
+		/* Assert distinct inodes */
+		while ((info = readdir(dp)) != NULL) {
+			TEST_ASSERT_LESS_THAN_INT(INO_T_TEST_MAX_DIRS, inode_counter);
+			/* Pass inode_counter as 'n' to avoid reading garbage/uninitialized memory */
+			TEST_ASSERT_EQUAL_INT(-1, d_ino_in(info->d_ino, inode_arr, inode_counter));
+			inode_arr[inode_counter++] = info->d_ino;
+		}
 	}
-
-	/* Assert distinct inodes */
-	while ((info = readdir(dp)) != NULL) {
-		TEST_ASSERT_EQUAL_INT(-1, d_ino_in(info->d_ino, inode_arr));
-		inode_arr[inode_counter++] = info->d_ino;
+	if (dp != NULL) {
+		closedir(dp);
 	}
-
-	closedir(dp);
 }
 
 
 TEST(dirent_readdir, same_file_reading_by_two_pointers)
 {
-	DIR *dp1, *dp2;
-	dp1 = TEST_OPENDIR_ASSERTED(MAIN_DIR);
-	dp2 = TEST_OPENDIR_ASSERTED(MAIN_DIR);
+	DIR *dp1 = NULL, *dp2 = NULL;
 
-	int counter = 2;
+	if (TEST_PROTECT()) {
+		dp1 = TEST_OPENDIR_ASSERTED(MAIN_DIR);
+		dp2 = TEST_OPENDIR_ASSERTED(MAIN_DIR);
 
-	readdir(dp1);
-	readdir(dp1);
+		int counter = 2;
 
-	errno = 0;
+		TEST_ASSERT_NOT_NULL(readdir(dp1));
+		TEST_ASSERT_NOT_NULL(readdir(dp1));
 
-	while (readdir(dp2) != NULL) {
-		continue;
+		errno = 0;
+
+		while (readdir(dp2) != NULL) {
+			continue;
+		}
+
+		TEST_ASSERT_EQUAL_INT(0, errno);
+
+		while (readdir(dp1) != NULL) {
+			counter++;
+		}
+
+		TEST_ASSERT_EQUAL_INT(0, errno);
+
+		TEST_ASSERT_EQUAL_INT(7, counter);
 	}
-
-	TEST_ASSERT_EQUAL_INT(0, errno);
-
-	while (readdir(dp1) != NULL) {
-		counter++;
+	if (dp1 != NULL) {
+		closedir(dp1);
 	}
-
-	TEST_ASSERT_EQUAL_INT(0, errno);
-
-	TEST_ASSERT_EQUAL_INT(7, counter);
-
-	closedir(dp1);
-	closedir(dp2);
+	if (dp2 != NULL) {
+		closedir(dp2);
+	}
 }
 
 
@@ -270,45 +325,154 @@ TEST(dirent_readdir, correct_dirent_names)
 	struct dirent *info;
 	int filename_bits = 0;
 	DIR *dp = TEST_OPENDIR_ASSERTED(MAIN_DIR);
+	if (TEST_PROTECT()) {
+		while ((info = readdir(dp)) != NULL) {
 
-	while ((info = readdir(dp)) != NULL) {
+			/* Set corresponding bit of filename_bits each time info->d_name is encountered */
+			if (!strcmp(info->d_name, "dir1")) {
 
-		/* Set corresponding bit of filename_bits each time info->d_name is encountered */
-		if (!strcmp(info->d_name, "dir1")) {
+				filename_bits |= 1;
+			}
 
-			filename_bits |= 1;
+			else if (!strcmp(info->d_name, "file1.txt")) {
+				filename_bits |= 2;
+			}
+
+			else if (!strcmp(info->d_name, "file2.dat")) {
+				filename_bits |= 4;
+			}
+
+			else if (!strcmp(info->d_name, ".")) {
+				filename_bits |= 8;
+			}
+
+			else if (!strcmp(info->d_name, "file3.json")) {
+				filename_bits |= 16;
+			}
+
+			else if (!strcmp(info->d_name, "..")) {
+				filename_bits |= 32;
+			}
+
+			else if (!strcmp(info->d_name, "dir2")) {
+				filename_bits |= 64;
+			}
+
+			else
+				TEST_FAIL_MESSAGE(info->d_name);
 		}
-
-		else if (!strcmp(info->d_name, "file1.txt")) {
-			filename_bits |= 2;
-		}
-
-		else if (!strcmp(info->d_name, "file2.dat")) {
-			filename_bits |= 4;
-		}
-
-		else if (!strcmp(info->d_name, ".")) {
-			filename_bits |= 8;
-		}
-
-		else if (!strcmp(info->d_name, "file3.json")) {
-			filename_bits |= 16;
-		}
-
-		else if (!strcmp(info->d_name, "..")) {
-			filename_bits |= 32;
-		}
-
-		else if (!strcmp(info->d_name, "dir2")) {
-			filename_bits |= 64;
-		}
-
-		else
-			TEST_FAIL_MESSAGE(info->d_name);
 	}
 
 	TEST_ASSERT_EQUAL_INT(0x7f, filename_bits);
-	closedir(dp);
+	if (dp != NULL) {
+		closedir(dp);
+	}
+}
+
+
+TEST(dirent_readdir, read_past_end_of_stream)
+{
+	DIR *dp = NULL;
+
+	if (TEST_PROTECT()) {
+		dp = TEST_OPENDIR_ASSERTED(MAIN_DIR);
+		while (readdir(dp) != NULL) {
+			continue;
+		}
+
+		errno = 0;
+		for (int i = 0; i < 10; i++) {
+			TEST_ASSERT_NULL(readdir(dp));
+			TEST_ASSERT_EQUAL_INT(0, errno);
+		}
+	}
+
+	if (dp != NULL) {
+		closedir(dp);
+	}
+}
+
+
+TEST(dirent_readdir, large_directory_pagination)
+{
+	const int NUM_FILES = 40;
+	char path[PATH_MAX];
+	DIR *dp = NULL;
+	int count = 0;
+	int dir_created = 0;
+	int files_created = 0;
+
+	memset(path, 0, sizeof(path));
+
+	if (TEST_PROTECT()) {
+		TEST_MKDIR_ASSERTED(MAIN_DIR "/stress_dir", 0700);
+		dir_created = 1;
+
+		for (int i = 0; i < NUM_FILES; i++) {
+			sprintf(path, MAIN_DIR "/stress_dir/file_%d.txt", i);
+			int fd = creat(path, S_IRUSR);
+			TEST_ASSERT_NOT_EQUAL(-1, fd);
+			close(fd);
+			files_created++;
+		}
+
+		dp = TEST_OPENDIR_ASSERTED(MAIN_DIR "/stress_dir");
+
+		while (readdir(dp) != NULL) {
+			count++;
+		}
+		/* NUM_FILES + "." + ".." */
+		TEST_ASSERT_EQUAL_INT(NUM_FILES + 2, count);
+	}
+
+	if (dp != NULL)
+		closedir(dp);
+
+	if (dir_created) {
+		for (int i = 0; i < files_created; i++) {
+			snprintf(path, PATH_MAX, MAIN_DIR "/stress_dir/file_%d.txt", i);
+			remove(path);
+		}
+		rmdir(MAIN_DIR "/stress_dir");
+	}
+}
+
+
+TEST(dirent_readdir, unlink_during_iteration)
+{
+	DIR *dp = NULL;
+	struct dirent *info;
+	const char *victim_path = MAIN_DIR "/victim.txt";
+	int file_created = 0;
+
+	if (TEST_PROTECT()) {
+		int fd = creat(victim_path, S_IRUSR);
+		TEST_ASSERT_NOT_EQUAL(-1, fd);
+		close(fd);
+		file_created = 1;
+
+		dp = TEST_OPENDIR_ASSERTED(MAIN_DIR);
+		TEST_ASSERT_NOT_NULL(dp);
+
+		info = readdir(dp);
+		TEST_ASSERT_NOT_NULL(info);
+
+		TEST_ASSERT_EQUAL_INT(0, remove(victim_path));
+		/* Clear flag to avoid double remove */
+		file_created = 0;
+
+		errno = 0;
+		while ((info = readdir(dp)) != NULL) {
+			continue;
+		}
+
+		TEST_ASSERT_EQUAL_INT(0, errno);
+	}
+
+	if (dp != NULL)
+		closedir(dp);
+	if (file_created)
+		remove(victim_path);
 }
 
 
@@ -321,4 +485,7 @@ TEST_GROUP_RUNNER(dirent_readdir)
 	RUN_TEST_CASE(dirent_readdir, same_file_reading_by_two_pointers);
 	RUN_TEST_CASE(dirent_readdir, reading_in_parent_and_child);
 	RUN_TEST_CASE(dirent_readdir, long_name_directory_check);
+	RUN_TEST_CASE(dirent_readdir, read_past_end_of_stream);
+	RUN_TEST_CASE(dirent_readdir, large_directory_pagination);
+	RUN_TEST_CASE(dirent_readdir, unlink_during_iteration);
 }

--- a/libc/dirent/rewinddir.c
+++ b/libc/dirent/rewinddir.c
@@ -1,0 +1,137 @@
+/*
+ * Phoenix-RTOS
+ *
+ * POSIX.1-2017 standard library functions tests
+ * HEADER:
+ *    - dirent.h
+ * TESTED:
+ *    - rewinddir()
+ *
+ * Copyright 2023 Phoenix Systems
+ * Author: Arkadiusz Kozlowski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <dirent.h>
+
+#include <string.h>
+#include <fcntl.h>
+
+#include <unity_fixture.h>
+#include "dirent_helper_functions.h"
+
+#include "common.h"
+
+#define MAIN_DIR               "test_rewinddir"
+#define MAIN_DIR_INIT_CONTENTS 4
+
+
+TEST_GROUP(dirent_rewinddir);
+
+TEST_SETUP(dirent_rewinddir)
+{
+	TEST_MKDIR_ASSERTED(MAIN_DIR, S_IRWXU);
+	TEST_MKDIR_ASSERTED(MAIN_DIR "/dir1", S_IRUSR);
+	TEST_MKDIR_ASSERTED(MAIN_DIR "/dir2", S_IRWXU);
+	TEST_MKDIR_ASSERTED(MAIN_DIR "/dir2/nestDir", S_IRUSR);
+}
+
+
+TEST_TEAR_DOWN(dirent_rewinddir)
+{
+	rmdir(MAIN_DIR "/dir2/nestDir");
+	rmdir(MAIN_DIR "/dir1");
+	rmdir(MAIN_DIR "/dir2");
+	rmdir(MAIN_DIR);
+}
+
+
+TEST(dirent_rewinddir, rewinddir_basic)
+{
+	struct stat bufBefore, bufAfter;
+	DIR *dp = opendir(MAIN_DIR);
+	int counter1, counter2;
+	counter1 = counter2 = 0;
+
+
+	TEST_ASSERT_NOT_NULL(dp);
+
+	stat(MAIN_DIR, &bufBefore);
+
+	while (readdir(dp)) {
+		counter1++;
+	}
+
+	rewinddir(dp);
+
+	while (readdir(dp)) {
+		counter2++;
+	}
+
+	TEST_ASSERT_EQUAL_INT(counter1, counter2);
+	TEST_ASSERT_EQUAL_INT(MAIN_DIR_INIT_CONTENTS, counter1);
+
+	rewinddir(dp);
+
+	stat(MAIN_DIR, &bufAfter);
+
+	TEST_ASSERT_EQUAL(bufBefore.st_blksize, bufAfter.st_blksize);
+	TEST_ASSERT_EQUAL(bufBefore.st_blocks, bufAfter.st_blocks);
+	TEST_ASSERT_EQUAL(bufBefore.st_dev, bufAfter.st_dev);
+	TEST_ASSERT_EQUAL(bufBefore.st_ino, bufAfter.st_ino);
+	TEST_ASSERT_EQUAL(bufBefore.st_mode, bufAfter.st_mode);
+
+	closedir(dp);
+}
+
+
+TEST(dirent_rewinddir, directory_contents_change)
+{
+	DIR *dp = opendir(MAIN_DIR);
+	int counter1, counter2, counter3;
+	counter1 = counter2 = counter3 = 0;
+
+	while (readdir(dp)) {
+		counter1++;
+	}
+
+	TEST_ASSERT_EQUAL_INT(MAIN_DIR_INIT_CONTENTS, counter1);
+
+	mkdir(MAIN_DIR "/newdir", S_IRUSR);
+	close(creat(MAIN_DIR "/textfile.txt", S_IRUSR | S_IWUSR));
+	TEST_ASSERT_LESS_OR_EQUAL_INT(0, link(MAIN_DIR, MAIN_DIR "/hardlink"));
+	TEST_ASSERT_EQUAL_INT(0, symlink(MAIN_DIR "/newdir", MAIN_DIR "/symlink"));
+
+	rewinddir(dp);
+
+	while (readdir(dp)) {
+		counter2++;
+	}
+
+	TEST_ASSERT_EQUAL_INT(MAIN_DIR_INIT_CONTENTS + 3, counter2);
+
+	rmdir(MAIN_DIR "/newdir");
+	unlink(MAIN_DIR "/hardlink");
+	unlink(MAIN_DIR "/symlink");
+	remove(MAIN_DIR "/textfile.txt");
+	rewinddir(dp);
+
+	while (readdir(dp)) {
+		counter3++;
+	}
+
+	TEST_ASSERT_EQUAL_INT(MAIN_DIR_INIT_CONTENTS, counter3);
+	closedir(dp);
+}
+
+
+TEST_GROUP_RUNNER(dirent_rewinddir)
+{
+	RUN_TEST_CASE(dirent_rewinddir, rewinddir_basic);
+	RUN_TEST_CASE(dirent_rewinddir, directory_contents_change);
+}

--- a/libc/dirent/rewinddir.c
+++ b/libc/dirent/rewinddir.c
@@ -7,8 +7,8 @@
  * TESTED:
  *    - rewinddir()
  *
- * Copyright 2023 Phoenix Systems
- * Author: Arkadiusz Kozlowski
+ * Copyright 2023-2026 Phoenix Systems
+ * Authors: Arkadiusz Kozlowski, Lukasz Kruszynski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -21,6 +21,7 @@
 
 #include <string.h>
 #include <fcntl.h>
+#include <stdlib.h>
 
 #include <unity_fixture.h>
 #include "dirent_helper_functions.h"
@@ -30,11 +31,18 @@
 #define MAIN_DIR               "test_rewinddir"
 #define MAIN_DIR_INIT_CONTENTS 4
 
+typedef struct {
+	DIR *dp1;
+	DIR *dp2;
+} test_ctx_t;
+
+static test_ctx_t test_ctx;
 
 TEST_GROUP(dirent_rewinddir);
 
 TEST_SETUP(dirent_rewinddir)
 {
+	memset(&test_ctx, 0, sizeof(test_ctx));
 	TEST_MKDIR_ASSERTED(MAIN_DIR, S_IRWXU);
 	TEST_MKDIR_ASSERTED(MAIN_DIR "/dir1", S_IRUSR);
 	TEST_MKDIR_ASSERTED(MAIN_DIR "/dir2", S_IRWXU);
@@ -44,6 +52,12 @@ TEST_SETUP(dirent_rewinddir)
 
 TEST_TEAR_DOWN(dirent_rewinddir)
 {
+	if (test_ctx.dp1 != NULL) {
+		closedir(test_ctx.dp1);
+	}
+	if (test_ctx.dp2 != NULL) {
+		closedir(test_ctx.dp2);
+	}
 	rmdir(MAIN_DIR "/dir2/nestDir");
 	rmdir(MAIN_DIR "/dir1");
 	rmdir(MAIN_DIR "/dir2");
@@ -54,14 +68,14 @@ TEST_TEAR_DOWN(dirent_rewinddir)
 TEST(dirent_rewinddir, rewinddir_basic)
 {
 	struct stat bufBefore, bufAfter;
-	DIR *dp = opendir(MAIN_DIR);
+	test_ctx.dp1 = TEST_OPENDIR_ASSERTED(MAIN_DIR);
+	DIR *dp = test_ctx.dp1;
 	int counter1, counter2;
 	counter1 = counter2 = 0;
 
-
 	TEST_ASSERT_NOT_NULL(dp);
 
-	stat(MAIN_DIR, &bufBefore);
+	TEST_ASSERT_EQUAL_INT(0, stat(MAIN_DIR, &bufBefore));
 
 	while (readdir(dp)) {
 		counter1++;
@@ -78,55 +92,345 @@ TEST(dirent_rewinddir, rewinddir_basic)
 
 	rewinddir(dp);
 
-	stat(MAIN_DIR, &bufAfter);
+	TEST_ASSERT_EQUAL_INT(0, stat(MAIN_DIR, &bufAfter));
 
 	TEST_ASSERT_EQUAL(bufBefore.st_blksize, bufAfter.st_blksize);
 	TEST_ASSERT_EQUAL(bufBefore.st_blocks, bufAfter.st_blocks);
 	TEST_ASSERT_EQUAL(bufBefore.st_dev, bufAfter.st_dev);
 	TEST_ASSERT_EQUAL(bufBefore.st_ino, bufAfter.st_ino);
 	TEST_ASSERT_EQUAL(bufBefore.st_mode, bufAfter.st_mode);
-
-	closedir(dp);
 }
 
 
 TEST(dirent_rewinddir, directory_contents_change)
 {
-	DIR *dp = opendir(MAIN_DIR);
-	int counter1, counter2, counter3;
-	counter1 = counter2 = counter3 = 0;
+	test_ctx.dp1 = TEST_OPENDIR_ASSERTED(MAIN_DIR);
+	DIR *dp = test_ctx.dp1;
+	int counter1 = 0, counter2 = 0, counter3 = 0;
+	int fd = -1;
 
-	while (readdir(dp)) {
-		counter1++;
+	if (TEST_PROTECT()) {
+		while (readdir(dp)) {
+			counter1++;
+		}
+
+		TEST_ASSERT_EQUAL_INT(MAIN_DIR_INIT_CONTENTS, counter1);
+		TEST_ASSERT_EQUAL_INT(0, mkdir(MAIN_DIR "/newdir", S_IRUSR));
+
+		fd = creat(MAIN_DIR "/textfile.txt", S_IRUSR | S_IWUSR);
+		TEST_ASSERT_NOT_EQUAL_INT(-1, fd);
+		close(fd);
+		TEST_ASSERT_EQUAL_INT(0, link(MAIN_DIR "/textfile.txt", MAIN_DIR "/hardlink"));
+		TEST_ASSERT_EQUAL_INT(0, symlink(MAIN_DIR "/newdir", MAIN_DIR "/symlink"));
+
+		rewinddir(dp);
+
+		while (readdir(dp)) {
+			counter2++;
+		}
+
+		TEST_ASSERT_EQUAL_INT(MAIN_DIR_INIT_CONTENTS + 4, counter2);
+
+		rmdir(MAIN_DIR "/newdir");
+		unlink(MAIN_DIR "/hardlink");
+		unlink(MAIN_DIR "/symlink");
+		remove(MAIN_DIR "/textfile.txt");
+		rewinddir(dp);
+
+		while (readdir(dp)) {
+			counter3++;
+		}
+
+		TEST_ASSERT_EQUAL_INT(MAIN_DIR_INIT_CONTENTS, counter3);
 	}
-
-	TEST_ASSERT_EQUAL_INT(MAIN_DIR_INIT_CONTENTS, counter1);
-
-	mkdir(MAIN_DIR "/newdir", S_IRUSR);
-	close(creat(MAIN_DIR "/textfile.txt", S_IRUSR | S_IWUSR));
-	TEST_ASSERT_LESS_OR_EQUAL_INT(0, link(MAIN_DIR, MAIN_DIR "/hardlink"));
-	TEST_ASSERT_EQUAL_INT(0, symlink(MAIN_DIR "/newdir", MAIN_DIR "/symlink"));
-
-	rewinddir(dp);
-
-	while (readdir(dp)) {
-		counter2++;
-	}
-
-	TEST_ASSERT_EQUAL_INT(MAIN_DIR_INIT_CONTENTS + 3, counter2);
-
+	/* Ensure a cleanup, ignore fails */
 	rmdir(MAIN_DIR "/newdir");
 	unlink(MAIN_DIR "/hardlink");
 	unlink(MAIN_DIR "/symlink");
 	remove(MAIN_DIR "/textfile.txt");
-	rewinddir(dp);
+}
 
-	while (readdir(dp)) {
-		counter3++;
+TEST(dirent_rewinddir, rewinddir_mid_stream)
+{
+	test_ctx.dp1 = TEST_OPENDIR_ASSERTED(MAIN_DIR);
+	DIR *dp = test_ctx.dp1;
+	struct dirent *info;
+	char first_entry[NAME_MAX + 1];
+
+	info = readdir(dp);
+	TEST_ASSERT_NOT_NULL(info);
+	snprintf(first_entry, sizeof(first_entry), "%s", info->d_name);
+
+	TEST_ASSERT_NOT_NULL(readdir(dp));
+
+	errno = 0;
+	rewinddir(dp);
+	TEST_ASSERT_EQUAL_INT(0, errno);
+
+	info = readdir(dp);
+	TEST_ASSERT_NOT_NULL(info);
+	TEST_ASSERT_EQUAL_STRING(first_entry, info->d_name);
+}
+
+
+TEST(dirent_rewinddir, rewinddir_multiple_consecutive)
+{
+	test_ctx.dp1 = TEST_OPENDIR_ASSERTED(MAIN_DIR);
+	DIR *dp = test_ctx.dp1;
+	struct dirent *info;
+	char first_entry[NAME_MAX + 1];
+
+	info = readdir(dp);
+	TEST_ASSERT_NOT_NULL(info);
+	snprintf(first_entry, sizeof(first_entry), "%s", info->d_name);
+
+	TEST_ASSERT_NOT_NULL(readdir(dp));
+	TEST_ASSERT_NOT_NULL(readdir(dp));
+
+	for (int i = 0; i < 10; i++) {
+		rewinddir(dp);
 	}
 
-	TEST_ASSERT_EQUAL_INT(MAIN_DIR_INIT_CONTENTS, counter3);
-	closedir(dp);
+	info = readdir(dp);
+	TEST_ASSERT_NOT_NULL(info);
+	TEST_ASSERT_EQUAL_STRING(first_entry, info->d_name);
+}
+
+
+TEST(dirent_rewinddir, rewinddir_independent_streams)
+{
+	char seq1[MAIN_DIR_INIT_CONTENTS][NAME_MAX + 1];
+	char seq2[MAIN_DIR_INIT_CONTENTS][NAME_MAX + 1];
+	struct dirent *entry;
+	int n1 = 0;
+	int n2 = 0;
+	int i, k;
+
+	test_ctx.dp1 = TEST_OPENDIR_ASSERTED(MAIN_DIR);
+	test_ctx.dp2 = TEST_OPENDIR_ASSERTED(MAIN_DIR);
+	DIR *dp1 = test_ctx.dp1;
+	DIR *dp2 = test_ctx.dp2;
+
+	TEST_ASSERT_NOT_NULL(dp1);
+	TEST_ASSERT_NOT_NULL(dp2);
+
+	errno = 0;
+	entry = readdir(dp1);
+	while (entry != NULL) {
+		TEST_ASSERT_LESS_THAN_INT(MAIN_DIR_INIT_CONTENTS, n1);
+		snprintf(seq1[n1], NAME_MAX + 1, "%s", entry->d_name);
+		n1++;
+		errno = 0;
+		entry = readdir(dp1);
+	}
+	TEST_ASSERT_EQUAL_INT(0, errno);
+
+	errno = 0;
+	entry = readdir(dp2);
+	while (entry != NULL) {
+		TEST_ASSERT_LESS_THAN_INT(MAIN_DIR_INIT_CONTENTS, n2);
+		snprintf(seq2[n2], NAME_MAX + 1, "%s", entry->d_name);
+		n2++;
+		errno = 0;
+		entry = readdir(dp2);
+	}
+	TEST_ASSERT_EQUAL_INT(0, errno);
+
+	TEST_ASSERT_EQUAL_INT(MAIN_DIR_INIT_CONTENTS, n1);
+	TEST_ASSERT_EQUAL_INT(MAIN_DIR_INIT_CONTENTS, n2);
+
+	rewinddir(dp1);
+	rewinddir(dp2);
+
+	/* Position dp2 at a known mid-stream offset just before the operation
+	 * under test. */
+	k = n2 / 2;
+	for (i = 0; i < k; i++) {
+		entry = readdir(dp2);
+		TEST_ASSERT_NOT_NULL(entry);
+		TEST_ASSERT_EQUAL_STRING(seq2[i], entry->d_name);
+	}
+
+	rewinddir(dp1);
+
+	/* dp2 must still be exactly at offset k and yield its full unchanged
+	 * tail followed by end-of-directory. */
+	for (i = k; i < n2; i++) {
+		errno = 0;
+		entry = readdir(dp2);
+		TEST_ASSERT_NOT_NULL(entry);
+		TEST_ASSERT_EQUAL_STRING(seq2[i], entry->d_name);
+	}
+	errno = 0;
+	TEST_ASSERT_NULL(readdir(dp2));
+	TEST_ASSERT_EQUAL_INT(0, errno);
+
+	/* dp1 itself was actually rewound to the start. */
+	errno = 0;
+	entry = readdir(dp1);
+	TEST_ASSERT_NOT_NULL(entry);
+	TEST_ASSERT_EQUAL_STRING(seq1[0], entry->d_name);
+
+	rewinddir(dp1);
+	rewinddir(dp2);
+
+	/* Position dp1 at a known mid-stream offset just before the operation
+	 * under test. */
+	k = n1 / 2;
+	for (i = 0; i < k; i++) {
+		entry = readdir(dp1);
+		TEST_ASSERT_NOT_NULL(entry);
+		TEST_ASSERT_EQUAL_STRING(seq1[i], entry->d_name);
+	}
+
+	rewinddir(dp2);
+
+	/* dp1 must still be exactly at offset k and yield its full unchanged
+	 * tail followed by end-of-directory. */
+	for (i = k; i < n1; i++) {
+		errno = 0;
+		entry = readdir(dp1);
+		TEST_ASSERT_NOT_NULL(entry);
+		TEST_ASSERT_EQUAL_STRING(seq1[i], entry->d_name);
+	}
+	errno = 0;
+	TEST_ASSERT_NULL(readdir(dp1));
+	TEST_ASSERT_EQUAL_INT(0, errno);
+
+	errno = 0;
+	entry = readdir(dp2);
+	TEST_ASSERT_NOT_NULL(entry);
+	TEST_ASSERT_EQUAL_STRING(seq2[0], entry->d_name);
+}
+
+
+TEST(dirent_rewinddir, rewind_empty_dir)
+{
+	int count1 = 0, count2 = 0;
+	int dir_created = 0;
+
+	if (TEST_PROTECT()) {
+		TEST_MKDIR_ASSERTED(MAIN_DIR "/emptydir", 0700);
+		dir_created = 1;
+
+		test_ctx.dp1 = TEST_OPENDIR_ASSERTED(MAIN_DIR "/emptydir");
+		DIR *dp = test_ctx.dp1;
+
+		while (readdir(dp) != NULL) {
+			count1++;
+		}
+
+		rewinddir(dp);
+
+		while (readdir(dp) != NULL) {
+			count2++;
+		}
+
+		TEST_ASSERT_EQUAL_INT(count1, count2);
+		TEST_ASSERT_EQUAL_INT(2, count1);
+	}
+
+	if (test_ctx.dp1 != NULL) {
+		closedir(test_ctx.dp1);
+		test_ctx.dp1 = NULL;
+	}
+
+	if (dir_created) {
+		rmdir(MAIN_DIR "/emptydir");
+	}
+}
+
+
+TEST(dirent_rewinddir, rewind_large_dir_pagination)
+{
+	const int NUM_FILES = 40;
+	char path[PATH_MAX];
+	int dir_created = 0;
+	int files_created = 0;
+	DIR *dp = NULL;
+	struct dirent *info = NULL;
+	char first_entry[NAME_MAX + 1];
+	int i;
+	int fd;
+
+	memset(path, 0, sizeof(path));
+	memset(first_entry, 0, sizeof(first_entry));
+
+	if (TEST_PROTECT()) {
+		TEST_MKDIR_ASSERTED(MAIN_DIR "/pagedir", 0700);
+		dir_created = 1;
+
+		for (i = 0; i < NUM_FILES; i++) {
+			snprintf(path, PATH_MAX, MAIN_DIR "/pagedir/file_%d.txt", i);
+			fd = creat(path, S_IRUSR);
+			TEST_ASSERT_NOT_EQUAL_INT(-1, fd);
+			close(fd);
+			files_created++;
+		}
+
+		test_ctx.dp1 = TEST_OPENDIR_ASSERTED(MAIN_DIR "/pagedir");
+		dp = test_ctx.dp1;
+
+		info = readdir(dp);
+		TEST_ASSERT_NOT_NULL(info);
+		snprintf(first_entry, sizeof(first_entry), "%s", info->d_name);
+
+		while (readdir(dp) != NULL) { }
+
+		rewinddir(dp);
+
+		info = readdir(dp);
+		TEST_ASSERT_NOT_NULL(info);
+		TEST_ASSERT_EQUAL_STRING(first_entry, info->d_name);
+	}
+
+	if (test_ctx.dp1 != NULL) {
+		closedir(test_ctx.dp1);
+		test_ctx.dp1 = NULL;
+	}
+
+	if (dir_created) {
+		for (i = 0; i < files_created; i++) {
+			snprintf(path, PATH_MAX, MAIN_DIR "/pagedir/file_%d.txt", i);
+			remove(path);
+		}
+		rmdir(MAIN_DIR "/pagedir");
+	}
+}
+
+
+TEST(dirent_rewinddir, rewind_unlinked_dir)
+{
+	/* issue #1663 https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1663 */
+	TEST_IGNORE_MESSAGE("#1663 issue");
+	DIR *dp = NULL;
+	void *ret = NULL;
+	int dir_created = 0;
+
+	if (TEST_PROTECT()) {
+		TEST_MKDIR_ASSERTED(MAIN_DIR "/ghostdir", 0700);
+		dir_created = 1;
+
+		test_ctx.dp1 = TEST_OPENDIR_ASSERTED(MAIN_DIR "/ghostdir");
+		dp = test_ctx.dp1;
+
+		TEST_ASSERT_EQUAL_INT(0, rmdir(MAIN_DIR "/ghostdir"));
+		dir_created = 0;
+
+		errno = 0;
+		while (readdir(dp) != NULL) { }
+		TEST_ASSERT_EQUAL_INT(0, errno);
+
+		rewinddir(dp);
+
+		ret = readdir(dp);
+		/* POSIX mandates . and .. are removed on rmdir, so this must be NULL */
+		TEST_ASSERT_NULL(ret);
+	}
+
+	if (dir_created) {
+		rmdir(MAIN_DIR "/ghostdir");
+	}
 }
 
 
@@ -134,4 +438,10 @@ TEST_GROUP_RUNNER(dirent_rewinddir)
 {
 	RUN_TEST_CASE(dirent_rewinddir, rewinddir_basic);
 	RUN_TEST_CASE(dirent_rewinddir, directory_contents_change);
+	RUN_TEST_CASE(dirent_rewinddir, rewinddir_mid_stream);
+	RUN_TEST_CASE(dirent_rewinddir, rewinddir_multiple_consecutive);
+	RUN_TEST_CASE(dirent_rewinddir, rewinddir_independent_streams);
+	RUN_TEST_CASE(dirent_rewinddir, rewind_empty_dir);
+	RUN_TEST_CASE(dirent_rewinddir, rewind_large_dir_pagination);
+	RUN_TEST_CASE(dirent_rewinddir, rewind_unlinked_dir);
 }

--- a/libc/test.yaml
+++ b/libc/test.yaml
@@ -97,7 +97,7 @@ test:
       execute: test-libc-unix-socket --extra-poll-delay-ms 150
       targets:
         value: [armv7a9-zynq7000-qemu]
-    
+
     - name: unix-socket # Issue: 1342 | https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1342
       execute: test-libc-unix-socket --extra-poll-delay-ms 250 --transfer-loop-cnt 30
       targets:
@@ -107,3 +107,9 @@ test:
       execute: test-libc-inet-socket
       targets:
         value: [ia32-generic-qemu, armv7a7-imx6ull-evk, host-generic-pc]
+
+    - name: dirent
+      execute: test-libc-dirent
+      targets:
+        include: [host-generic-pc]
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds a test coverage for `dirent.h` functions.

## Description
<!--- Describe your changes shortly -->
The coverage includes:
* `readdir()`
* `closedir()`
* `opendir()`
* `rewinddir()`

Ensures the functions are POSIX compliant.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Ensures a fuller test coverage of libc functions
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. (https://github.com/phoenix-rtos/phoenix-rtos-doc/pull/257)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
