### PR TITLE
libc/stdio: add test for gets() and more for fgets()

### DIFF
--- a/libc/stdio/stdio_file.c
+++ b/libc/stdio/stdio_file.c
@@ -355,7 +355,168 @@ TEST(stdio_getput, fgets_eof)
 }
 
 
+TEST(stdio_getput, fgets_sizes)
+{
+	static const struct {
+		int size;
+		const char *expected;
+	} cases[] = {
+		{ .size = 0, .expected = NULL },
+#ifdef __phoenix__
+		/*
+		 * Turned off for host-generic-pc.
+		 * It seems that in glibc>=2.36 there's a bug
+		 * that makes this case not work.
+		 * TODO: update with link to issue when account
+		 * creation request is accepted.
+		 */
+		{ .size = 1, .expected = "" },
+#endif
+		{ .size = 2, .expected = "A" },
+		{ .size = 3, .expected = "AB" },
+		{ .size = 4, .expected = "ABC" },
+		{ .size = 5, .expected = "ABC\n" },
+	};
+
+	char buf[16];
+	size_t i;
+
+	for (i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
+		filep = fopen(STDIO_TEST_FILENAME, "r+");
+		TEST_ASSERT_NOT_NULL(filep);
+		TEST_ASSERT_GREATER_OR_EQUAL_INT(0, fputs("ABC\n", filep));
+		TEST_ASSERT_EQUAL(0, fflush(filep));
+		rewind(filep);
+
+		memset(buf, 0xaa, sizeof(buf));
+
+		char *ret = fgets(buf, cases[i].size, filep);
+
+		if (cases[i].expected == NULL) {
+			TEST_ASSERT_NULL(ret);
+			TEST_ASSERT_EACH_EQUAL_HEX8(0xaa, buf, sizeof(buf));
+		}
+		else {
+			TEST_ASSERT_EQUAL_PTR_MESSAGE(buf, ret, cases[i].expected);
+			TEST_ASSERT_EQUAL_STRING(cases[i].expected, (char *)buf);
+			TEST_ASSERT_NOT_NULL(memchr(buf, '\0', cases[i].size));
+		}
+
+		assert_fclosed(&filep);
+	}
+}
+
+
+TEST(stdio_getput, fgets_truncation)
+{
+	char buf[5];
+
+	filep = fopen(STDIO_TEST_FILENAME, "r+");
+	TEST_ASSERT_NOT_NULL(filep);
+	TEST_ASSERT_GREATER_OR_EQUAL_INT(0, fputs("abcdef\n", filep));
+	TEST_ASSERT_EQUAL(0, fflush(filep));
+	rewind(filep);
+
+	TEST_ASSERT_EQUAL_PTR(buf, fgets(buf, sizeof(buf), filep));
+	TEST_ASSERT_EQUAL_STRING("abcd", buf);
+
+	assert_fclosed(&filep);
+}
+
+
+TEST(stdio_getput, fgets_newline_preserved)
+{
+	char buf[16];
+	filep = fopen(STDIO_TEST_FILENAME, "r+");
+	TEST_ASSERT_NOT_NULL(filep);
+	TEST_ASSERT_GREATER_OR_EQUAL_INT(0, fputs("abc\nxyz\n", filep));
+	TEST_ASSERT_EQUAL(0, fflush(filep));
+	rewind(filep);
+
+	TEST_ASSERT_EQUAL_PTR(buf, fgets(buf, sizeof(buf), filep));
+	TEST_ASSERT_EQUAL_STRING("abc\n", buf);
+
+	TEST_ASSERT_EQUAL_PTR(buf, fgets(buf, sizeof(buf), filep));
+	TEST_ASSERT_EQUAL_STRING("xyz\n", buf);
+
+	assert_fclosed(&filep);
+}
+
+
+TEST(stdio_getput, fgets_partial_reads)
+{
+	char buf[4];
+	filep = fopen(STDIO_TEST_FILENAME, "r+");
+	TEST_ASSERT_NOT_NULL(filep);
+	TEST_ASSERT_GREATER_OR_EQUAL_INT(0, fputs("abcdef\n", filep));
+	TEST_ASSERT_EQUAL(0, fflush(filep));
+	rewind(filep);
+
+	TEST_ASSERT_EQUAL_PTR(buf, fgets(buf, sizeof(buf), filep));
+	TEST_ASSERT_EQUAL_STRING("abc", buf);
+
+	TEST_ASSERT_EQUAL_PTR(buf, fgets(buf, sizeof(buf), filep));
+	TEST_ASSERT_EQUAL_STRING("def", buf);
+
+	TEST_ASSERT_EQUAL_PTR(buf, fgets(buf, sizeof(buf), filep));
+	TEST_ASSERT_EQUAL_STRING("\n", buf);
+
+	assert_fclosed(&filep);
+}
+
+
+#ifndef __phoenix__
+/* >c99 doesn't seem to expose gets() anymore, but we still want to test it on host to keep libphoenix implementation in sync */
+extern char *gets(char *str);
+#endif
+
+
+static void assertGetsOnStream(FILE *stream, char *buf, const char *expected)
+{
+	FILE *oldStdin = stdin;
+	stdin = filep;
+	char *s = gets(buf);
+	stdin = oldStdin;
+
+	TEST_ASSERT_EQUAL_PTR(buf, s);
+	TEST_ASSERT_EQUAL_STRING(expected, buf);
+}
+
+
 TEST(stdio_getput, getsputs_basic)
+{
+	char buf[16];
+	filep = fopen(STDIO_TEST_FILENAME, "r+");
+	TEST_ASSERT_NOT_NULL(filep);
+	TEST_ASSERT_GREATER_OR_EQUAL_INT(0, fputs("hello\n", filep));
+	TEST_ASSERT_EQUAL(0, fflush(filep));
+	rewind(filep);
+
+	assertGetsOnStream(filep, buf, "hello");
+
+	assert_fclosed(&filep);
+}
+
+
+TEST(stdio_getput, getsputs_multiline)
+{
+	char buf[16];
+	filep = fopen(STDIO_TEST_FILENAME, "r+");
+	TEST_ASSERT_NOT_NULL(filep);
+	TEST_ASSERT_GREATER_OR_EQUAL_INT(0, fputs("hello\nworld\n\nsecret", filep));
+	TEST_ASSERT_EQUAL(0, fflush(filep));
+	rewind(filep);
+
+	assertGetsOnStream(filep, buf, "hello");
+	assertGetsOnStream(filep, buf, "world");
+	assertGetsOnStream(filep, buf, "");
+	assertGetsOnStream(filep, buf, "secret");
+
+	assert_fclosed(&filep);
+}
+
+
+TEST(stdio_getput, fgetsfputs_basic)
 {
 	char buf[BUF_SIZE];
 
@@ -381,7 +542,7 @@ TEST(stdio_getput, getsputs_basic)
 }
 
 
-TEST(stdio_getput, getsputs_readonly)
+TEST(stdio_getput, fgetsfputs_readonly)
 {
 	char buf[BUF_SIZE];
 
@@ -437,9 +598,15 @@ TEST_GROUP_RUNNER(stdio_getput)
 	RUN_TEST_CASE(stdio_getput, fwritefread_basic);
 	RUN_TEST_CASE(stdio_getput, getput_basic);
 	RUN_TEST_CASE(stdio_getput, fgetc_eof);
-	RUN_TEST_CASE(stdio_getput, getsputs_basic);
+	RUN_TEST_CASE(stdio_getput, fgetsfputs_basic);
 	RUN_TEST_CASE(stdio_getput, fgets_eof);
-	RUN_TEST_CASE(stdio_getput, getsputs_readonly);
+	RUN_TEST_CASE(stdio_getput, fgetsfputs_readonly);
+	RUN_TEST_CASE(stdio_getput, fgets_sizes);
+	RUN_TEST_CASE(stdio_getput, fgets_truncation);
+	RUN_TEST_CASE(stdio_getput, fgets_newline_preserved);
+	RUN_TEST_CASE(stdio_getput, fgets_partial_reads);
+	RUN_TEST_CASE(stdio_getput, getsputs_basic);
+	RUN_TEST_CASE(stdio_getput, getsputs_multiline);
 	RUN_TEST_CASE(stdio_getput, ungetc_basic);
 }
 

--- a/libc/stdio/stdio_file.c
+++ b/libc/stdio/stdio_file.c
@@ -8,9 +8,10 @@
  * TESTED:
  * fopen, fclose, fdopen, freopen,
  * fwrite, fread,
- * putc, fputc, fputs,
  * getc, fgetc, fgets,
+ * putc, fputc, fputs,
  * ungetc,
+ * puts, gets
  * getline,
  * fseek, fseeko, rewind,
  * ftell,
@@ -19,7 +20,6 @@
  * setvbuf, setbuf, fflush,
  *
  * UNTESTED:
- * puts, gets < needs writing to stdin/unimplemented
  * popen, pclose < not usable on all targets
  *
  * Copyright 2021, 2022 Phoenix Systems
@@ -222,7 +222,7 @@ Tets group for:
 - getc, fgetc,
 - putchar, getchar, < need threads
 - ungetc,
-- puts, fputs, fgets
+- puts, fputs, gets, fgets
 */
 TEST_GROUP(stdio_getput);
 
@@ -471,6 +471,19 @@ extern char *gets(char *str);
 #endif
 
 
+static void assertPutsOnStream(FILE *stream, const char *buf)
+{
+	FILE *oldStdin = stdout;
+	stdout = filep;
+	int putsRes = puts(buf);
+	int fflushRes = fflush(stdout);
+	stdout = oldStdin;
+
+	TEST_ASSERT_GREATER_OR_EQUAL(0, putsRes);
+	TEST_ASSERT_EQUAL(0, fflushRes);
+}
+
+
 static void assertGetsOnStream(FILE *stream, char *buf, const char *expected)
 {
 	FILE *oldStdin = stdin;
@@ -488,8 +501,8 @@ TEST(stdio_getput, getsputs_basic)
 	char buf[16];
 	filep = fopen(STDIO_TEST_FILENAME, "r+");
 	TEST_ASSERT_NOT_NULL(filep);
-	TEST_ASSERT_GREATER_OR_EQUAL_INT(0, fputs("hello\n", filep));
-	TEST_ASSERT_EQUAL(0, fflush(filep));
+
+	assertPutsOnStream(filep, "hello\n");
 	rewind(filep);
 
 	assertGetsOnStream(filep, buf, "hello");
@@ -503,8 +516,11 @@ TEST(stdio_getput, getsputs_multiline)
 	char buf[16];
 	filep = fopen(STDIO_TEST_FILENAME, "r+");
 	TEST_ASSERT_NOT_NULL(filep);
-	TEST_ASSERT_GREATER_OR_EQUAL_INT(0, fputs("hello\nworld\n\nsecret", filep));
-	TEST_ASSERT_EQUAL(0, fflush(filep));
+
+	assertPutsOnStream(filep, "hello");
+	assertPutsOnStream(filep, "world");
+	assertPutsOnStream(filep, "");
+	assertPutsOnStream(filep, "secret");
 	rewind(filep);
 
 	assertGetsOnStream(filep, buf, "hello");


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `ia32-generic-qemu`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work:
    - https://github.com/phoenix-rtos/libphoenix/pull/473
- [ ] I will merge this PR by myself when appropriate.
