### PR TITLE
sys/mutex: add tests for mutexTry on recursive lock

### DIFF
--- a/sys/mutex/mutex.c
+++ b/sys/mutex/mutex.c
@@ -132,6 +132,20 @@ TEST(mutex_single_thread, type_recursive)
 }
 
 
+TEST(mutex_single_thread, type_recursive_try)
+{
+	handle_t mutex;
+	struct lockAttr attr = { .type = PH_LOCK_RECURSIVE };
+
+	TEST_ASSERT_EQUAL_INT(0, mutexCreateWithAttr(&mutex, &attr));
+	TEST_ASSERT_EQUAL_INT(0, mutexTry(mutex));
+	TEST_ASSERT_EQUAL_INT(0, mutexTry(mutex));
+	TEST_ASSERT_EQUAL_INT(0, mutexUnlock(mutex));
+	TEST_ASSERT_EQUAL_INT(0, mutexUnlock(mutex));
+	TEST_ASSERT_EQUAL_INT(0, resourceDestroy(mutex));
+}
+
+
 /*
  *--------------------------------- MULTITHREADED TESTS -----------------------------------*
  */
@@ -210,6 +224,38 @@ static void recursive_thread(void *arg)
 			endthread();
 		}
 		if ((mutexLock(mt_common.mutex)) < 0) {
+			mt_common.thrErrors[targ->id]++;
+			endthread();
+		}
+		if (targ->id == 0) {
+			mt_common.counter++;
+		}
+		else {
+			mt_common.counter--;
+		}
+		usleep(targ->delay);
+		if ((mutexUnlock(mt_common.mutex)) < 0) {
+			mt_common.thrErrors[targ->id]++;
+			endthread();
+		}
+		if ((mutexUnlock(mt_common.mutex)) < 0) {
+			mt_common.thrErrors[targ->id]++;
+			endthread();
+		}
+	}
+	endthread();
+}
+
+
+static void recursive_try_thread(void *arg)
+{
+	threadArg_t *targ = (threadArg_t *)arg;
+	for (int i = 0; i < 100; i++) {
+		if ((mutexLock(mt_common.mutex)) < 0) {
+			mt_common.thrErrors[targ->id]++;
+			endthread();
+		}
+		if ((mutexTry(mt_common.mutex)) < 0) {
 			mt_common.thrErrors[targ->id]++;
 			endthread();
 		}
@@ -318,6 +364,24 @@ TEST(mutex_multithreaded, type_recursive)
 }
 
 
+TEST(mutex_multithreaded, type_recursive_try)
+{
+	handle_t tid1, tid2;
+	struct lockAttr attr = { .type = PH_LOCK_RECURSIVE };
+	threadArg_t arg1 = { .id = 0, .delay = 1 };
+	threadArg_t arg2 = { .id = 1, .delay = 3 };
+
+	TEST_ASSERT_EQUAL_INT(0, mutexCreateWithAttr(&mt_common.mutex, &attr));
+	TEST_ASSERT_EQUAL_INT(0, beginthreadex(recursive_try_thread, 4, mt_common.stack[0], sizeof(mt_common.stack[0]), &arg1, &tid1));
+	TEST_ASSERT_EQUAL_INT(0, beginthreadex(recursive_try_thread, 4, mt_common.stack[1], sizeof(mt_common.stack[1]), &arg2, &tid2));
+	TEST_ASSERT_EQUAL_INT(tid1, threadJoin(tid1, 0));
+	TEST_ASSERT_EQUAL_INT(tid2, threadJoin(tid2, 0));
+	TEST_ASSERT_EQUAL_INT(0, mt_common.counter);
+	TEST_ASSERT_EQUAL_INT(0, mt_common.thrErrors[0]);
+	TEST_ASSERT_EQUAL_INT(0, mt_common.thrErrors[1]);
+}
+
+
 /*
 ///////////////////////////////////////////////////////////////////////////////////////////////
 */
@@ -336,6 +400,7 @@ TEST_GROUP_RUNNER(mutex_single_thread)
 	RUN_TEST_CASE(mutex_single_thread, type_default);
 	RUN_TEST_CASE(mutex_single_thread, type_errorcheck);
 	RUN_TEST_CASE(mutex_single_thread, type_recursive);
+	RUN_TEST_CASE(mutex_single_thread, type_recursive_try);
 }
 
 
@@ -345,6 +410,7 @@ TEST_GROUP_RUNNER(mutex_multithreaded)
 	RUN_TEST_CASE(mutex_multithreaded, type_default);
 	RUN_TEST_CASE(mutex_multithreaded, type_errorcheck);
 	RUN_TEST_CASE(mutex_multithreaded, type_recursive);
+	RUN_TEST_CASE(mutex_multithreaded, type_recursive_try);
 }
 
 

--- a/sys/mutex/mutex.c
+++ b/sys/mutex/mutex.c
@@ -225,6 +225,7 @@ static void recursive_thread(void *arg)
 		}
 		if ((mutexLock(mt_common.mutex)) < 0) {
 			mt_common.thrErrors[targ->id]++;
+			mutexUnlock(mt_common.mutex);
 			endthread();
 		}
 		if (targ->id == 0) {
@@ -257,6 +258,7 @@ static void recursive_try_thread(void *arg)
 		}
 		if ((mutexTry(mt_common.mutex)) < 0) {
 			mt_common.thrErrors[targ->id]++;
+			mutexUnlock(mt_common.mutex);
 			endthread();
 		}
 		if (targ->id == 0) {


### PR DESCRIPTION
YT: CI-676

<!--- Provide a general summary of your changes in the Title above -->

## Description
Depends-On: phoenix-rtos-kernel:julianuziemblo/RTOS-1334

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work:
    - https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/785
- [ ] I will merge this PR by myself when appropriate.
