### PR TITLE
trunner: increase delayafterterminate in qemu close

### DIFF
--- a/trunner/dut.py
+++ b/trunner/dut.py
@@ -157,7 +157,7 @@ class ProcessDut(Dut):
             # when a child process needs to be forcefully terminated, pexpect sends SIGHUP, SIGINT and SIGKILL signals
             # this value defines how long pexpect waits before checking if the child process is still alive
             # by default, it's 0.1s, but it's increased here because the child sometimes appeared to still be running
-            self.pexpect_proc.ptyproc.delayafterterminate = 0.5
+            self.pexpect_proc.ptyproc.delayafterterminate = 1
             self.pexpect_proc.close()
 
     def open(self):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

A sporadic 'Could not terminate the child' error appeared on CI. It may be related to the recent addition of hal_cpuReschedule yields during thread destruction, which could cause more context switches in the guest and affect QEMU's shutdown timing on the host. Increased the timeout to add some margin.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
