### PR TITLE
trunner: add pexpect.TIMEOUT handling to HostPCGenericTarget

### DIFF
--- a/trunner/target/host.py
+++ b/trunner/target/host.py
@@ -1,6 +1,8 @@
 import shlex
 from typing import Callable, List, TextIO
 
+import pexpect
+
 from trunner.ctx import TestContext
 from trunner.dut import HostDut
 from trunner.harness import IntermediateHarness, HarnessBuilder
@@ -32,7 +34,7 @@ class HostPCGenericTarget(TargetBase):
                 exitstatus = self.dut.wait()
                 if exitstatus != 0:
                     result.fail(msg=f"non-zero exit status: {exitstatus}", summary="Exit Status failure")
-            except TimeoutError as exc:
+            except (TimeoutError, pexpect.TIMEOUT) as exc:
                 result.fail_harness_exception(exc)
 
             return res


### PR DESCRIPTION
JIRA: CI-647

<!--- Provide a general summary of your changes in the Title above -->

Add pexpect.TIMEOUT handling to HostPCGenericTarget

## Description
<!--- Describe your changes shortly -->
Adds pexpect.TIMEOUT handling to HostPCGenericTarget's ExecHarness 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
HostPCGenericTarget's ExecHarness does not handle pexpect.TIMEOUT exception in case the process it's running does not end, without writing anything to buffer (silent forever loop).

We can reproduce this issue by raising an exception in sample/test/test-echo.py before the terminating signal is sent to the running pexpect process, causing the trunner to wait at dut.wait() for 30s and raising the pexpect.TIMEOUT.
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: host-generic-pc.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
