### PR TITLE
psh: unpack command arguments to an array

### DIFF
--- a/psh/test-ps.py
+++ b/psh/test-ps.py
@@ -32,12 +32,9 @@ def harness(p):
             header_seen = True
         else:
             try:
-                pid, ppid, pr, state, cpu, wait, time, vmem, thr, task = line.split()
+                pid, ppid, pr, state, cpu, wait, time, vmem, thr, task, *arguments = line.split()
             except ValueError:
-                try:
-                    pid, ppid, pr, state, cpu, wait, time, vmem, thr, task, arguments = line.split()
-                except ValueError:
-                    assert False, f'wrong ps output: {line}'
+                assert False, f'wrong ps output: {line}'
             # handle for example /bin/psh
             if task.endswith('psh'):
                 task = 'psh'


### PR DESCRIPTION
arguments variable here is treated as a single value. If .split() returns an array with more values than there are on the left side of the assignment, a ValueError exception will be raised.

JIRA: RTOS-1319

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [X] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/776
- [X] I will merge this PR by myself when appropriate.
