### PR TITLE
libc: add socket posix tests

### DIFF
--- a/libc/Makefile
+++ b/libc/Makefile
@@ -46,5 +46,6 @@ $(eval $(call add_test_libc,math, -lm, -ffloat-store)) # -ffloat-store - prevent
 # -Wno-attribute-warning - ignore warning when using sendmsg/recvmsg, we know it's not fully supported
 $(eval $(call add_test_libc_custom,socket,inet-socket,, -Wno-attribute-warning, inet-socket.c common.c))
 $(eval $(call add_test_libc_custom,socket,unix-socket,, -Wno-attribute-warning, unix-socket.c common.c))
+$(eval $(call add_test_libc_custom,socket,socket,, -Wno-attribute-warning, main.c getsockopt.c listen.c recv.c recvfrom.c recvmsg.c send.c sendmsg.c sendto.c setsockopt.c shutdown.c socketpair.c accept.c bind.c connect.c getpeername.c getsockname.c sockatmark.c))
 $(eval $(call add_test_libc,poll))
 $(eval $(call add_test_libc,dirent, -lpthread))

--- a/libc/socket/accept.c
+++ b/libc/socket/accept.c
@@ -1,0 +1,364 @@
+/*
+ * Phoenix-RTOS
+ *
+ * POSIX.1-2017 standard library functions tests
+ * HEADER:
+ *    - <sys/socket.h>
+ * TESTED:
+ *    - accept()
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Damian Loewnau
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+
+#include "unity_fixture.h"
+
+#define ACCEPT_SOCK_PATH "/tmp/test_accept_sock"
+#define CLIENT_SOCK_PATH "/tmp/test_client_sock"
+#define ACCEPT_BACKLOG   5
+
+
+static struct {
+	int listenFd;
+	int acceptFd;
+	int clientFd;
+	int genericFd;
+} test_common;
+
+
+TEST_GROUP(socket_api_accept);
+
+
+TEST_SETUP(socket_api_accept)
+{
+	unlink(ACCEPT_SOCK_PATH);
+	unlink(CLIENT_SOCK_PATH);
+	test_common.listenFd = -1;
+	test_common.acceptFd = -1;
+	test_common.clientFd = -1;
+	test_common.genericFd = -1;
+}
+
+
+TEST_TEAR_DOWN(socket_api_accept)
+{
+	if (test_common.acceptFd >= 0) {
+		close(test_common.acceptFd);
+		test_common.acceptFd = -1;
+	}
+	if (test_common.clientFd >= 0) {
+		close(test_common.clientFd);
+		test_common.clientFd = -1;
+	}
+	if (test_common.listenFd >= 0) {
+		close(test_common.listenFd);
+		test_common.listenFd = -1;
+	}
+	if (test_common.genericFd >= 0) {
+		close(test_common.genericFd);
+		test_common.genericFd = -1;
+	}
+	unlink(ACCEPT_SOCK_PATH);
+	unlink(CLIENT_SOCK_PATH);
+}
+
+
+static void setup_sockaddr_un(struct sockaddr_un *addr, const char *path)
+{
+	memset(addr, 0, sizeof(*addr));
+	addr->sun_family = AF_UNIX;
+	strncpy(addr->sun_path, path, sizeof(addr->sun_path) - 1);
+}
+
+static int test_setupListener(void)
+{
+	struct sockaddr_un addr;
+	int fd;
+	int ret;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (fd < 0) {
+		return -1;
+	}
+
+	setup_sockaddr_un(&addr, ACCEPT_SOCK_PATH);
+
+	ret = bind(fd, (struct sockaddr *)&addr, sizeof(addr));
+	if (ret != 0) {
+		close(fd);
+		return -1;
+	}
+
+	ret = listen(fd, ACCEPT_BACKLOG);
+	if (ret != 0) {
+		close(fd);
+		return -1;
+	}
+
+	return fd;
+}
+
+
+static int test_connectClient(int bindClient)
+{
+	struct sockaddr_un serverAddr, clientAddr;
+	int fd;
+	int ret;
+	int flags;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (fd < 0) {
+		return -1;
+	}
+
+	if (bindClient) {
+		setup_sockaddr_un(&clientAddr, CLIENT_SOCK_PATH);
+		ret = bind(fd, (struct sockaddr *)&clientAddr, sizeof(clientAddr));
+		if (ret != 0) {
+			close(fd);
+			return -1;
+		}
+	}
+
+	setup_sockaddr_un(&serverAddr, ACCEPT_SOCK_PATH);
+
+	flags = fcntl(fd, F_GETFL, 0);
+	fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+
+	ret = connect(fd, (struct sockaddr *)&serverAddr, sizeof(serverAddr));
+	if (ret != 0 && errno != EINPROGRESS) {
+		close(fd);
+		return -1;
+	}
+
+	fcntl(fd, F_SETFL, flags);
+
+	return fd;
+}
+
+
+TEST(socket_api_accept, accept_success)
+{
+	/* "accept() shall extract the first connection on the queue of pending
+	 *  connections, create a new socket ... and allocate a new file descriptor" */
+	int ret;
+	size_t total;
+
+	test_common.listenFd = test_setupListener();
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.listenFd);
+
+	test_common.clientFd = test_connectClient(0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.clientFd);
+
+	test_common.acceptFd = accept(test_common.listenFd, NULL, NULL);
+	TEST_ASSERT_TRUE(test_common.acceptFd >= 0);
+
+	/* Accepted fd is different from listen fd */
+	TEST_ASSERT_NOT_EQUAL_INT(test_common.listenFd, test_common.acceptFd);
+
+	/* Verify connection works: send data through */
+	const char msg[] = "hello";
+	char buf[16];
+
+	/* Prevent undefined behavior if read() fails or returns early */
+	memset(buf, 0, sizeof(buf));
+
+	total = 0;
+	while (total < sizeof(msg)) {
+		ret = write(test_common.clientFd, msg + total, sizeof(msg) - total);
+		/* If write fails or returns 0, Unity aborts here and routes to TEAR_DOWN */
+		TEST_ASSERT_TRUE(ret > 0);
+		total += (size_t)ret;
+	}
+
+	total = 0;
+	while (total < sizeof(msg)) {
+		ret = read(test_common.acceptFd, buf + total, sizeof(msg) - total);
+		/* If read fails or returns 0, Unity aborts here and routes to TEAR_DOWN */
+		TEST_ASSERT_TRUE(ret > 0);
+		total += (size_t)ret;
+	}
+
+	TEST_ASSERT_EQUAL_STRING(msg, buf);
+}
+
+
+TEST(socket_api_accept, accept_with_address)
+{
+	/* "If address is not a null pointer, the address of the peer for
+	 *  the accepted connection shall be stored" */
+	struct sockaddr_un peerAddr;
+	socklen_t addrLen = sizeof(peerAddr);
+
+/* https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1666 */
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1666 issue");
+#endif
+
+	test_common.listenFd = test_setupListener();
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.listenFd);
+
+	test_common.clientFd = test_connectClient(1);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.clientFd);
+
+	memset(&peerAddr, 0xff, sizeof(peerAddr));
+	test_common.acceptFd = accept(test_common.listenFd, (struct sockaddr *)&peerAddr, &addrLen);
+	TEST_ASSERT_TRUE(test_common.acceptFd >= 0);
+
+	/* For AF_UNIX, the address family should be AF_UNIX */
+	TEST_ASSERT_EQUAL_INT(AF_UNIX, peerAddr.sun_family);
+	TEST_ASSERT_EQUAL_STRING(CLIENT_SOCK_PATH, peerAddr.sun_path);
+}
+
+
+TEST(socket_api_accept, accept_null_address)
+{
+	/* "address: Either a null pointer ..." — must succeed with NULL */
+	test_common.listenFd = test_setupListener();
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.listenFd);
+
+	test_common.clientFd = test_connectClient(0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.clientFd);
+
+	test_common.acceptFd = accept(test_common.listenFd, NULL, NULL);
+	TEST_ASSERT_TRUE(test_common.acceptFd >= 0);
+}
+
+
+TEST(socket_api_accept, accept_original_still_accepts)
+{
+	/* "The original socket remains open and can accept more connections." */
+	volatile int secondClient = -1;
+	volatile int secondAccept = -1;
+
+	test_common.listenFd = test_setupListener();
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.listenFd);
+
+	test_common.clientFd = test_connectClient(0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.clientFd);
+
+	test_common.acceptFd = accept(test_common.listenFd, NULL, NULL);
+	TEST_ASSERT_TRUE(test_common.acceptFd >= 0);
+
+	if (TEST_PROTECT()) {
+		/* Second connection */
+		secondClient = test_connectClient(0);
+		TEST_ASSERT_NOT_EQUAL_INT(-1, secondClient);
+
+		secondAccept = accept(test_common.listenFd, NULL, NULL);
+		TEST_ASSERT_TRUE(secondAccept >= 0);
+	}
+	if (secondClient >= 0) {
+		close(secondClient);
+	}
+	if (secondAccept >= 0) {
+		close(secondAccept);
+	}
+}
+
+
+TEST(socket_api_accept, accept_ebadf)
+{
+	/* "EBADF: The socket argument is not a valid file descriptor." */
+	int ret;
+
+	errno = 0;
+	ret = accept(-1, NULL, NULL);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_EQUAL_INT(EBADF, errno);
+}
+
+
+TEST(socket_api_accept, accept_enotsock)
+{
+	/* "ENOTSOCK: The socket argument does not refer to a socket." */
+	int ret;
+
+	test_common.genericFd = open("/dev/null", O_RDONLY);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.genericFd);
+
+	errno = 0;
+	ret = accept(test_common.genericFd, NULL, NULL);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_EQUAL_INT(ENOTSOCK, errno);
+}
+
+
+TEST(socket_api_accept, accept_einval_not_listening)
+{
+	/* "EINVAL: The socket is not accepting connections." */
+	int ret;
+
+	test_common.genericFd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.genericFd);
+
+	/* Socket created but not listening */
+	errno = 0;
+	ret = accept(test_common.genericFd, NULL, NULL);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_EQUAL_INT(EINVAL, errno);
+}
+
+
+TEST(socket_api_accept, accept_eagain_nonblock)
+{
+	/* "EAGAIN or EWOULDBLOCK: O_NONBLOCK is set ... and no connections
+	 *  are present to be accepted." */
+	int flags;
+	int ret;
+
+	test_common.listenFd = test_setupListener();
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.listenFd);
+
+	/* Set non-blocking */
+	flags = fcntl(test_common.listenFd, F_GETFL, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, flags);
+	TEST_ASSERT_EQUAL_INT(0, fcntl(test_common.listenFd, F_SETFL, flags | O_NONBLOCK));
+
+	errno = 0;
+	ret = accept(test_common.listenFd, NULL, NULL);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_TRUE(errno == EAGAIN || errno == EWOULDBLOCK);
+}
+
+
+TEST(socket_api_accept, accept_eopnotsupp_dgram)
+{
+	/* "EOPNOTSUPP: The socket type of the specified socket does not
+	 *  support accepting connections." */
+	int ret;
+
+	test_common.genericFd = socket(AF_UNIX, SOCK_DGRAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.genericFd);
+
+	errno = 0;
+	ret = accept(test_common.genericFd, NULL, NULL);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	/* EOPNOTSUPP or EINVAL are both acceptable depending on implementation */
+	TEST_ASSERT_TRUE(errno == EOPNOTSUPP || errno == EINVAL);
+}
+
+
+TEST_GROUP_RUNNER(socket_api_accept)
+{
+	RUN_TEST_CASE(socket_api_accept, accept_success);
+	RUN_TEST_CASE(socket_api_accept, accept_with_address);
+	RUN_TEST_CASE(socket_api_accept, accept_null_address);
+	RUN_TEST_CASE(socket_api_accept, accept_original_still_accepts);
+	RUN_TEST_CASE(socket_api_accept, accept_ebadf);
+	RUN_TEST_CASE(socket_api_accept, accept_enotsock);
+	RUN_TEST_CASE(socket_api_accept, accept_einval_not_listening);
+	RUN_TEST_CASE(socket_api_accept, accept_eagain_nonblock);
+	RUN_TEST_CASE(socket_api_accept, accept_eopnotsupp_dgram);
+}

--- a/libc/socket/bind.c
+++ b/libc/socket/bind.c
@@ -1,0 +1,322 @@
+/*
+ * Phoenix-RTOS
+ *
+ * POSIX.1-2017 standard library functions tests
+ * HEADER:
+ *    - <sys/socket.h>
+ * TESTED:
+ *    - bind()
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Damian Loewnau
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#include "unity_fixture.h"
+
+#define BIND_SOCK_PATH    "/tmp/test_bind_sock"
+#define BIND_SOCK_PATH2   "/tmp/test_bind_sock2"
+#define BIND_NOENT_PATH   "/tmp/test_bind_noent_dir/sock"
+#define BIND_SYMLINK_PATH "/tmp/test_bind_symlink"
+
+
+static struct {
+	int fd;
+	int fd2;
+} test_common;
+
+
+TEST_GROUP(socket_api_bind);
+
+
+TEST_SETUP(socket_api_bind)
+{
+	unlink(BIND_SOCK_PATH);
+	unlink(BIND_SOCK_PATH2);
+	unlink(BIND_SYMLINK_PATH);
+	test_common.fd = -1;
+	test_common.fd2 = -1;
+}
+
+
+TEST_TEAR_DOWN(socket_api_bind)
+{
+	if (test_common.fd >= 0) {
+		close(test_common.fd);
+		test_common.fd = -1;
+	}
+	if (test_common.fd2 >= 0) {
+		close(test_common.fd2);
+		test_common.fd2 = -1;
+	}
+	unlink(BIND_SOCK_PATH);
+	unlink(BIND_SOCK_PATH2);
+	unlink(BIND_SYMLINK_PATH);
+}
+
+
+TEST(socket_api_bind, bind_unix_success)
+{
+	/* "bind() shall assign a local socket address address to a socket" */
+	struct sockaddr_un addr;
+	int ret;
+
+	test_common.fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.fd);
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	strncpy(addr.sun_path, BIND_SOCK_PATH, sizeof(addr.sun_path) - 1);
+
+	errno = 0;
+	ret = bind(test_common.fd, (struct sockaddr *)&addr, sizeof(addr));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_EQUAL_INT(0, errno);
+
+	/* Socket file should exist */
+	struct stat st;
+	TEST_ASSERT_EQUAL_INT(0, stat(BIND_SOCK_PATH, &st));
+}
+
+
+TEST(socket_api_bind, bind_unix_dgram_success)
+{
+	/* bind works for SOCK_DGRAM as well */
+	struct sockaddr_un addr;
+	int ret;
+
+	test_common.fd = socket(AF_UNIX, SOCK_DGRAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.fd);
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	strncpy(addr.sun_path, BIND_SOCK_PATH, sizeof(addr.sun_path) - 1);
+
+	ret = bind(test_common.fd, (struct sockaddr *)&addr, sizeof(addr));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+
+TEST(socket_api_bind, bind_inet_success)
+{
+	/* bind to INADDR_LOOPBACK with port 0 (kernel assigns) */
+	struct sockaddr_in addr;
+	int ret;
+
+	test_common.fd = socket(AF_INET, SOCK_STREAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.fd);
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sin_family = AF_INET;
+	addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	addr.sin_port = 0;
+
+	ret = bind(test_common.fd, (struct sockaddr *)&addr, sizeof(addr));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+
+TEST(socket_api_bind, bind_ebadf)
+{
+	/* "EBADF: The socket argument is not a valid file descriptor." */
+	struct sockaddr_un addr;
+	int ret;
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	strncpy(addr.sun_path, BIND_SOCK_PATH, sizeof(addr.sun_path) - 1);
+
+	errno = 0;
+	ret = bind(-1, (struct sockaddr *)&addr, sizeof(addr));
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_EQUAL_INT(EBADF, errno);
+}
+
+
+TEST(socket_api_bind, bind_enotsock)
+{
+	/* "ENOTSOCK: The socket argument does not refer to a socket." */
+	struct sockaddr_un addr;
+	int ret;
+
+	test_common.fd = open("/dev/null", O_RDONLY);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.fd);
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	strncpy(addr.sun_path, BIND_SOCK_PATH, sizeof(addr.sun_path) - 1);
+
+	errno = 0;
+	ret = bind(test_common.fd, (struct sockaddr *)&addr, sizeof(addr));
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_EQUAL_INT(ENOTSOCK, errno);
+}
+
+
+TEST(socket_api_bind, bind_eaddrinuse)
+{
+	/* "EADDRINUSE: The specified address is already in use." */
+	struct sockaddr_un addr;
+	int ret;
+
+	test_common.fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.fd);
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	strncpy(addr.sun_path, BIND_SOCK_PATH, sizeof(addr.sun_path) - 1);
+
+	ret = bind(test_common.fd, (struct sockaddr *)&addr, sizeof(addr));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Second bind to same path */
+	test_common.fd2 = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.fd2);
+
+	errno = 0;
+	ret = bind(test_common.fd2, (struct sockaddr *)&addr, sizeof(addr));
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+#ifdef __phoenix__
+	/* https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1667 */
+	TEST_IGNORE_MESSAGE("#1667 issue");
+#else
+	TEST_ASSERT_EQUAL_INT(EADDRINUSE, errno);
+#endif
+}
+
+
+TEST(socket_api_bind, bind_eaddrinuse_symlink)
+{
+	/* "If the address family of the socket is AF_UNIX and the pathname
+	 *  in address names a symbolic link, bind() shall fail and set errno
+	 *  to [EADDRINUSE]." */
+	struct sockaddr_un addr;
+	int ret;
+
+	/* Create a symlink at the target path */
+	ret = symlink("/tmp", BIND_SOCK_PATH);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	test_common.fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.fd);
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	strncpy(addr.sun_path, BIND_SOCK_PATH, sizeof(addr.sun_path) - 1);
+
+	errno = 0;
+	ret = bind(test_common.fd, (struct sockaddr *)&addr, sizeof(addr));
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+#ifdef __phoenix__
+	/* https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1667 */
+	TEST_IGNORE_MESSAGE("#1667 issue");
+#else
+	TEST_ASSERT_EQUAL_INT(EADDRINUSE, errno);
+#endif
+}
+
+
+TEST(socket_api_bind, bind_einval_already_bound)
+{
+	/* "EINVAL: The socket is already bound to an address, and the protocol
+	 *  does not support binding to a new address" */
+	struct sockaddr_un addr1, addr2;
+	int ret;
+
+	test_common.fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.fd);
+
+	memset(&addr1, 0, sizeof(addr1));
+	addr1.sun_family = AF_UNIX;
+	strncpy(addr1.sun_path, BIND_SOCK_PATH, sizeof(addr1.sun_path) - 1);
+
+	ret = bind(test_common.fd, (struct sockaddr *)&addr1, sizeof(addr1));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Try to rebind to different address */
+	memset(&addr2, 0, sizeof(addr2));
+	addr2.sun_family = AF_UNIX;
+	strncpy(addr2.sun_path, BIND_SOCK_PATH2, sizeof(addr2.sun_path) - 1);
+
+	errno = 0;
+	ret = bind(test_common.fd, (struct sockaddr *)&addr2, sizeof(addr2));
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_EQUAL_INT(EINVAL, errno);
+}
+
+
+TEST(socket_api_bind, bind_enoent_missing_dir)
+{
+	/* "ENOENT: A component of the path prefix ... does not name an existing file" */
+	struct sockaddr_un addr;
+	int ret;
+
+	test_common.fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.fd);
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	strncpy(addr.sun_path, BIND_NOENT_PATH, sizeof(addr.sun_path) - 1);
+
+	errno = 0;
+	ret = bind(test_common.fd, (struct sockaddr *)&addr, sizeof(addr));
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+#ifdef __phoenix__
+	/* https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1668 */
+	TEST_IGNORE_MESSAGE("#1668 issue");
+#else
+	TEST_ASSERT_EQUAL_INT(ENOENT, errno);
+#endif
+}
+
+
+TEST(socket_api_bind, bind_eafnosupport)
+{
+	/* "EAFNOSUPPORT: The specified address is not a valid address for
+	 *  the address family of the specified socket." */
+	struct sockaddr_in inetAddr;
+	int ret;
+
+	/* AF_UNIX socket but AF_INET address */
+	test_common.fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.fd);
+
+	memset(&inetAddr, 0, sizeof(inetAddr));
+	inetAddr.sin_family = AF_INET;
+	inetAddr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	inetAddr.sin_port = htons(0);
+
+	errno = 0;
+	ret = bind(test_common.fd, (struct sockaddr *)&inetAddr, sizeof(inetAddr));
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	/* EAFNOSUPPORT or EINVAL are acceptable */
+	TEST_ASSERT_TRUE(errno == EAFNOSUPPORT || errno == EINVAL);
+}
+
+
+TEST_GROUP_RUNNER(socket_api_bind)
+{
+	RUN_TEST_CASE(socket_api_bind, bind_unix_success);
+	RUN_TEST_CASE(socket_api_bind, bind_unix_dgram_success);
+	RUN_TEST_CASE(socket_api_bind, bind_inet_success);
+	RUN_TEST_CASE(socket_api_bind, bind_ebadf);
+	RUN_TEST_CASE(socket_api_bind, bind_enotsock);
+	RUN_TEST_CASE(socket_api_bind, bind_eaddrinuse);
+	RUN_TEST_CASE(socket_api_bind, bind_eaddrinuse_symlink);
+	RUN_TEST_CASE(socket_api_bind, bind_einval_already_bound);
+	RUN_TEST_CASE(socket_api_bind, bind_enoent_missing_dir);
+	RUN_TEST_CASE(socket_api_bind, bind_eafnosupport);
+}

--- a/libc/socket/connect.c
+++ b/libc/socket/connect.c
@@ -1,0 +1,424 @@
+/*
+ * Phoenix-RTOS
+ *
+ * POSIX.1-2017 standard library functions tests
+ * HEADER:
+ *    - <sys/socket.h>
+ * TESTED:
+ *    - connect()
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Damian Loewnau
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+
+#include "unity_fixture.h"
+
+#define CONNECT_SOCK_PATH  "/tmp/test_connect_sock"
+#define CONNECT_NOENT_PATH "/tmp/test_connect_noent_dir/sock"
+#define CONNECT_BACKLOG    5
+
+
+static struct {
+	int listenFd;
+	int clientFd;
+	int acceptFd;
+	int genericFd;
+} test_common;
+
+
+TEST_GROUP(socket_api_connect);
+
+
+TEST_SETUP(socket_api_connect)
+{
+	unlink(CONNECT_SOCK_PATH);
+	test_common.listenFd = -1;
+	test_common.clientFd = -1;
+	test_common.acceptFd = -1;
+	test_common.genericFd = -1;
+}
+
+
+TEST_TEAR_DOWN(socket_api_connect)
+{
+	if (test_common.acceptFd >= 0) {
+		close(test_common.acceptFd);
+		test_common.acceptFd = -1;
+	}
+	if (test_common.clientFd >= 0) {
+		close(test_common.clientFd);
+		test_common.clientFd = -1;
+	}
+	if (test_common.listenFd >= 0) {
+		close(test_common.listenFd);
+		test_common.listenFd = -1;
+	}
+	if (test_common.genericFd >= 0) {
+		close(test_common.genericFd);
+		test_common.genericFd = -1;
+	}
+	unlink(CONNECT_SOCK_PATH);
+}
+
+
+static int test_setupListener(void)
+{
+	struct sockaddr_un addr;
+	int fd;
+	int ret;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (fd < 0) {
+		return -1;
+	}
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	strncpy(addr.sun_path, CONNECT_SOCK_PATH, sizeof(addr.sun_path) - 1);
+
+	ret = bind(fd, (struct sockaddr *)&addr, sizeof(addr));
+	if (ret != 0) {
+		close(fd);
+		return -1;
+	}
+
+	ret = listen(fd, CONNECT_BACKLOG);
+	if (ret != 0) {
+		close(fd);
+		return -1;
+	}
+
+	return fd;
+}
+
+
+TEST(socket_api_connect, connect_unix_stream_success)
+{
+	/* "connect() shall attempt to make a connection on a connection-mode socket" */
+	struct sockaddr_un addr;
+	int ret, flags;
+
+	test_common.listenFd = test_setupListener();
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.listenFd);
+
+	test_common.clientFd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.clientFd);
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	strncpy(addr.sun_path, CONNECT_SOCK_PATH, sizeof(addr.sun_path) - 1);
+
+	flags = fcntl(test_common.clientFd, F_GETFL, 0);
+	fcntl(test_common.clientFd, F_SETFL, flags | O_NONBLOCK);
+
+	errno = 0;
+	ret = connect(test_common.clientFd, (struct sockaddr *)&addr, sizeof(addr));
+	TEST_ASSERT_TRUE(ret == 0 || (ret == -1 && errno == EINPROGRESS));
+
+	/* FIX: Complete the handshake on the server side */
+	test_common.acceptFd = accept(test_common.listenFd, NULL, NULL);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.acceptFd);
+
+	/* Restore blocking mode */
+	fcntl(test_common.clientFd, F_SETFL, flags);
+}
+
+
+TEST(socket_api_connect, connect_unix_dgram_sets_peer)
+{
+	/* "If the initiating socket is not connection-mode, then connect()
+	 *  shall set the socket's peer address" */
+	struct sockaddr_un srvAddr;
+	int srvFd;
+	int ret;
+
+	/* Create and bind a DGRAM server */
+	srvFd = socket(AF_UNIX, SOCK_DGRAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, srvFd);
+	test_common.listenFd = srvFd;
+
+	memset(&srvAddr, 0, sizeof(srvAddr));
+	srvAddr.sun_family = AF_UNIX;
+	strncpy(srvAddr.sun_path, CONNECT_SOCK_PATH, sizeof(srvAddr.sun_path) - 1);
+
+	ret = bind(srvFd, (struct sockaddr *)&srvAddr, sizeof(srvAddr));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Create client and connect */
+	test_common.clientFd = socket(AF_UNIX, SOCK_DGRAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.clientFd);
+
+	ret = connect(test_common.clientFd, (struct sockaddr *)&srvAddr, sizeof(srvAddr));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* After connect, send() can be used without specifying destination */
+	const char msg[] = "dgram";
+	ret = (int)send(test_common.clientFd, msg, sizeof(msg), 0);
+	TEST_ASSERT_EQUAL_INT((int)sizeof(msg), ret);
+
+	/* Server receives it */
+	char buf[16];
+	ret = (int)recv(srvFd, buf, sizeof(buf), 0);
+	TEST_ASSERT_EQUAL_INT((int)sizeof(msg), ret);
+	TEST_ASSERT_EQUAL_STRING(msg, buf);
+}
+
+
+TEST(socket_api_connect, connect_dgram_unspec_resets_peer)
+{
+	/* "If the sa_family member of address is AF_UNSPEC, the socket's
+	 *  peer address shall be reset." */
+	struct sockaddr_un srvAddr;
+	struct sockaddr unspecAddr;
+	int srvFd;
+	int ret;
+
+	srvFd = socket(AF_UNIX, SOCK_DGRAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, srvFd);
+	test_common.listenFd = srvFd;
+
+	memset(&srvAddr, 0, sizeof(srvAddr));
+	srvAddr.sun_family = AF_UNIX;
+	strncpy(srvAddr.sun_path, CONNECT_SOCK_PATH, sizeof(srvAddr.sun_path) - 1);
+
+	ret = bind(srvFd, (struct sockaddr *)&srvAddr, sizeof(srvAddr));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	test_common.clientFd = socket(AF_UNIX, SOCK_DGRAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.clientFd);
+
+	/* Connect to server */
+	ret = connect(test_common.clientFd, (struct sockaddr *)&srvAddr, sizeof(srvAddr));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Reset peer with AF_UNSPEC */
+	memset(&unspecAddr, 0, sizeof(unspecAddr));
+	unspecAddr.sa_family = AF_UNSPEC;
+
+	ret = connect(test_common.clientFd, &unspecAddr, sizeof(unspecAddr));
+	/* Some implementations return 0, some return -1 with EAFNOSUPPORT but still reset */
+
+#ifdef __phoenix__
+	(void)ret;
+	/* https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1669 */
+	TEST_IGNORE_MESSAGE("#1669 issue");
+#else
+	TEST_ASSERT_TRUE(ret == 0 || (ret == -1 && errno == EAFNOSUPPORT));
+
+	/* After reset, send() without destination should fail */
+	errno = 0;
+	ret = (int)send(test_common.clientFd, "x", 1, 0);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_TRUE(errno == EDESTADDRREQ || errno == ENOTCONN);
+#endif
+}
+
+
+TEST(socket_api_connect, connect_ebadf)
+{
+	/* "EBADF: The socket argument is not a valid file descriptor." */
+	struct sockaddr_un addr;
+	int ret;
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	strncpy(addr.sun_path, CONNECT_SOCK_PATH, sizeof(addr.sun_path) - 1);
+
+	errno = 0;
+	ret = connect(-1, (struct sockaddr *)&addr, sizeof(addr));
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_EQUAL_INT(EBADF, errno);
+}
+
+
+TEST(socket_api_connect, connect_enotsock)
+{
+	/* "ENOTSOCK: The socket argument does not refer to a socket." */
+	struct sockaddr_un addr;
+	int ret;
+
+	test_common.genericFd = open("/dev/null", O_RDONLY);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.genericFd);
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	strncpy(addr.sun_path, CONNECT_SOCK_PATH, sizeof(addr.sun_path) - 1);
+
+	errno = 0;
+	ret = connect(test_common.genericFd, (struct sockaddr *)&addr, sizeof(addr));
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_EQUAL_INT(ENOTSOCK, errno);
+
+	close(test_common.genericFd);
+}
+
+
+TEST(socket_api_connect, connect_enoent)
+{
+	/* "ENOENT: A component of the pathname does not name an existing file" */
+	struct sockaddr_un addr;
+	int ret;
+
+	test_common.clientFd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.clientFd);
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	strncpy(addr.sun_path, CONNECT_NOENT_PATH, sizeof(addr.sun_path) - 1);
+
+	errno = 0;
+	ret = connect(test_common.clientFd, (struct sockaddr *)&addr, sizeof(addr));
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+#ifdef __phoenix__
+	/* https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1670 */
+	TEST_IGNORE_MESSAGE("#1670 issue");
+#else
+	TEST_ASSERT_EQUAL_INT(ENOENT, errno);
+#endif
+}
+
+
+TEST(socket_api_connect, connect_econnrefused)
+{
+	/* "ECONNREFUSED: The target address was not listening for connections
+	 *  or refused the connection request." */
+	struct sockaddr_in addr;
+	int ret;
+
+	test_common.clientFd = socket(AF_INET, SOCK_STREAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.clientFd);
+
+	/* Connect to loopback on a port that nobody is listening on */
+	memset(&addr, 0, sizeof(addr));
+	addr.sin_family = AF_INET;
+	addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	addr.sin_port = htons(19999);
+
+	errno = 0;
+	ret = connect(test_common.clientFd, (struct sockaddr *)&addr, sizeof(addr));
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+#ifdef __phoenix__
+	/* https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1671 */
+	TEST_IGNORE_MESSAGE("#1671 issue");
+#else
+	TEST_ASSERT_EQUAL_INT(ECONNREFUSED, errno);
+#endif
+}
+
+
+TEST(socket_api_connect, connect_eisconn)
+{
+	/* "EISCONN: The specified socket is connection-mode and is already connected." */
+	struct sockaddr_un addr;
+	int ret;
+
+	test_common.listenFd = test_setupListener();
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.listenFd);
+
+	test_common.clientFd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.clientFd);
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	strncpy(addr.sun_path, CONNECT_SOCK_PATH, sizeof(addr.sun_path) - 1);
+
+/* https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1016 */
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1016 issue");
+#endif
+
+	ret = connect(test_common.clientFd, (struct sockaddr *)&addr, sizeof(addr));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Second connect on already-connected socket */
+	errno = 0;
+	ret = connect(test_common.clientFd, (struct sockaddr *)&addr, sizeof(addr));
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_EQUAL_INT(EISCONN, errno);
+}
+
+
+TEST(socket_api_connect, connect_eafnosupport)
+{
+	/* "EAFNOSUPPORT: The specified address is not a valid address for
+	 *  the address family of the specified socket." */
+	struct sockaddr_in inetAddr;
+	int ret;
+
+	test_common.clientFd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.clientFd);
+
+	memset(&inetAddr, 0, sizeof(inetAddr));
+	inetAddr.sin_family = AF_INET;
+	inetAddr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	inetAddr.sin_port = htons(80);
+
+	errno = 0;
+	ret = connect(test_common.clientFd, (struct sockaddr *)&inetAddr, sizeof(inetAddr));
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	/* EAFNOSUPPORT or EINVAL are acceptable */
+	TEST_ASSERT_TRUE(errno == EAFNOSUPPORT || errno == EINVAL);
+}
+
+
+TEST(socket_api_connect, connect_binds_unnamed)
+{
+	/* "If the socket has not already been bound to a local address,
+	 *  connect() shall bind it to an address" */
+	struct sockaddr_un addr, localAddr;
+	socklen_t addrLen;
+	int ret;
+
+	test_common.listenFd = test_setupListener();
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.listenFd);
+
+	test_common.clientFd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.clientFd);
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	strncpy(addr.sun_path, CONNECT_SOCK_PATH, sizeof(addr.sun_path) - 1);
+
+/* https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1016 */
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1016 issue");
+#endif
+
+	ret = connect(test_common.clientFd, (struct sockaddr *)&addr, sizeof(addr));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* getsockname should succeed after implicit bind */
+	memset(&localAddr, 0, sizeof(localAddr));
+	addrLen = sizeof(localAddr);
+	ret = getsockname(test_common.clientFd, (struct sockaddr *)&localAddr, &addrLen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_EQUAL_INT(AF_UNIX, localAddr.sun_family);
+}
+
+
+TEST_GROUP_RUNNER(socket_api_connect)
+{
+	RUN_TEST_CASE(socket_api_connect, connect_unix_stream_success);
+	RUN_TEST_CASE(socket_api_connect, connect_unix_dgram_sets_peer);
+	RUN_TEST_CASE(socket_api_connect, connect_dgram_unspec_resets_peer);
+	RUN_TEST_CASE(socket_api_connect, connect_ebadf);
+	RUN_TEST_CASE(socket_api_connect, connect_enotsock);
+	RUN_TEST_CASE(socket_api_connect, connect_enoent);
+	RUN_TEST_CASE(socket_api_connect, connect_econnrefused);
+	RUN_TEST_CASE(socket_api_connect, connect_eisconn);
+	RUN_TEST_CASE(socket_api_connect, connect_eafnosupport);
+	RUN_TEST_CASE(socket_api_connect, connect_binds_unnamed);
+}

--- a/libc/socket/getpeername.c
+++ b/libc/socket/getpeername.c
@@ -1,0 +1,309 @@
+/*
+ * Phoenix-RTOS
+ *
+ * POSIX.1-2017 standard library functions tests
+ * HEADER:
+ *    - <sys/socket.h>
+ * TESTED:
+ *    - getpeername()
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Damian Loewnau
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+
+#include "unity_fixture.h"
+
+#define GETPEERNAME_SOCK_PATH "/tmp/test_getpeername_sock"
+#define GETPEERNAME_BACKLOG   5
+
+
+static struct {
+	int listenFd;
+	int clientFd;
+	int acceptFd;
+	int genericFd;
+} test_common;
+
+
+TEST_GROUP(socket_api_getpeername);
+
+
+TEST_SETUP(socket_api_getpeername)
+{
+	unlink(GETPEERNAME_SOCK_PATH);
+	test_common.listenFd = -1;
+	test_common.clientFd = -1;
+	test_common.acceptFd = -1;
+	test_common.genericFd = -1;
+}
+
+
+TEST_TEAR_DOWN(socket_api_getpeername)
+{
+	if (test_common.acceptFd >= 0) {
+		close(test_common.acceptFd);
+		test_common.acceptFd = -1;
+	}
+	if (test_common.clientFd >= 0) {
+		close(test_common.clientFd);
+		test_common.clientFd = -1;
+	}
+	if (test_common.listenFd >= 0) {
+		close(test_common.listenFd);
+		test_common.listenFd = -1;
+	}
+	if (test_common.genericFd >= 0) {
+		close(test_common.genericFd);
+		test_common.genericFd = -1;
+	}
+	unlink(GETPEERNAME_SOCK_PATH);
+}
+
+
+static int test_setupConnectedPair(void)
+{
+	struct sockaddr_un addr;
+	int ret;
+	int flags;
+
+	test_common.listenFd = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (test_common.listenFd < 0) {
+		return -1;
+	}
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	strncpy(addr.sun_path, GETPEERNAME_SOCK_PATH, sizeof(addr.sun_path) - 1);
+
+	ret = bind(test_common.listenFd, (struct sockaddr *)&addr, sizeof(addr));
+	if (ret != 0) {
+		return -1;
+	}
+
+	ret = listen(test_common.listenFd, GETPEERNAME_BACKLOG);
+	if (ret != 0) {
+		return -1;
+	}
+
+	test_common.clientFd = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (test_common.clientFd < 0) {
+		return -1;
+	}
+
+	flags = fcntl(test_common.clientFd, F_GETFL, 0);
+	fcntl(test_common.clientFd, F_SETFL, flags | O_NONBLOCK);
+
+	ret = connect(test_common.clientFd, (struct sockaddr *)&addr, sizeof(addr));
+	if (ret != 0 && errno != EINPROGRESS) {
+		return -1;
+	}
+
+	test_common.acceptFd = accept(test_common.listenFd, NULL, NULL);
+	if (test_common.acceptFd < 0) {
+		return -1;
+	}
+
+	fcntl(test_common.clientFd, F_SETFL, flags);
+
+	return 0;
+}
+
+
+TEST(socket_api_getpeername, getpeername_success_accepted)
+{
+	/* "getpeername() shall retrieve the peer address of the specified socket" */
+	struct sockaddr_un peerAddr;
+	socklen_t addrLen = sizeof(peerAddr);
+	int ret;
+
+	TEST_ASSERT_EQUAL_INT(0, test_setupConnectedPair());
+
+	/* On the accepted socket, peer is the client */
+	memset(&peerAddr, 0, sizeof(peerAddr));
+	ret = getpeername(test_common.acceptFd, (struct sockaddr *)&peerAddr, &addrLen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+
+TEST(socket_api_getpeername, getpeername_success_client)
+{
+	/* On the client socket, peer is the server address */
+	struct sockaddr_un peerAddr;
+	socklen_t addrLen = sizeof(peerAddr);
+	int ret;
+
+	TEST_ASSERT_EQUAL_INT(0, test_setupConnectedPair());
+
+	memset(&peerAddr, 0, sizeof(peerAddr));
+	ret = getpeername(test_common.clientFd, (struct sockaddr *)&peerAddr, &addrLen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+#ifdef __phoenix__
+	/* https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1672 */
+	TEST_IGNORE_MESSAGE("#1672 issue");
+#else
+	TEST_ASSERT_EQUAL_INT(AF_UNIX, peerAddr.sun_family);
+	/* The server's path should be in the peer address */
+	TEST_ASSERT_EQUAL_STRING(GETPEERNAME_SOCK_PATH, peerAddr.sun_path);
+#endif
+}
+
+
+TEST(socket_api_getpeername, getpeername_truncation)
+{
+	/* "If the actual length of the address is greater than the length
+	 *  of the supplied sockaddr structure, the stored address shall be truncated." */
+	struct sockaddr_un peerAddr;
+	socklen_t addrLen;
+	int ret;
+
+	TEST_ASSERT_EQUAL_INT(0, test_setupConnectedPair());
+
+	/* Provide a small buffer */
+	addrLen = (socklen_t)sizeof(sa_family_t);
+	memset(&peerAddr, 0xff, sizeof(peerAddr));
+	ret = getpeername(test_common.clientFd, (struct sockaddr *)&peerAddr, &addrLen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+#ifdef __phoenix__
+	/* https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1672 */
+	TEST_IGNORE_MESSAGE("#1672 issue");
+#else
+	/* addrLen should be updated to actual length (larger than what we passed) */
+	TEST_ASSERT_GREATER_THAN_UINT((unsigned int)sizeof(sa_family_t), (unsigned int)addrLen);
+#endif
+}
+
+
+TEST(socket_api_getpeername, getpeername_ebadf)
+{
+	/* "EBADF: The socket argument is not a valid file descriptor." */
+	struct sockaddr_un addr;
+	socklen_t addrLen = sizeof(addr);
+	int ret;
+
+	errno = 0;
+	ret = getpeername(-1, (struct sockaddr *)&addr, &addrLen);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_EQUAL_INT(EBADF, errno);
+}
+
+
+TEST(socket_api_getpeername, getpeername_enotsock)
+{
+	/* "ENOTSOCK: The socket argument does not refer to a socket." */
+	struct sockaddr_un addr;
+	socklen_t addrLen = sizeof(addr);
+	int ret;
+
+	test_common.genericFd = open("/dev/null", O_RDONLY);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.genericFd);
+
+	errno = 0;
+	ret = getpeername(test_common.genericFd, (struct sockaddr *)&addr, &addrLen);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_EQUAL_INT(ENOTSOCK, errno);
+}
+
+
+TEST(socket_api_getpeername, getpeername_enotconn)
+{
+	/* "ENOTCONN: The socket is not connected or otherwise has not had
+	 *  the peer pre-specified." */
+	struct sockaddr_un addr;
+	socklen_t addrLen = sizeof(addr);
+	int ret;
+
+	test_common.genericFd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.genericFd);
+
+	errno = 0;
+	ret = getpeername(test_common.genericFd, (struct sockaddr *)&addr, &addrLen);
+#ifdef __phoenix__
+	(void)ret;
+	/* https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1673 */
+	TEST_IGNORE_MESSAGE("#1673 issue");
+#else
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_EQUAL_INT(ENOTCONN, errno);
+#endif
+}
+
+
+TEST(socket_api_getpeername, getpeername_inet_loopback)
+{
+	/* Verify getpeername works for AF_INET connected sockets */
+	struct sockaddr_in srvAddr, peerAddr;
+	socklen_t addrLen;
+	int srvFd, cliFd, accFd;
+	int ret;
+	int flags;
+
+	srvFd = socket(AF_INET, SOCK_STREAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, srvFd);
+	test_common.listenFd = srvFd;
+
+	memset(&srvAddr, 0, sizeof(srvAddr));
+	srvAddr.sin_family = AF_INET;
+	srvAddr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	srvAddr.sin_port = 0;
+
+	ret = bind(srvFd, (struct sockaddr *)&srvAddr, sizeof(srvAddr));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	ret = listen(srvFd, GETPEERNAME_BACKLOG);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Find assigned port */
+	addrLen = sizeof(srvAddr);
+	ret = getsockname(srvFd, (struct sockaddr *)&srvAddr, &addrLen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	cliFd = socket(AF_INET, SOCK_STREAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, cliFd);
+	test_common.clientFd = cliFd;
+
+	flags = fcntl(cliFd, F_GETFL, 0);
+	fcntl(cliFd, F_SETFL, flags | O_NONBLOCK);
+
+	ret = connect(cliFd, (struct sockaddr *)&srvAddr, sizeof(srvAddr));
+	TEST_ASSERT_TRUE(ret == 0 || (ret == -1 && errno == EINPROGRESS));
+
+	accFd = accept(srvFd, NULL, NULL);
+	TEST_ASSERT_TRUE(accFd >= 0);
+	test_common.acceptFd = accFd;
+
+	fcntl(cliFd, F_SETFL, flags);
+
+	/* getpeername on client should return server address */
+	memset(&peerAddr, 0, sizeof(peerAddr));
+	addrLen = sizeof(peerAddr);
+	ret = getpeername(cliFd, (struct sockaddr *)&peerAddr, &addrLen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_EQUAL_INT(AF_INET, peerAddr.sin_family);
+	TEST_ASSERT_EQUAL_UINT32(htonl(INADDR_LOOPBACK), peerAddr.sin_addr.s_addr);
+	TEST_ASSERT_EQUAL_INT(srvAddr.sin_port, peerAddr.sin_port);
+}
+
+
+TEST_GROUP_RUNNER(socket_api_getpeername)
+{
+	RUN_TEST_CASE(socket_api_getpeername, getpeername_success_accepted);
+	RUN_TEST_CASE(socket_api_getpeername, getpeername_success_client);
+	RUN_TEST_CASE(socket_api_getpeername, getpeername_truncation);
+	RUN_TEST_CASE(socket_api_getpeername, getpeername_ebadf);
+	RUN_TEST_CASE(socket_api_getpeername, getpeername_enotsock);
+	RUN_TEST_CASE(socket_api_getpeername, getpeername_enotconn);
+	RUN_TEST_CASE(socket_api_getpeername, getpeername_inet_loopback);
+}

--- a/libc/socket/getsockname.c
+++ b/libc/socket/getsockname.c
@@ -1,0 +1,288 @@
+/*
+ * Phoenix-RTOS
+ *
+ * POSIX.1-2017 standard library functions tests
+ * HEADER:
+ *    - <sys/socket.h>
+ * TESTED:
+ *    - getsockname()
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Damian Loewnau
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+
+#include "unity_fixture.h"
+
+#define GETSOCKNAME_SOCK_PATH "/tmp/test_getsockname_sock"
+
+
+static struct {
+	int fd;
+} test_common;
+
+
+TEST_GROUP(socket_api_getsockname);
+
+
+TEST_SETUP(socket_api_getsockname)
+{
+	unlink(GETSOCKNAME_SOCK_PATH);
+	test_common.fd = -1;
+}
+
+
+TEST_TEAR_DOWN(socket_api_getsockname)
+{
+	if (test_common.fd >= 0) {
+		close(test_common.fd);
+		test_common.fd = -1;
+	}
+	unlink(GETSOCKNAME_SOCK_PATH);
+}
+
+
+TEST(socket_api_getsockname, getsockname_unix_bound)
+{
+	/* "getsockname() shall retrieve the locally-bound name of the
+	 *  specified socket" */
+	struct sockaddr_un bindAddr, nameAddr;
+	socklen_t addrLen;
+	int ret;
+
+	test_common.fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.fd);
+
+	memset(&bindAddr, 0, sizeof(bindAddr));
+	bindAddr.sun_family = AF_UNIX;
+	strncpy(bindAddr.sun_path, GETSOCKNAME_SOCK_PATH, sizeof(bindAddr.sun_path) - 1);
+
+	ret = bind(test_common.fd, (struct sockaddr *)&bindAddr, sizeof(bindAddr));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	memset(&nameAddr, 0, sizeof(nameAddr));
+	addrLen = sizeof(nameAddr);
+	errno = 0;
+	ret = getsockname(test_common.fd, (struct sockaddr *)&nameAddr, &addrLen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_EQUAL_INT(0, errno);
+#ifdef __phoenix__
+	/* https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1674 */
+	TEST_IGNORE_MESSAGE("#1674 issue");
+#else
+	TEST_ASSERT_EQUAL_INT(AF_UNIX, nameAddr.sun_family);
+	TEST_ASSERT_EQUAL_STRING(GETSOCKNAME_SOCK_PATH, nameAddr.sun_path);
+#endif
+}
+
+
+TEST(socket_api_getsockname, getsockname_inet_bound)
+{
+	/* getsockname returns the bound address for AF_INET */
+	struct sockaddr_in bindAddr, nameAddr;
+	socklen_t addrLen;
+	int ret;
+
+	test_common.fd = socket(AF_INET, SOCK_STREAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.fd);
+
+	memset(&bindAddr, 0, sizeof(bindAddr));
+	bindAddr.sin_family = AF_INET;
+	bindAddr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	bindAddr.sin_port = 0; /* kernel assigns */
+
+	ret = bind(test_common.fd, (struct sockaddr *)&bindAddr, sizeof(bindAddr));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	memset(&nameAddr, 0, sizeof(nameAddr));
+	addrLen = sizeof(nameAddr);
+	ret = getsockname(test_common.fd, (struct sockaddr *)&nameAddr, &addrLen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_EQUAL_INT(AF_INET, nameAddr.sin_family);
+	TEST_ASSERT_EQUAL_UINT32(htonl(INADDR_LOOPBACK), nameAddr.sin_addr.s_addr);
+	/* Port must be non-zero (kernel assigned) */
+	TEST_ASSERT_NOT_EQUAL_INT(0, ntohs(nameAddr.sin_port));
+}
+
+
+TEST(socket_api_getsockname, getsockname_addrlen_updated)
+{
+	/* "on output specifies the length of the stored address" */
+	struct sockaddr_un bindAddr, nameAddr;
+	socklen_t addrLen;
+	int ret;
+
+	test_common.fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.fd);
+
+	memset(&bindAddr, 0, sizeof(bindAddr));
+	bindAddr.sun_family = AF_UNIX;
+	strncpy(bindAddr.sun_path, GETSOCKNAME_SOCK_PATH, sizeof(bindAddr.sun_path) - 1);
+
+	ret = bind(test_common.fd, (struct sockaddr *)&bindAddr, sizeof(bindAddr));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Pass large buffer, addrLen should be updated to actual size */
+	addrLen = sizeof(nameAddr);
+	memset(&nameAddr, 0, sizeof(nameAddr));
+	ret = getsockname(test_common.fd, (struct sockaddr *)&nameAddr, &addrLen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	/* addrLen should be at least offsetof(sun_family) + path length + 1 */
+	TEST_ASSERT_GREATER_THAN_UINT(0U, (unsigned int)addrLen);
+}
+
+
+TEST(socket_api_getsockname, getsockname_truncation)
+{
+	/* "If the actual length of the address is greater than the length
+	 *  of the supplied sockaddr structure, the stored address shall be truncated." */
+	struct sockaddr_un bindAddr;
+	struct sockaddr smallBuf;
+	socklen_t addrLen;
+	int ret;
+
+	test_common.fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.fd);
+
+	memset(&bindAddr, 0, sizeof(bindAddr));
+	bindAddr.sun_family = AF_UNIX;
+	strncpy(bindAddr.sun_path, GETSOCKNAME_SOCK_PATH, sizeof(bindAddr.sun_path) - 1);
+
+	ret = bind(test_common.fd, (struct sockaddr *)&bindAddr, sizeof(bindAddr));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Pass very small buffer */
+	addrLen = (socklen_t)sizeof(sa_family_t);
+	memset(&smallBuf, 0xff, sizeof(smallBuf));
+	ret = getsockname(test_common.fd, &smallBuf, &addrLen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+#ifdef __phoenix__
+	/* https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1674 */
+	TEST_IGNORE_MESSAGE("#1674 issue");
+#else
+	/* addrLen updated to actual (larger) size */
+	TEST_ASSERT_GREATER_THAN_UINT((unsigned int)sizeof(sa_family_t), (unsigned int)addrLen);
+#endif
+}
+
+
+TEST(socket_api_getsockname, getsockname_unbound)
+{
+	/* "If the socket has not been bound to a local name, the value stored
+	 *  in the object pointed to by address is unspecified." — but call succeeds */
+	struct sockaddr_un nameAddr;
+	socklen_t addrLen = sizeof(nameAddr);
+	int ret;
+
+	test_common.fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.fd);
+
+	memset(&nameAddr, 0xff, sizeof(nameAddr));
+	ret = getsockname(test_common.fd, (struct sockaddr *)&nameAddr, &addrLen);
+	/* Must succeed — address content is unspecified */
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+
+TEST(socket_api_getsockname, getsockname_ebadf)
+{
+	/* "EBADF: The socket argument is not a valid file descriptor." */
+	struct sockaddr_un addr;
+	socklen_t addrLen = sizeof(addr);
+	int ret;
+
+	errno = 0;
+	ret = getsockname(-1, (struct sockaddr *)&addr, &addrLen);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_EQUAL_INT(EBADF, errno);
+}
+
+
+TEST(socket_api_getsockname, getsockname_enotsock)
+{
+	/* "ENOTSOCK: The socket argument does not refer to a socket." */
+	struct sockaddr_un addr;
+	socklen_t addrLen = sizeof(addr);
+	int ret;
+
+	test_common.fd = open("/dev/null", O_RDONLY);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, test_common.fd);
+
+	errno = 0;
+	ret = getsockname(test_common.fd, (struct sockaddr *)&addr, &addrLen);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_EQUAL_INT(ENOTSOCK, errno);
+}
+
+
+TEST(socket_api_getsockname, getsockname_after_connect)
+{
+	/* After connect(), getsockname returns the implicitly-bound address */
+	struct sockaddr_un srvAddr, cliAddr;
+	socklen_t addrLen;
+	int srvFd, cliFd;
+	int ret;
+	int flags;
+
+	srvFd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, srvFd);
+	test_common.fd = srvFd;
+
+	memset(&srvAddr, 0, sizeof(srvAddr));
+	srvAddr.sun_family = AF_UNIX;
+	strncpy(srvAddr.sun_path, GETSOCKNAME_SOCK_PATH, sizeof(srvAddr.sun_path) - 1);
+
+	ret = bind(srvFd, (struct sockaddr *)&srvAddr, sizeof(srvAddr));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	ret = listen(srvFd, 5);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	cliFd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_NOT_EQUAL_INT(-1, cliFd);
+	if (TEST_PROTECT()) {
+		flags = fcntl(cliFd, F_GETFL, 0);
+		fcntl(cliFd, F_SETFL, flags | O_NONBLOCK);
+		ret = connect(cliFd, (struct sockaddr *)&srvAddr, sizeof(srvAddr));
+		TEST_ASSERT_TRUE(ret == 0 || (ret == -1 && errno == EINPROGRESS));
+		fcntl(cliFd, F_SETFL, flags);
+
+		/* getsockname on client after connect */
+		memset(&cliAddr, 0, sizeof(cliAddr));
+		addrLen = sizeof(cliAddr);
+		ret = getsockname(cliFd, (struct sockaddr *)&cliAddr, &addrLen);
+		TEST_ASSERT_EQUAL_INT(0, ret);
+#ifdef __phoenix__
+		/* https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1674 */
+		TEST_IGNORE_MESSAGE("#1674 issue");
+#else
+		TEST_ASSERT_EQUAL_INT(AF_UNIX, cliAddr.sun_family);
+#endif
+	}
+	close(cliFd);
+}
+
+
+TEST_GROUP_RUNNER(socket_api_getsockname)
+{
+	RUN_TEST_CASE(socket_api_getsockname, getsockname_unix_bound);
+	RUN_TEST_CASE(socket_api_getsockname, getsockname_inet_bound);
+	RUN_TEST_CASE(socket_api_getsockname, getsockname_addrlen_updated);
+	RUN_TEST_CASE(socket_api_getsockname, getsockname_truncation);
+	RUN_TEST_CASE(socket_api_getsockname, getsockname_unbound);
+	RUN_TEST_CASE(socket_api_getsockname, getsockname_ebadf);
+	RUN_TEST_CASE(socket_api_getsockname, getsockname_enotsock);
+	RUN_TEST_CASE(socket_api_getsockname, getsockname_after_connect);
+}

--- a/libc/socket/getsockopt.c
+++ b/libc/socket/getsockopt.c
@@ -1,0 +1,364 @@
+/*
+ * Phoenix-RTOS
+ *
+ * POSIX.1-2017 standard library functions tests
+ * HEADER:
+ *    - <sys/socket.h>
+ * TESTED:
+ *    - getsockopt()
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Lukasz Kruszynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <netinet/in.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <fcntl.h>
+
+#include "unity_fixture.h"
+
+
+TEST_GROUP(socket_api_getsockopt);
+
+static int fd;
+
+TEST_SETUP(socket_api_getsockopt)
+{
+	fd = -1;
+}
+
+TEST_TEAR_DOWN(socket_api_getsockopt)
+{
+	if (fd >= 0) {
+		close(fd);
+		fd = -1;
+	}
+}
+
+
+TEST(socket_api_getsockopt, basic_so_type_stream)
+{
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1644 issue");
+#endif
+	int ret;
+	int optval;
+	socklen_t optlen;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	optval = -1;
+	optlen = sizeof(optval);
+	ret = getsockopt(fd, SOL_SOCKET, SO_TYPE, &optval, &optlen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_EQUAL_INT(SOCK_STREAM, optval);
+	TEST_ASSERT_EQUAL_INT((socklen_t)sizeof(optval), optlen);
+}
+
+
+TEST(socket_api_getsockopt, basic_so_type_dgram)
+{
+	int ret;
+	int optval;
+	socklen_t optlen;
+
+	fd = socket(AF_UNIX, SOCK_DGRAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	optval = -1;
+	optlen = sizeof(optval);
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1644 issue");
+#endif
+	ret = getsockopt(fd, SOL_SOCKET, SO_TYPE, &optval, &optlen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_EQUAL_INT(SOCK_DGRAM, optval);
+}
+
+
+TEST(socket_api_getsockopt, so_error_no_error)
+{
+	int ret;
+	int optval;
+	socklen_t optlen;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	optval = -1;
+	optlen = sizeof(optval);
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1644 issue");
+#endif
+	ret = getsockopt(fd, SOL_SOCKET, SO_ERROR, &optval, &optlen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_EQUAL_INT(0, optval);
+}
+
+
+TEST(socket_api_getsockopt, so_rcvbuf)
+{
+	int ret;
+	int optval;
+	socklen_t optlen;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	optval = 0;
+	optlen = sizeof(optval);
+	ret = getsockopt(fd, SOL_SOCKET, SO_RCVBUF, &optval, &optlen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_GREATER_THAN_INT(0, optval);
+}
+
+
+TEST(socket_api_getsockopt, so_sndbuf)
+{
+	int ret;
+	int optval;
+	socklen_t optlen;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	optval = 0;
+	optlen = sizeof(optval);
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1644 issue");
+#endif
+	ret = getsockopt(fd, SOL_SOCKET, SO_SNDBUF, &optval, &optlen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_GREATER_THAN_INT(0, optval);
+}
+
+
+TEST(socket_api_getsockopt, truncation_small_optlen)
+{
+	int ret;
+	int optval;
+	socklen_t optlen;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	/* Request with optlen smaller than actual value size - value shall be truncated */
+	optval = 0;
+	optlen = 1;
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1644 issue");
+#endif
+	ret = getsockopt(fd, SOL_SOCKET, SO_RCVBUF, &optval, &optlen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	/* optlen should remain at 1 (truncated) or be adjusted - either way, no error */
+}
+
+
+TEST(socket_api_getsockopt, optlen_updated)
+{
+	int ret;
+	int optval;
+	socklen_t optlen;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	/* optlen larger than needed - shall be modified to indicate actual length */
+	optval = 0;
+	optlen = 128;
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1644 issue");
+#endif
+	ret = getsockopt(fd, SOL_SOCKET, SO_TYPE, &optval, &optlen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_EQUAL_INT((socklen_t)sizeof(int), optlen);
+}
+
+
+TEST(socket_api_getsockopt, ebadf_invalid_fd)
+{
+	int ret;
+	int optval;
+	socklen_t optlen;
+
+	optval = 0;
+	optlen = sizeof(optval);
+	errno = 0;
+	ret = getsockopt(-1, SOL_SOCKET, SO_TYPE, &optval, &optlen);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_EQUAL_INT(EBADF, errno);
+}
+
+
+TEST(socket_api_getsockopt, enotsock_regular_fd)
+{
+	int ret;
+	int optval;
+	socklen_t optlen;
+	int pipefd[2];
+
+	ret = pipe(pipefd);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	if (TEST_PROTECT()) {
+		optval = 0;
+		optlen = sizeof(optval);
+		errno = 0;
+		ret = getsockopt(pipefd[0], SOL_SOCKET, SO_TYPE, &optval, &optlen);
+		TEST_ASSERT_EQUAL_INT(-1, ret);
+		TEST_ASSERT_EQUAL_INT(ENOTSOCK, errno);
+	}
+	close(pipefd[0]);
+	close(pipefd[1]);
+}
+
+
+TEST(socket_api_getsockopt, enoprotoopt_unsupported_option)
+{
+	int ret;
+	int optval;
+	socklen_t optlen;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	/* TCP-level option on a UNIX socket should fail with ENOPROTOOPT */
+	optval = 0;
+	optlen = sizeof(optval);
+	errno = 0;
+	ret = getsockopt(fd, IPPROTO_TCP, 1, &optval, &optlen);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_TRUE(errno == ENOPROTOOPT || errno == EINVAL || errno == EOPNOTSUPP);
+}
+
+
+TEST(socket_api_getsockopt, so_acceptconn_not_listening)
+{
+	int ret;
+	int optval;
+	socklen_t optlen;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	optval = -1;
+	optlen = sizeof(optval);
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1644 issue");
+#endif
+	ret = getsockopt(fd, SOL_SOCKET, SO_ACCEPTCONN, &optval, &optlen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_EQUAL_INT(0, optval);
+}
+
+
+TEST(socket_api_getsockopt, so_rcvtimeo_default)
+{
+	int ret;
+	struct timeval tv;
+	socklen_t optlen;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	memset(&tv, 0xff, sizeof(tv));
+	optlen = sizeof(tv);
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1644 issue");
+#endif
+	ret = getsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, &optlen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	/* Default timeout should be 0 (infinite/no timeout) */
+	TEST_ASSERT_EQUAL_INT(0, (int)tv.tv_sec);
+	TEST_ASSERT_EQUAL_INT(0, (int)tv.tv_usec);
+}
+
+
+TEST(socket_api_getsockopt, so_sndtimeo_default)
+{
+	int ret;
+	struct timeval tv;
+	socklen_t optlen;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	memset(&tv, 0xff, sizeof(tv));
+	optlen = sizeof(tv);
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1644 issue");
+#endif
+	ret = getsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, &optlen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_EQUAL_INT(0, (int)tv.tv_sec);
+	TEST_ASSERT_EQUAL_INT(0, (int)tv.tv_usec);
+}
+
+
+TEST(socket_api_getsockopt, retrieves_value_after_setsockopt)
+{
+	int ret;
+	int optval;
+	socklen_t optlen;
+	struct timeval tv;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1644 issue");
+#endif
+	/* Set SO_RCVTIMEO to 2 seconds */
+	tv.tv_sec = 2;
+	tv.tv_usec = 0;
+	ret = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Retrieve and verify */
+	memset(&tv, 0, sizeof(tv));
+	optlen = sizeof(tv);
+	ret = getsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, &optlen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_EQUAL_INT(2, (int)tv.tv_sec);
+	TEST_ASSERT_EQUAL_INT(0, (int)tv.tv_usec);
+
+	/* Set SO_SNDBUF */
+	optval = 4096;
+	ret = setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &optval, sizeof(optval));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	optval = 0;
+	optlen = sizeof(optval);
+	ret = getsockopt(fd, SOL_SOCKET, SO_SNDBUF, &optval, &optlen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	/* Implementation may double the value, but it should be >= what was set */
+	TEST_ASSERT_GREATER_THAN_INT(0, optval);
+}
+
+
+TEST_GROUP_RUNNER(socket_api_getsockopt)
+{
+	RUN_TEST_CASE(socket_api_getsockopt, basic_so_type_stream);
+	RUN_TEST_CASE(socket_api_getsockopt, basic_so_type_dgram);
+	RUN_TEST_CASE(socket_api_getsockopt, so_error_no_error);
+	RUN_TEST_CASE(socket_api_getsockopt, so_rcvbuf);
+	RUN_TEST_CASE(socket_api_getsockopt, so_sndbuf);
+	RUN_TEST_CASE(socket_api_getsockopt, truncation_small_optlen);
+	RUN_TEST_CASE(socket_api_getsockopt, optlen_updated);
+	RUN_TEST_CASE(socket_api_getsockopt, ebadf_invalid_fd);
+	RUN_TEST_CASE(socket_api_getsockopt, enotsock_regular_fd);
+	RUN_TEST_CASE(socket_api_getsockopt, enoprotoopt_unsupported_option);
+	RUN_TEST_CASE(socket_api_getsockopt, so_acceptconn_not_listening);
+	RUN_TEST_CASE(socket_api_getsockopt, so_rcvtimeo_default);
+	RUN_TEST_CASE(socket_api_getsockopt, so_sndtimeo_default);
+	RUN_TEST_CASE(socket_api_getsockopt, retrieves_value_after_setsockopt);
+}

--- a/libc/socket/listen.c
+++ b/libc/socket/listen.c
@@ -1,0 +1,278 @@
+/*
+ * Phoenix-RTOS
+ *
+ * POSIX.1-2017 standard library functions tests
+ * HEADER:
+ *    - <sys/socket.h>
+ * TESTED:
+ *    - listen()
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Lukasz Kruszynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <fcntl.h>
+
+#include "unity_fixture.h"
+
+#define LISTEN_SOCK_PATH "/tmp/test_listen_sock"
+#define LISTEN_BACKLOG   5
+
+#ifndef SOMAXCONN
+#define SOMAXCONN 128
+#endif
+
+static struct {
+	int fd;
+} test_common;
+
+
+TEST_GROUP(socket_api_listen);
+
+TEST_SETUP(socket_api_listen)
+{
+	unlink(LISTEN_SOCK_PATH);
+	test_common.fd = -1;
+}
+
+TEST_TEAR_DOWN(socket_api_listen)
+{
+	if (test_common.fd >= 0) {
+		close(test_common.fd);
+		test_common.fd = -1;
+	}
+	unlink(LISTEN_SOCK_PATH);
+}
+
+
+static int test_bindUnixStream(int fd)
+{
+	struct sockaddr_un addr;
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	strncpy(addr.sun_path, LISTEN_SOCK_PATH, sizeof(addr.sun_path) - 1);
+
+	return bind(fd, (struct sockaddr *)&addr, sizeof(addr));
+}
+
+
+TEST(socket_api_listen, basic_success)
+{
+	int ret;
+
+	test_common.fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(test_common.fd >= 0);
+
+	ret = test_bindUnixStream(test_common.fd);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	ret = listen(test_common.fd, LISTEN_BACKLOG);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+
+TEST(socket_api_listen, backlog_zero)
+{
+	int ret;
+
+	test_common.fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(test_common.fd >= 0);
+
+	ret = test_bindUnixStream(test_common.fd);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* backlog of 0 may allow the socket to accept connections */
+	ret = listen(test_common.fd, 0);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+
+TEST(socket_api_listen, backlog_negative)
+{
+	int ret;
+
+	test_common.fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(test_common.fd >= 0);
+
+	ret = test_bindUnixStream(test_common.fd);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Negative backlog shall behave as if called with backlog of 0 */
+	ret = listen(test_common.fd, -1);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+
+TEST(socket_api_listen, backlog_somaxconn)
+{
+	int ret;
+
+	test_common.fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(test_common.fd >= 0);
+
+	ret = test_bindUnixStream(test_common.fd);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Implementations shall support values of backlog up to SOMAXCONN */
+	ret = listen(test_common.fd, SOMAXCONN);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+
+TEST(socket_api_listen, backlog_exceeds_somaxconn)
+{
+	int ret;
+
+	test_common.fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(test_common.fd >= 0);
+
+	ret = test_bindUnixStream(test_common.fd);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Backlog exceeding limit: length of listen queue is set to the limit, no error */
+	ret = listen(test_common.fd, SOMAXCONN + 100);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+
+TEST(socket_api_listen, marks_socket_accepting)
+{
+	int ret;
+	int optval;
+	socklen_t optlen;
+
+	test_common.fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(test_common.fd >= 0);
+
+	ret = test_bindUnixStream(test_common.fd);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	ret = listen(test_common.fd, LISTEN_BACKLOG);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Verify socket is now accepting connections via SO_ACCEPTCONN */
+	optval = 0;
+	optlen = sizeof(optval);
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1644 issue");
+#endif
+	ret = getsockopt(test_common.fd, SOL_SOCKET, SO_ACCEPTCONN, &optval, &optlen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_NOT_EQUAL_INT(0, optval);
+}
+
+
+TEST(socket_api_listen, ebadf_invalid_fd)
+{
+	int ret;
+
+	errno = 0;
+	ret = listen(-1, LISTEN_BACKLOG);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_EQUAL_INT(EBADF, errno);
+}
+
+
+TEST(socket_api_listen, enotsock_pipe_fd)
+{
+	int ret;
+	int pipefd[2];
+
+	ret = pipe(pipefd);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	if (TEST_PROTECT()) {
+		errno = 0;
+		ret = listen(pipefd[0], LISTEN_BACKLOG);
+		TEST_ASSERT_EQUAL_INT(-1, ret);
+		TEST_ASSERT_EQUAL_INT(ENOTSOCK, errno);
+	}
+	close(pipefd[0]);
+	close(pipefd[1]);
+}
+
+
+TEST(socket_api_listen, eopnotsupp_dgram_socket)
+{
+	int ret;
+
+	test_common.fd = socket(AF_UNIX, SOCK_DGRAM, 0);
+	TEST_ASSERT_TRUE(test_common.fd >= 0);
+
+	/* DGRAM sockets do not support listen */
+	errno = 0;
+	ret = listen(test_common.fd, LISTEN_BACKLOG);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_EQUAL_INT(EOPNOTSUPP, errno);
+}
+
+
+TEST(socket_api_listen, einval_already_connected)
+{
+	int ret;
+	int sv[2];
+
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1649 issue");
+#endif
+
+	ret = socketpair(AF_UNIX, SOCK_STREAM, 0, sv);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	if (TEST_PROTECT()) {
+		/* Socket is already connected - shall fail with EINVAL */
+		errno = 0;
+		ret = listen(sv[0], LISTEN_BACKLOG);
+		TEST_ASSERT_EQUAL_INT(-1, ret);
+		TEST_ASSERT_EQUAL_INT(EINVAL, errno);
+	}
+	close(sv[0]);
+	close(sv[1]);
+}
+
+
+TEST(socket_api_listen, listen_called_twice)
+{
+	int ret;
+
+	test_common.fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(test_common.fd >= 0);
+
+	ret = test_bindUnixStream(test_common.fd);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	ret = listen(test_common.fd, LISTEN_BACKLOG);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Calling listen again on an already listening socket should succeed */
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1649 issue");
+#endif
+	ret = listen(test_common.fd, LISTEN_BACKLOG + 1);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+
+TEST_GROUP_RUNNER(socket_api_listen)
+{
+	RUN_TEST_CASE(socket_api_listen, basic_success);
+	RUN_TEST_CASE(socket_api_listen, backlog_zero);
+	RUN_TEST_CASE(socket_api_listen, backlog_negative);
+	RUN_TEST_CASE(socket_api_listen, backlog_somaxconn);
+	RUN_TEST_CASE(socket_api_listen, backlog_exceeds_somaxconn);
+	RUN_TEST_CASE(socket_api_listen, marks_socket_accepting);
+	RUN_TEST_CASE(socket_api_listen, ebadf_invalid_fd);
+	RUN_TEST_CASE(socket_api_listen, enotsock_pipe_fd);
+	RUN_TEST_CASE(socket_api_listen, eopnotsupp_dgram_socket);
+	RUN_TEST_CASE(socket_api_listen, einval_already_connected);
+	RUN_TEST_CASE(socket_api_listen, listen_called_twice);
+}

--- a/libc/socket/main.c
+++ b/libc/socket/main.c
@@ -1,0 +1,70 @@
+/*
+ * Phoenix-RTOS
+ *
+ * POSIX.1-2017 standard library functions tests
+ * HEADER:
+ *    - <sys/socket.h>
+ * TESTED:
+ *    - accept()
+ *    - bind()
+ *    - connect()
+ *    - getpeername()
+ *    - getsockname()
+ *    - getsockopt()
+ *    - listen()
+ *    - recv()
+ *    - recvfrom()
+ *    - recvmsg()
+ *    - send()
+ *    - sendmsg()
+ *    - sendto()
+ *    - setsockopt()
+ *    - shutdown()
+ *    - socketpair()
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Lukasz Kruszynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include "unity_fixture.h"
+
+void runner(void)
+{
+	RUN_TEST_GROUP(socket_api_socketpair);
+	RUN_TEST_GROUP(socket_api_shutdown);
+	RUN_TEST_GROUP(socket_api_setsockopt);
+	RUN_TEST_GROUP(socket_api_getsockopt);
+	RUN_TEST_GROUP(socket_api_listen);
+	RUN_TEST_GROUP(socket_api_send);
+	RUN_TEST_GROUP(socket_api_sendto);
+	RUN_TEST_GROUP(socket_api_sendmsg);
+	RUN_TEST_GROUP(socket_api_recv);
+	RUN_TEST_GROUP(socket_api_recvfrom);
+	RUN_TEST_GROUP(socket_api_recvmsg);
+	RUN_TEST_GROUP(socket_api_accept);
+	RUN_TEST_GROUP(socket_api_bind);
+	RUN_TEST_GROUP(socket_api_connect);
+	RUN_TEST_GROUP(socket_api_getpeername);
+	RUN_TEST_GROUP(socket_api_getsockname);
+	RUN_TEST_GROUP(socket_api_sockatmark);
+}
+
+int main(int argc, char *argv[])
+{
+	const char *var = "POSIXLY_CORRECT";
+
+	if (setenv(var, "y", 1) != 0) {
+		fprintf(stderr, "Setting %s environment variable failed: %s\n", var, strerror(errno));
+		return 1;
+	}
+
+	return (UnityMain(argc, (const char **)argv, runner) == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/libc/socket/recv.c
+++ b/libc/socket/recv.c
@@ -1,0 +1,282 @@
+/*
+ * Phoenix-RTOS
+ *
+ * POSIX.1-2017 standard library functions tests
+ * HEADER:
+ *    - <sys/socket.h>
+ * TESTED:
+ *    - recv()
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Lukasz Kruszynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <sys/socket.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <fcntl.h>
+
+#include "unity_fixture.h"
+
+#define RECV_MSG     "hello"
+#define RECV_MSG_LEN 5
+#define RECV_BUF_SZ  32
+
+static struct {
+	int sv[2];
+} test_common;
+
+
+TEST_GROUP(socket_api_recv);
+
+TEST_SETUP(socket_api_recv)
+{
+	int ret;
+
+	ret = socketpair(AF_UNIX, SOCK_STREAM, 0, test_common.sv);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+TEST_TEAR_DOWN(socket_api_recv)
+{
+	if (test_common.sv[0] >= 0) {
+		close(test_common.sv[0]);
+		test_common.sv[0] = -1;
+	}
+	if (test_common.sv[1] >= 0) {
+		close(test_common.sv[1]);
+		test_common.sv[1] = -1;
+	}
+}
+
+
+TEST(socket_api_recv, basic_success)
+{
+	ssize_t n;
+	char buf[RECV_BUF_SZ];
+
+	n = send(test_common.sv[0], RECV_MSG, RECV_MSG_LEN, 0);
+	TEST_ASSERT_EQUAL_INT(RECV_MSG_LEN, (int)n);
+
+	memset(buf, 0, sizeof(buf));
+	n = recv(test_common.sv[1], buf, sizeof(buf), 0);
+	TEST_ASSERT_EQUAL_INT(RECV_MSG_LEN, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY(RECV_MSG, buf, RECV_MSG_LEN);
+}
+
+
+TEST(socket_api_recv, returns_message_length)
+{
+	ssize_t n;
+	char buf[RECV_BUF_SZ];
+	const char *msg = "abcdefghij";
+	const size_t msgLen = 10;
+
+	n = send(test_common.sv[0], msg, msgLen, 0);
+	TEST_ASSERT_EQUAL_INT((int)msgLen, (int)n);
+
+	memset(buf, 0, sizeof(buf));
+	n = recv(test_common.sv[1], buf, sizeof(buf), 0);
+	TEST_ASSERT_EQUAL_INT((int)msgLen, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY(msg, buf, msgLen);
+}
+
+
+TEST(socket_api_recv, partial_read_stream)
+{
+	ssize_t n;
+	char buf[4];
+	const char *msg = "abcdefgh";
+	const size_t msgLen = 8;
+
+	n = send(test_common.sv[0], msg, msgLen, 0);
+	TEST_ASSERT_EQUAL_INT((int)msgLen, (int)n);
+
+	/* Stream socket: read only 4 bytes, rest remains available */
+	memset(buf, 0, sizeof(buf));
+	n = recv(test_common.sv[1], buf, sizeof(buf), 0);
+	TEST_ASSERT_EQUAL_INT(4, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY("abcd", buf, 4);
+
+	/* Read remaining data */
+	memset(buf, 0, sizeof(buf));
+	n = recv(test_common.sv[1], buf, sizeof(buf), 0);
+	TEST_ASSERT_EQUAL_INT(4, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY("efgh", buf, 4);
+}
+
+
+TEST(socket_api_recv, msg_peek)
+{
+	ssize_t n;
+	char buf[RECV_BUF_SZ];
+
+	n = send(test_common.sv[0], RECV_MSG, RECV_MSG_LEN, 0);
+	TEST_ASSERT_EQUAL_INT(RECV_MSG_LEN, (int)n);
+
+	/* MSG_PEEK: data is treated as unread */
+	memset(buf, 0, sizeof(buf));
+	n = recv(test_common.sv[1], buf, sizeof(buf), MSG_PEEK);
+	TEST_ASSERT_EQUAL_INT(RECV_MSG_LEN, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY(RECV_MSG, buf, RECV_MSG_LEN);
+
+	/* Next recv shall still return the same data */
+	memset(buf, 0, sizeof(buf));
+	n = recv(test_common.sv[1], buf, sizeof(buf), 0);
+	TEST_ASSERT_EQUAL_INT(RECV_MSG_LEN, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY(RECV_MSG, buf, RECV_MSG_LEN);
+}
+
+
+TEST(socket_api_recv, msg_waitall)
+{
+	ssize_t n;
+	char buf[RECV_BUF_SZ];
+
+	n = send(test_common.sv[0], RECV_MSG, RECV_MSG_LEN, 0);
+	TEST_ASSERT_EQUAL_INT(RECV_MSG_LEN, (int)n);
+
+	/* Close writer so MSG_WAITALL returns what's available */
+	close(test_common.sv[0]);
+	test_common.sv[0] = -1;
+
+	memset(buf, 0, sizeof(buf));
+	n = recv(test_common.sv[1], buf, sizeof(buf), MSG_WAITALL);
+	TEST_ASSERT_EQUAL_INT(RECV_MSG_LEN, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY(RECV_MSG, buf, RECV_MSG_LEN);
+}
+
+
+TEST(socket_api_recv, orderly_shutdown_returns_zero)
+{
+	ssize_t n;
+	char buf[RECV_BUF_SZ];
+
+	/* Close the writing end */
+	close(test_common.sv[0]);
+	test_common.sv[0] = -1;
+
+	/* Peer has performed orderly shutdown: recv shall return 0 */
+	n = recv(test_common.sv[1], buf, sizeof(buf), 0);
+	TEST_ASSERT_EQUAL_INT(0, (int)n);
+}
+
+
+TEST(socket_api_recv, eagain_nonblock_no_data)
+{
+	ssize_t n;
+	int ret;
+	int flags;
+	char buf[RECV_BUF_SZ];
+
+	/* Set non-blocking */
+	flags = fcntl(test_common.sv[1], F_GETFL, 0);
+	TEST_ASSERT_TRUE(flags >= 0);
+	ret = fcntl(test_common.sv[1], F_SETFL, flags | O_NONBLOCK);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* No data available, O_NONBLOCK set */
+	errno = 0;
+	n = recv(test_common.sv[1], buf, sizeof(buf), 0);
+	TEST_ASSERT_EQUAL_INT(-1, (int)n);
+	TEST_ASSERT_TRUE(errno == EAGAIN || errno == EWOULDBLOCK);
+}
+
+
+TEST(socket_api_recv, ebadf_invalid_fd)
+{
+	ssize_t n;
+	char buf[RECV_BUF_SZ];
+
+	errno = 0;
+	n = recv(-1, buf, sizeof(buf), 0);
+	TEST_ASSERT_EQUAL_INT(-1, (int)n);
+	TEST_ASSERT_EQUAL_INT(EBADF, errno);
+}
+
+
+TEST(socket_api_recv, enotsock_pipe_fd)
+{
+	ssize_t n;
+	int ret;
+	int pipefd[2];
+	char buf[RECV_BUF_SZ];
+
+	ret = pipe(pipefd);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	if (TEST_PROTECT()) {
+		errno = 0;
+		n = recv(pipefd[0], buf, sizeof(buf), 0);
+		TEST_ASSERT_EQUAL_INT(-1, (int)n);
+		TEST_ASSERT_EQUAL_INT(ENOTSOCK, errno);
+	}
+	close(pipefd[0]);
+	close(pipefd[1]);
+}
+
+
+TEST(socket_api_recv, enotconn_unconnected_stream)
+{
+	ssize_t n;
+	int fd;
+	char buf[RECV_BUF_SZ];
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	if (TEST_PROTECT()) {
+		errno = 0;
+		n = recv(fd, buf, sizeof(buf), 0);
+		TEST_ASSERT_EQUAL_INT(-1, (int)n);
+#ifndef __phoenix__
+		/* glibc may return EINVAL instead of ENOTCONN on unbound AF_UNIX stream socket */
+		TEST_ASSERT_TRUE(errno == ENOTCONN || errno == EINVAL);
+#else
+		TEST_ASSERT_EQUAL_INT(ENOTCONN, errno);
+#endif
+	}
+	close(fd);
+}
+
+
+TEST(socket_api_recv, multiple_sends_single_recv)
+{
+	ssize_t n;
+	char buf[RECV_BUF_SZ];
+
+	/* Send two messages */
+	n = send(test_common.sv[0], "abc", 3, 0);
+	TEST_ASSERT_EQUAL_INT(3, (int)n);
+	n = send(test_common.sv[0], "def", 3, 0);
+	TEST_ASSERT_EQUAL_INT(3, (int)n);
+
+	/* Stream socket: boundaries are ignored, single recv gets all */
+	memset(buf, 0, sizeof(buf));
+	n = recv(test_common.sv[1], buf, sizeof(buf), 0);
+	TEST_ASSERT_GREATER_THAN_INT(0, (int)n);
+	/* At least 3 bytes should be available (may be 6 if coalesced) */
+	TEST_ASSERT_TRUE(n >= 3);
+	TEST_ASSERT_EQUAL_MEMORY("abc", buf, 3);
+}
+
+
+TEST_GROUP_RUNNER(socket_api_recv)
+{
+	RUN_TEST_CASE(socket_api_recv, basic_success);
+	RUN_TEST_CASE(socket_api_recv, returns_message_length);
+	RUN_TEST_CASE(socket_api_recv, partial_read_stream);
+	RUN_TEST_CASE(socket_api_recv, msg_peek);
+	RUN_TEST_CASE(socket_api_recv, msg_waitall);
+	RUN_TEST_CASE(socket_api_recv, orderly_shutdown_returns_zero);
+	RUN_TEST_CASE(socket_api_recv, eagain_nonblock_no_data);
+	RUN_TEST_CASE(socket_api_recv, ebadf_invalid_fd);
+	RUN_TEST_CASE(socket_api_recv, enotsock_pipe_fd);
+	RUN_TEST_CASE(socket_api_recv, enotconn_unconnected_stream);
+	RUN_TEST_CASE(socket_api_recv, multiple_sends_single_recv);
+}

--- a/libc/socket/recvfrom.c
+++ b/libc/socket/recvfrom.c
@@ -1,0 +1,359 @@
+/*
+ * Phoenix-RTOS
+ *
+ * POSIX.1-2017 standard library functions tests
+ * HEADER:
+ *    - <sys/socket.h>
+ * TESTED:
+ *    - recvfrom()
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Lukasz Kruszynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <fcntl.h>
+
+#include "unity_fixture.h"
+
+#define RECVFROM_MSG       "hello"
+#define RECVFROM_MSG_LEN   5
+#define RECVFROM_BUF_SZ    32
+#define RECVFROM_SOCK_PATH "/tmp/test_recvfrom_sock"
+
+static struct {
+	int sv[2];
+} test_common;
+
+
+TEST_GROUP(socket_api_recvfrom);
+
+TEST_SETUP(socket_api_recvfrom)
+{
+	int ret;
+
+	ret = socketpair(AF_UNIX, SOCK_STREAM, 0, test_common.sv);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+TEST_TEAR_DOWN(socket_api_recvfrom)
+{
+	if (test_common.sv[0] >= 0) {
+		close(test_common.sv[0]);
+		test_common.sv[0] = -1;
+	}
+	if (test_common.sv[1] >= 0) {
+		close(test_common.sv[1]);
+		test_common.sv[1] = -1;
+	}
+	unlink(RECVFROM_SOCK_PATH);
+}
+
+
+TEST(socket_api_recvfrom, basic_success_null_address)
+{
+	ssize_t n;
+	char buf[RECVFROM_BUF_SZ];
+
+	n = send(test_common.sv[0], RECVFROM_MSG, RECVFROM_MSG_LEN, 0);
+	TEST_ASSERT_EQUAL_INT(RECVFROM_MSG_LEN, (int)n);
+
+	/* recvfrom with NULL address and address_len */
+	memset(buf, 0, sizeof(buf));
+	n = recvfrom(test_common.sv[1], buf, sizeof(buf), 0, NULL, NULL);
+	TEST_ASSERT_EQUAL_INT(RECVFROM_MSG_LEN, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY(RECVFROM_MSG, buf, RECVFROM_MSG_LEN);
+}
+
+
+TEST(socket_api_recvfrom, returns_message_length)
+{
+	ssize_t n;
+	char buf[RECVFROM_BUF_SZ];
+	const char *msg = "abcdefghij";
+	const size_t msgLen = 10;
+
+	n = send(test_common.sv[0], msg, msgLen, 0);
+	TEST_ASSERT_EQUAL_INT((int)msgLen, (int)n);
+
+	memset(buf, 0, sizeof(buf));
+	n = recvfrom(test_common.sv[1], buf, sizeof(buf), 0, NULL, NULL);
+	TEST_ASSERT_EQUAL_INT((int)msgLen, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY(msg, buf, msgLen);
+}
+
+
+TEST(socket_api_recvfrom, dgram_source_address)
+{
+	volatile int srvFd = -1;
+	volatile int cliFd = -1;
+	int ret;
+	ssize_t n;
+	char buf[RECVFROM_BUF_SZ];
+	struct sockaddr_un srvAddr;
+	struct sockaddr_un srcAddr;
+	socklen_t addrLen;
+
+	/* Close the default socketpair - use dgram sockets instead */
+	close(test_common.sv[0]);
+	close(test_common.sv[1]);
+	test_common.sv[0] = -1;
+	test_common.sv[1] = -1;
+
+	unlink(RECVFROM_SOCK_PATH);
+
+	if (TEST_PROTECT()) {
+		srvFd = socket(AF_UNIX, SOCK_DGRAM, 0);
+		TEST_ASSERT_TRUE(srvFd >= 0);
+
+		memset(&srvAddr, 0, sizeof(srvAddr));
+		srvAddr.sun_family = AF_UNIX;
+		strncpy(srvAddr.sun_path, RECVFROM_SOCK_PATH, sizeof(srvAddr.sun_path) - 1);
+
+		ret = bind(srvFd, (struct sockaddr *)&srvAddr, sizeof(srvAddr));
+		TEST_ASSERT_EQUAL_INT(0, ret);
+
+		cliFd = socket(AF_UNIX, SOCK_DGRAM, 0);
+		TEST_ASSERT_TRUE(cliFd >= 0);
+
+		n = sendto(cliFd, RECVFROM_MSG, RECVFROM_MSG_LEN, 0,
+				(struct sockaddr *)&srvAddr, sizeof(srvAddr));
+		TEST_ASSERT_EQUAL_INT(RECVFROM_MSG_LEN, (int)n);
+
+		/* Receive with source address retrieval */
+		memset(buf, 0, sizeof(buf));
+		memset(&srcAddr, 0, sizeof(srcAddr));
+		addrLen = sizeof(srcAddr);
+		n = recvfrom(srvFd, buf, sizeof(buf), 0, (struct sockaddr *)&srcAddr, &addrLen);
+		TEST_ASSERT_EQUAL_INT(RECVFROM_MSG_LEN, (int)n);
+		TEST_ASSERT_EQUAL_MEMORY(RECVFROM_MSG, buf, RECVFROM_MSG_LEN);
+	}
+	if (srvFd >= 0) {
+		close(srvFd);
+	}
+	if (cliFd >= 0) {
+		close(cliFd);
+	}
+}
+
+
+TEST(socket_api_recvfrom, msg_peek)
+{
+	ssize_t n;
+	char buf[RECVFROM_BUF_SZ];
+
+	n = send(test_common.sv[0], RECVFROM_MSG, RECVFROM_MSG_LEN, 0);
+	TEST_ASSERT_EQUAL_INT(RECVFROM_MSG_LEN, (int)n);
+
+	/* MSG_PEEK: data is treated as unread */
+	memset(buf, 0, sizeof(buf));
+	n = recvfrom(test_common.sv[1], buf, sizeof(buf), MSG_PEEK, NULL, NULL);
+	TEST_ASSERT_EQUAL_INT(RECVFROM_MSG_LEN, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY(RECVFROM_MSG, buf, RECVFROM_MSG_LEN);
+
+	/* Next recvfrom shall still return the same data */
+	memset(buf, 0, sizeof(buf));
+	n = recvfrom(test_common.sv[1], buf, sizeof(buf), 0, NULL, NULL);
+	TEST_ASSERT_EQUAL_INT(RECVFROM_MSG_LEN, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY(RECVFROM_MSG, buf, RECVFROM_MSG_LEN);
+}
+
+
+TEST(socket_api_recvfrom, msg_waitall_stream)
+{
+	ssize_t n;
+	char buf[RECVFROM_BUF_SZ];
+
+	n = send(test_common.sv[0], RECVFROM_MSG, RECVFROM_MSG_LEN, 0);
+	TEST_ASSERT_EQUAL_INT(RECVFROM_MSG_LEN, (int)n);
+
+	/* Close writer so MSG_WAITALL returns what's available */
+	close(test_common.sv[0]);
+	test_common.sv[0] = -1;
+
+	memset(buf, 0, sizeof(buf));
+	n = recvfrom(test_common.sv[1], buf, sizeof(buf), MSG_WAITALL, NULL, NULL);
+	TEST_ASSERT_EQUAL_INT(RECVFROM_MSG_LEN, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY(RECVFROM_MSG, buf, RECVFROM_MSG_LEN);
+}
+
+
+TEST(socket_api_recvfrom, orderly_shutdown_returns_zero)
+{
+	ssize_t n;
+	char buf[RECVFROM_BUF_SZ];
+
+	close(test_common.sv[0]);
+	test_common.sv[0] = -1;
+
+	n = recvfrom(test_common.sv[1], buf, sizeof(buf), 0, NULL, NULL);
+	TEST_ASSERT_EQUAL_INT(0, (int)n);
+}
+
+
+TEST(socket_api_recvfrom, eagain_nonblock_no_data)
+{
+	ssize_t n;
+	int ret;
+	int flags;
+	char buf[RECVFROM_BUF_SZ];
+
+	flags = fcntl(test_common.sv[1], F_GETFL, 0);
+	TEST_ASSERT_TRUE(flags >= 0);
+	ret = fcntl(test_common.sv[1], F_SETFL, flags | O_NONBLOCK);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	errno = 0;
+	n = recvfrom(test_common.sv[1], buf, sizeof(buf), 0, NULL, NULL);
+	TEST_ASSERT_EQUAL_INT(-1, (int)n);
+	TEST_ASSERT_TRUE(errno == EAGAIN || errno == EWOULDBLOCK);
+}
+
+
+TEST(socket_api_recvfrom, ebadf_invalid_fd)
+{
+	ssize_t n;
+	char buf[RECVFROM_BUF_SZ];
+
+	errno = 0;
+	n = recvfrom(-1, buf, sizeof(buf), 0, NULL, NULL);
+	TEST_ASSERT_EQUAL_INT(-1, (int)n);
+	TEST_ASSERT_EQUAL_INT(EBADF, errno);
+}
+
+
+TEST(socket_api_recvfrom, enotsock_pipe_fd)
+{
+	ssize_t n;
+	int ret;
+	int pipefd[2] = { -1, -1 };
+	char buf[RECVFROM_BUF_SZ];
+
+	ret = pipe(pipefd);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	if (TEST_PROTECT()) {
+		errno = 0;
+		n = recvfrom(pipefd[0], buf, sizeof(buf), 0, NULL, NULL);
+		TEST_ASSERT_EQUAL_INT(-1, (int)n);
+		TEST_ASSERT_EQUAL_INT(ENOTSOCK, errno);
+	}
+	if (pipefd[0] >= 0) {
+		close(pipefd[0]);
+	}
+	if (pipefd[1] >= 0) {
+		close(pipefd[1]);
+	}
+}
+
+
+TEST(socket_api_recvfrom, enotconn_unconnected_stream)
+{
+	ssize_t n;
+	int fd;
+	char buf[RECVFROM_BUF_SZ];
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	if (TEST_PROTECT()) {
+		errno = 0;
+		n = recvfrom(fd, buf, sizeof(buf), 0, NULL, NULL);
+		TEST_ASSERT_EQUAL_INT(-1, (int)n);
+#ifndef __phoenix__
+		/* glibc may return EINVAL instead of ENOTCONN on unbound AF_UNIX stream socket */
+		TEST_ASSERT_TRUE(errno == ENOTCONN || errno == EINVAL);
+#else
+		TEST_ASSERT_EQUAL_INT(ENOTCONN, errno);
+#endif
+	}
+	close(fd);
+}
+
+
+TEST(socket_api_recvfrom, partial_read_stream)
+{
+	ssize_t n;
+	char buf[4];
+	const char *msg = "abcdefgh";
+	const size_t msgLen = 8;
+
+	n = send(test_common.sv[0], msg, msgLen, 0);
+	TEST_ASSERT_EQUAL_INT((int)msgLen, (int)n);
+
+	/* Read only 4 bytes from stream */
+	memset(buf, 0, sizeof(buf));
+	n = recvfrom(test_common.sv[1], buf, sizeof(buf), 0, NULL, NULL);
+	TEST_ASSERT_EQUAL_INT(4, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY("abcd", buf, 4);
+
+	/* Remaining 4 bytes still available */
+	memset(buf, 0, sizeof(buf));
+	n = recvfrom(test_common.sv[1], buf, sizeof(buf), 0, NULL, NULL);
+	TEST_ASSERT_EQUAL_INT(4, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY("efgh", buf, 4);
+}
+
+
+TEST(socket_api_recvfrom, dgram_excess_bytes_discarded)
+{
+	int ret;
+	int *sv;
+	ssize_t n;
+	char buf[4];
+	const char *msg = "abcdefgh";
+	const size_t msgLen = 8;
+
+	/* Close the default stream pair */
+	close(test_common.sv[0]);
+	close(test_common.sv[1]);
+	test_common.sv[0] = -1;
+	test_common.sv[1] = -1;
+
+	sv = test_common.sv;
+
+	ret = socketpair(AF_UNIX, SOCK_DGRAM, 0, sv);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	n = send(sv[0], msg, msgLen, 0);
+	TEST_ASSERT_EQUAL_INT((int)msgLen, (int)n);
+
+	/* Buffer smaller than message: excess bytes discarded for DGRAM */
+	memset(buf, 0, sizeof(buf));
+	n = recvfrom(sv[1], buf, sizeof(buf), 0, NULL, NULL);
+	TEST_ASSERT_EQUAL_INT(4, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY("abcd", buf, 4);
+
+	/* Next recv should not get remaining bytes since they were discarded */
+	ret = fcntl(sv[1], F_SETFL, fcntl(sv[1], F_GETFL, 0) | O_NONBLOCK);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	errno = 0;
+	n = recvfrom(sv[1], buf, sizeof(buf), 0, NULL, NULL);
+	TEST_ASSERT_EQUAL_INT(-1, (int)n);
+	TEST_ASSERT_TRUE(errno == EAGAIN || errno == EWOULDBLOCK);
+}
+
+
+TEST_GROUP_RUNNER(socket_api_recvfrom)
+{
+	RUN_TEST_CASE(socket_api_recvfrom, basic_success_null_address);
+	RUN_TEST_CASE(socket_api_recvfrom, returns_message_length);
+	RUN_TEST_CASE(socket_api_recvfrom, dgram_source_address);
+	RUN_TEST_CASE(socket_api_recvfrom, msg_peek);
+	RUN_TEST_CASE(socket_api_recvfrom, msg_waitall_stream);
+	RUN_TEST_CASE(socket_api_recvfrom, orderly_shutdown_returns_zero);
+	RUN_TEST_CASE(socket_api_recvfrom, eagain_nonblock_no_data);
+	RUN_TEST_CASE(socket_api_recvfrom, ebadf_invalid_fd);
+	RUN_TEST_CASE(socket_api_recvfrom, enotsock_pipe_fd);
+	RUN_TEST_CASE(socket_api_recvfrom, enotconn_unconnected_stream);
+	RUN_TEST_CASE(socket_api_recvfrom, partial_read_stream);
+	RUN_TEST_CASE(socket_api_recvfrom, dgram_excess_bytes_discarded);
+}

--- a/libc/socket/recvmsg.c
+++ b/libc/socket/recvmsg.c
@@ -1,0 +1,516 @@
+/*
+ * Phoenix-RTOS
+ *
+ * POSIX.1-2017 standard library functions tests
+ * HEADER:
+ *    - <sys/socket.h>
+ * TESTED:
+ *    - recvmsg()
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Lukasz Kruszynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <fcntl.h>
+
+#include "unity_fixture.h"
+
+#define RECVMSG_MSG       "hello"
+#define RECVMSG_MSG_LEN   5
+#define RECVMSG_BUF_SZ    32
+#define RECVMSG_SOCK_PATH "/tmp/test_recvmsg_sock"
+
+#ifndef MSG_TRUNC
+#define MSG_TRUNC 0x20
+#endif
+
+static struct {
+	int sv[2];
+} test_common;
+
+
+TEST_GROUP(socket_api_recvmsg);
+
+TEST_SETUP(socket_api_recvmsg)
+{
+	int ret;
+
+	ret = socketpair(AF_UNIX, SOCK_STREAM, 0, test_common.sv);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+TEST_TEAR_DOWN(socket_api_recvmsg)
+{
+	if (test_common.sv[0] >= 0) {
+		close(test_common.sv[0]);
+		test_common.sv[0] = -1;
+	}
+	if (test_common.sv[1] >= 0) {
+		close(test_common.sv[1]);
+		test_common.sv[1] = -1;
+	}
+	unlink(RECVMSG_SOCK_PATH);
+}
+
+
+TEST(socket_api_recvmsg, basic_success)
+{
+	ssize_t n;
+	char buf[RECVMSG_BUF_SZ];
+	struct msghdr msg;
+	struct iovec iov;
+
+	n = send(test_common.sv[0], RECVMSG_MSG, RECVMSG_MSG_LEN, 0);
+	TEST_ASSERT_EQUAL_INT(RECVMSG_MSG_LEN, (int)n);
+
+	memset(buf, 0, sizeof(buf));
+	iov.iov_base = buf;
+	iov.iov_len = sizeof(buf);
+
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	n = recvmsg(test_common.sv[1], &msg, 0);
+	TEST_ASSERT_EQUAL_INT(RECVMSG_MSG_LEN, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY(RECVMSG_MSG, buf, RECVMSG_MSG_LEN);
+}
+
+
+TEST(socket_api_recvmsg, returns_total_length)
+{
+	ssize_t n;
+	char buf[RECVMSG_BUF_SZ];
+	struct msghdr msg;
+	struct iovec iov;
+	const char *data = "abcdefghij";
+	const size_t dataLen = 10;
+
+	n = send(test_common.sv[0], data, dataLen, 0);
+	TEST_ASSERT_EQUAL_INT((int)dataLen, (int)n);
+
+	memset(buf, 0, sizeof(buf));
+	iov.iov_base = buf;
+	iov.iov_len = sizeof(buf);
+
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	n = recvmsg(test_common.sv[1], &msg, 0);
+	TEST_ASSERT_EQUAL_INT((int)dataLen, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY(data, buf, dataLen);
+}
+
+
+TEST(socket_api_recvmsg, scatter_multiple_iovecs)
+{
+	ssize_t n;
+	char buf1[4];
+	char buf2[4];
+	char buf3[4];
+	struct msghdr msg;
+	struct iovec iov[3];
+	const char *data = "abcdefghij";
+	const size_t dataLen = 10;
+
+	n = send(test_common.sv[0], data, dataLen, 0);
+	TEST_ASSERT_EQUAL_INT((int)dataLen, (int)n);
+
+	memset(buf1, 0, sizeof(buf1));
+	memset(buf2, 0, sizeof(buf2));
+	memset(buf3, 0, sizeof(buf3));
+
+	iov[0].iov_base = buf1;
+	iov[0].iov_len = sizeof(buf1);
+	iov[1].iov_base = buf2;
+	iov[1].iov_len = sizeof(buf2);
+	iov[2].iov_base = buf3;
+	iov[2].iov_len = sizeof(buf3);
+
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_iov = iov;
+	msg.msg_iovlen = 3;
+
+	n = recvmsg(test_common.sv[1], &msg, 0);
+	TEST_ASSERT_EQUAL_INT((int)dataLen, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY("abcd", buf1, 4);
+	TEST_ASSERT_EQUAL_MEMORY("efgh", buf2, 4);
+	TEST_ASSERT_EQUAL_MEMORY("ij\0\0", buf3, 4);
+}
+
+
+TEST(socket_api_recvmsg, msg_name_null)
+{
+	ssize_t n;
+	char buf[RECVMSG_BUF_SZ];
+	struct msghdr msg;
+	struct iovec iov;
+
+	n = send(test_common.sv[0], RECVMSG_MSG, RECVMSG_MSG_LEN, 0);
+	TEST_ASSERT_EQUAL_INT(RECVMSG_MSG_LEN, (int)n);
+
+	memset(buf, 0, sizeof(buf));
+	iov.iov_base = buf;
+	iov.iov_len = sizeof(buf);
+
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_name = NULL;
+	msg.msg_namelen = 0;
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	n = recvmsg(test_common.sv[1], &msg, 0);
+	TEST_ASSERT_EQUAL_INT(RECVMSG_MSG_LEN, (int)n);
+}
+
+
+TEST(socket_api_recvmsg, msg_peek)
+{
+	ssize_t n;
+	char buf[RECVMSG_BUF_SZ];
+	struct msghdr msg;
+	struct iovec iov;
+
+	n = send(test_common.sv[0], RECVMSG_MSG, RECVMSG_MSG_LEN, 0);
+	TEST_ASSERT_EQUAL_INT(RECVMSG_MSG_LEN, (int)n);
+
+	memset(buf, 0, sizeof(buf));
+	iov.iov_base = buf;
+	iov.iov_len = sizeof(buf);
+
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	/* MSG_PEEK: data is treated as unread */
+	n = recvmsg(test_common.sv[1], &msg, MSG_PEEK);
+	TEST_ASSERT_EQUAL_INT(RECVMSG_MSG_LEN, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY(RECVMSG_MSG, buf, RECVMSG_MSG_LEN);
+
+	/* Next recvmsg shall still return the same data */
+	memset(buf, 0, sizeof(buf));
+	n = recvmsg(test_common.sv[1], &msg, 0);
+	TEST_ASSERT_EQUAL_INT(RECVMSG_MSG_LEN, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY(RECVMSG_MSG, buf, RECVMSG_MSG_LEN);
+}
+
+
+TEST(socket_api_recvmsg, msg_waitall_stream)
+{
+	ssize_t n;
+	char buf[RECVMSG_BUF_SZ];
+	struct msghdr msg;
+	struct iovec iov;
+
+	n = send(test_common.sv[0], RECVMSG_MSG, RECVMSG_MSG_LEN, 0);
+	TEST_ASSERT_EQUAL_INT(RECVMSG_MSG_LEN, (int)n);
+
+	close(test_common.sv[0]);
+	test_common.sv[0] = -1;
+
+	memset(buf, 0, sizeof(buf));
+	iov.iov_base = buf;
+	iov.iov_len = sizeof(buf);
+
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	n = recvmsg(test_common.sv[1], &msg, MSG_WAITALL);
+	TEST_ASSERT_EQUAL_INT(RECVMSG_MSG_LEN, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY(RECVMSG_MSG, buf, RECVMSG_MSG_LEN);
+}
+
+
+TEST(socket_api_recvmsg, orderly_shutdown_returns_zero)
+{
+	ssize_t n;
+	char buf[RECVMSG_BUF_SZ];
+	struct msghdr msg;
+	struct iovec iov;
+
+	close(test_common.sv[0]);
+	test_common.sv[0] = -1;
+
+	memset(buf, 0, sizeof(buf));
+	iov.iov_base = buf;
+	iov.iov_len = sizeof(buf);
+
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	n = recvmsg(test_common.sv[1], &msg, 0);
+	TEST_ASSERT_EQUAL_INT(0, (int)n);
+}
+
+
+TEST(socket_api_recvmsg, eagain_nonblock_no_data)
+{
+	ssize_t n;
+	int ret;
+	int flags;
+	char buf[RECVMSG_BUF_SZ];
+	struct msghdr msg;
+	struct iovec iov;
+
+	flags = fcntl(test_common.sv[1], F_GETFL, 0);
+	TEST_ASSERT_TRUE(flags >= 0);
+	ret = fcntl(test_common.sv[1], F_SETFL, flags | O_NONBLOCK);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	memset(buf, 0, sizeof(buf));
+	iov.iov_base = buf;
+	iov.iov_len = sizeof(buf);
+
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	errno = 0;
+	n = recvmsg(test_common.sv[1], &msg, 0);
+	TEST_ASSERT_EQUAL_INT(-1, (int)n);
+	TEST_ASSERT_TRUE(errno == EAGAIN || errno == EWOULDBLOCK);
+}
+
+
+TEST(socket_api_recvmsg, ebadf_invalid_fd)
+{
+	ssize_t n;
+	char buf[RECVMSG_BUF_SZ];
+	struct msghdr msg;
+	struct iovec iov;
+
+	memset(buf, 0, sizeof(buf));
+	iov.iov_base = buf;
+	iov.iov_len = sizeof(buf);
+
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	errno = 0;
+	n = recvmsg(-1, &msg, 0);
+	TEST_ASSERT_EQUAL_INT(-1, (int)n);
+	TEST_ASSERT_EQUAL_INT(EBADF, errno);
+}
+
+
+TEST(socket_api_recvmsg, enotsock_pipe_fd)
+{
+	ssize_t n;
+	int ret;
+	int pipefd[2];
+	char buf[RECVMSG_BUF_SZ];
+	struct msghdr msg;
+	struct iovec iov;
+
+	ret = pipe(pipefd);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	memset(buf, 0, sizeof(buf));
+	iov.iov_base = buf;
+	iov.iov_len = sizeof(buf);
+
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	errno = 0;
+	if (TEST_PROTECT()) {
+		n = recvmsg(pipefd[0], &msg, 0);
+		TEST_ASSERT_EQUAL_INT(-1, (int)n);
+		TEST_ASSERT_EQUAL_INT(ENOTSOCK, errno);
+	}
+	close(pipefd[0]);
+	close(pipefd[1]);
+}
+
+
+TEST(socket_api_recvmsg, enotconn_unconnected_stream)
+{
+	ssize_t n;
+	int fd;
+	char buf[RECVMSG_BUF_SZ];
+	struct msghdr msg;
+	struct iovec iov;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	memset(buf, 0, sizeof(buf));
+	iov.iov_base = buf;
+	iov.iov_len = sizeof(buf);
+
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	errno = 0;
+	n = recvmsg(fd, &msg, 0);
+	TEST_ASSERT_EQUAL_INT(-1, (int)n);
+#ifndef __phoenix__
+	/* glibc may return EINVAL instead of ENOTCONN on unbound AF_UNIX stream socket */
+	TEST_ASSERT_TRUE(errno == ENOTCONN || errno == EINVAL);
+#else
+	TEST_ASSERT_EQUAL_INT(ENOTCONN, errno);
+#endif
+
+	close(fd);
+}
+
+
+TEST(socket_api_recvmsg, dgram_msg_trunc_flag)
+{
+	int ret;
+	int *sv;
+	ssize_t n;
+	char buf[4];
+	struct msghdr msg;
+	struct iovec iov;
+	const char *data = "abcdefgh";
+	const size_t dataLen = 8;
+
+	/* Close the default stream pair */
+	close(test_common.sv[0]);
+	close(test_common.sv[1]);
+	test_common.sv[0] = -1;
+	test_common.sv[1] = -1;
+
+	sv = test_common.sv;
+
+	ret = socketpair(AF_UNIX, SOCK_DGRAM, 0, sv);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	n = send(sv[0], data, dataLen, 0);
+	TEST_ASSERT_EQUAL_INT((int)dataLen, (int)n);
+
+	/* Buffer smaller than message: MSG_TRUNC should be set in msg_flags */
+	memset(buf, 0, sizeof(buf));
+	iov.iov_base = buf;
+	iov.iov_len = sizeof(buf);
+
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	n = recvmsg(sv[1], &msg, 0);
+	/* Returns bytes written to buffer (truncated) */
+	TEST_ASSERT_GREATER_THAN_INT(0, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY("abcd", buf, 4);
+	/* MSG_TRUNC shall be set when data was truncated */
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1648 issue");
+#endif
+	TEST_ASSERT_TRUE((msg.msg_flags & MSG_TRUNC) != 0);
+}
+
+
+TEST(socket_api_recvmsg, dgram_source_address)
+{
+	volatile int srvFd = -1;
+	volatile int cliFd = -1;
+	int ret;
+	ssize_t n;
+	char buf[RECVMSG_BUF_SZ];
+	struct sockaddr_un srvAddr;
+	struct sockaddr_un srcAddr;
+	struct msghdr msg;
+	struct iovec iov;
+	const char *cliPath = "/tmp/test_recvmsg_cli_sock";
+
+#ifdef __phoenix__
+	/* https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1665 */
+	TEST_IGNORE_MESSAGE("#1665 issue");
+#endif
+
+	/* Close the default stream pair */
+	close(test_common.sv[0]);
+	close(test_common.sv[1]);
+	test_common.sv[0] = -1;
+	test_common.sv[1] = -1;
+
+	unlink(RECVMSG_SOCK_PATH);
+
+	srvFd = socket(AF_UNIX, SOCK_DGRAM, 0);
+	TEST_ASSERT_TRUE(srvFd >= 0);
+
+	if (TEST_PROTECT()) {
+		memset(&srvAddr, 0, sizeof(srvAddr));
+		srvAddr.sun_family = AF_UNIX;
+		snprintf(srvAddr.sun_path, sizeof(srvAddr.sun_path), "%s", RECVMSG_SOCK_PATH);
+
+		ret = bind(srvFd, (struct sockaddr *)&srvAddr, sizeof(srvAddr));
+		TEST_ASSERT_EQUAL_INT(0, ret);
+
+		cliFd = socket(AF_UNIX, SOCK_DGRAM, 0);
+		TEST_ASSERT_TRUE(cliFd >= 0);
+
+		struct sockaddr_un cliAddr;
+		memset(&cliAddr, 0, sizeof(cliAddr));
+		cliAddr.sun_family = AF_UNIX;
+		strncpy(cliAddr.sun_path, cliPath, sizeof(cliAddr.sun_path) - 1);
+
+		unlink(cliPath);
+		ret = bind(cliFd, (struct sockaddr *)&cliAddr, sizeof(cliAddr));
+		TEST_ASSERT_EQUAL_INT(0, ret);
+
+		n = sendto(cliFd, RECVMSG_MSG, RECVMSG_MSG_LEN, 0,
+				(struct sockaddr *)&srvAddr, sizeof(srvAddr));
+		TEST_ASSERT_EQUAL_INT(RECVMSG_MSG_LEN, (int)n);
+
+		/* Receive with source address */
+		memset(buf, 0, sizeof(buf));
+		memset(&srcAddr, 0, sizeof(srcAddr));
+
+		iov.iov_base = buf;
+		iov.iov_len = sizeof(buf);
+
+		memset(&msg, 0, sizeof(msg));
+		msg.msg_name = &srcAddr;
+		msg.msg_namelen = sizeof(srcAddr);
+		msg.msg_iov = &iov;
+		msg.msg_iovlen = 1;
+
+		n = recvmsg(srvFd, &msg, 0);
+		TEST_ASSERT_EQUAL_INT(RECVMSG_MSG_LEN, (int)n);
+		TEST_ASSERT_EQUAL_MEMORY(RECVMSG_MSG, buf, RECVMSG_MSG_LEN);
+		TEST_ASSERT_GREATER_THAN_INT(0, msg.msg_namelen);
+		TEST_ASSERT_EQUAL_INT(AF_UNIX, srcAddr.sun_family);
+		TEST_ASSERT_EQUAL_STRING(cliPath, srcAddr.sun_path);
+	}
+	if (srvFd >= 0) {
+		close(srvFd);
+	}
+	if (cliFd >= 0) {
+		close(cliFd);
+	}
+}
+
+
+TEST_GROUP_RUNNER(socket_api_recvmsg)
+{
+	RUN_TEST_CASE(socket_api_recvmsg, basic_success);
+	RUN_TEST_CASE(socket_api_recvmsg, returns_total_length);
+	RUN_TEST_CASE(socket_api_recvmsg, scatter_multiple_iovecs);
+	RUN_TEST_CASE(socket_api_recvmsg, msg_name_null);
+	RUN_TEST_CASE(socket_api_recvmsg, msg_peek);
+	RUN_TEST_CASE(socket_api_recvmsg, msg_waitall_stream);
+	RUN_TEST_CASE(socket_api_recvmsg, orderly_shutdown_returns_zero);
+	RUN_TEST_CASE(socket_api_recvmsg, eagain_nonblock_no_data);
+	RUN_TEST_CASE(socket_api_recvmsg, ebadf_invalid_fd);
+	RUN_TEST_CASE(socket_api_recvmsg, enotsock_pipe_fd);
+	RUN_TEST_CASE(socket_api_recvmsg, enotconn_unconnected_stream);
+	RUN_TEST_CASE(socket_api_recvmsg, dgram_msg_trunc_flag);
+	RUN_TEST_CASE(socket_api_recvmsg, dgram_source_address);
+}

--- a/libc/socket/send.c
+++ b/libc/socket/send.c
@@ -1,0 +1,360 @@
+/*
+ * Phoenix-RTOS
+ *
+ * POSIX.1-2017 standard library functions tests
+ * HEADER:
+ *    - <sys/socket.h>
+ * TESTED:
+ *    - send()
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Lukasz Kruszynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <sys/socket.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <fcntl.h>
+#include <signal.h>
+
+#include "unity_fixture.h"
+
+#define SEND_MSG       "hello"
+#define SEND_MSG_LEN   5
+#define SEND_BUF_SZ    32
+#define SEND_EMPTY_LEN 0
+
+static struct {
+	int sv[2];
+	struct sigaction oldsa;
+	int sigaction_changed;
+} test_common;
+
+TEST_GROUP(socket_api_send);
+
+TEST_SETUP(socket_api_send)
+{
+	int ret;
+	test_common.sigaction_changed = 0;
+	ret = socketpair(AF_UNIX, SOCK_STREAM, 0, test_common.sv);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+TEST_TEAR_DOWN(socket_api_send)
+{
+	if (test_common.sv[0] >= 0) {
+		close(test_common.sv[0]);
+		test_common.sv[0] = -1;
+	}
+	if (test_common.sv[1] >= 0) {
+		close(test_common.sv[1]);
+		test_common.sv[1] = -1;
+	}
+	if (test_common.sigaction_changed) {
+		alarm(0);
+		sigaction(SIGALRM, &test_common.oldsa, NULL);
+		test_common.sigaction_changed = 0;
+	}
+}
+
+
+TEST(socket_api_send, basic_success)
+{
+	ssize_t n;
+	char buf[SEND_BUF_SZ];
+
+	n = send(test_common.sv[0], SEND_MSG, SEND_MSG_LEN, 0);
+	TEST_ASSERT_EQUAL_INT(SEND_MSG_LEN, (int)n);
+
+	memset(buf, 0, sizeof(buf));
+	n = recv(test_common.sv[1], buf, sizeof(buf), 0);
+	TEST_ASSERT_EQUAL_INT(SEND_MSG_LEN, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY(SEND_MSG, buf, SEND_MSG_LEN);
+}
+
+
+TEST(socket_api_send, returns_bytes_sent)
+{
+	ssize_t n;
+
+	/* Upon successful completion, send() shall return the number of bytes sent */
+	n = send(test_common.sv[0], SEND_MSG, SEND_MSG_LEN, 0);
+	TEST_ASSERT_EQUAL_INT(SEND_MSG_LEN, (int)n);
+}
+
+
+TEST(socket_api_send, zero_length_message)
+{
+	ssize_t n;
+
+	/* Sending zero-length message should succeed */
+	n = send(test_common.sv[0], SEND_MSG, SEND_EMPTY_LEN, 0);
+	TEST_ASSERT_EQUAL_INT(SEND_EMPTY_LEN, (int)n);
+}
+
+
+TEST(socket_api_send, msg_nosignal_flag)
+{
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1635 issue");
+#endif
+	ssize_t n;
+
+	/* Shut down write end of peer so send will get EPIPE */
+	close(test_common.sv[1]);
+	test_common.sv[1] = -1;
+
+	/* MSG_NOSIGNAL: requests not to send SIGPIPE, EPIPE shall still be returned */
+	errno = 0;
+	n = send(test_common.sv[0], SEND_MSG, SEND_MSG_LEN, MSG_NOSIGNAL);
+	TEST_ASSERT_EQUAL_INT(-1, (int)n);
+	TEST_ASSERT_EQUAL_INT(EPIPE, errno);
+}
+
+
+TEST(socket_api_send, ebadf_invalid_fd)
+{
+	ssize_t n;
+
+	errno = 0;
+	n = send(-1, SEND_MSG, SEND_MSG_LEN, 0);
+	TEST_ASSERT_EQUAL_INT(-1, (int)n);
+	TEST_ASSERT_EQUAL_INT(EBADF, errno);
+}
+
+
+TEST(socket_api_send, enotsock_not_socket)
+{
+	ssize_t n;
+	int pipefd[2] = { -1, -1 };
+	int ret;
+
+	ret = pipe(pipefd);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	if (TEST_PROTECT()) {
+		errno = 0;
+		n = send(pipefd[0], SEND_MSG, SEND_MSG_LEN, 0);
+		TEST_ASSERT_EQUAL_INT(-1, (int)n);
+		TEST_ASSERT_EQUAL_INT(ENOTSOCK, errno);
+	}
+	if (pipefd[0] >= 0) {
+		close(pipefd[0]);
+	}
+	if (pipefd[1] >= 0) {
+		close(pipefd[1]);
+	}
+}
+
+
+TEST(socket_api_send, enotconn_unconnected)
+{
+	ssize_t n;
+	int fd;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+	if (TEST_PROTECT()) {
+		errno = 0;
+		n = send(fd, SEND_MSG, SEND_MSG_LEN, 0);
+		TEST_ASSERT_EQUAL_INT(-1, (int)n);
+		TEST_ASSERT_EQUAL_INT(ENOTCONN, errno);
+	}
+	close(fd);
+}
+
+
+TEST(socket_api_send, epipe_after_shutdown_wr)
+{
+	ssize_t n;
+	int ret;
+
+	ret = shutdown(test_common.sv[0], SHUT_WR);
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1634 issue");
+#endif
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* send on socket shut down for writing shall fail with EPIPE */
+	errno = 0;
+	n = send(test_common.sv[0], SEND_MSG, SEND_MSG_LEN, MSG_NOSIGNAL);
+	TEST_ASSERT_EQUAL_INT(-1, (int)n);
+	TEST_ASSERT_EQUAL_INT(EPIPE, errno);
+}
+
+
+TEST(socket_api_send, ewouldblock_nonblocking)
+{
+	ssize_t n;
+	int ret;
+	int flags;
+	static char bigBuf[65536];
+
+	flags = fcntl(test_common.sv[0], F_GETFL);
+	TEST_ASSERT_TRUE(flags >= 0);
+
+	ret = fcntl(test_common.sv[0], F_SETFL, flags | O_NONBLOCK);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Fill the send buffer until it would block */
+	memset(bigBuf, 'A', sizeof(bigBuf));
+	while (1) {
+		errno = 0;
+		n = send(test_common.sv[0], bigBuf, sizeof(bigBuf), MSG_NOSIGNAL);
+		if (n == -1) {
+			TEST_ASSERT_TRUE(errno == EAGAIN || errno == EWOULDBLOCK);
+			break;
+		}
+	}
+}
+
+
+TEST(socket_api_send, equivalent_to_write_with_flags_zero)
+{
+	/* send() with flags==0 is equivalent to write() */
+	ssize_t n1;
+	ssize_t n2;
+	char buf[SEND_BUF_SZ];
+
+	n1 = send(test_common.sv[0], SEND_MSG, SEND_MSG_LEN, 0);
+	TEST_ASSERT_EQUAL_INT(SEND_MSG_LEN, (int)n1);
+
+	memset(buf, 0, sizeof(buf));
+	n2 = read(test_common.sv[1], buf, sizeof(buf));
+	TEST_ASSERT_EQUAL_INT(SEND_MSG_LEN, (int)n2);
+	TEST_ASSERT_EQUAL_MEMORY(SEND_MSG, buf, SEND_MSG_LEN);
+}
+
+
+TEST(socket_api_send, edestaddrreq_dgram_no_peer)
+{
+	ssize_t n;
+	int fd;
+
+	/* connectionless-mode socket with no peer address set */
+	fd = socket(AF_UNIX, SOCK_DGRAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+	if (TEST_PROTECT()) {
+		errno = 0;
+		n = send(fd, SEND_MSG, SEND_MSG_LEN, 0);
+		TEST_ASSERT_EQUAL_INT(-1, (int)n);
+		/* EDESTADDRREQ or ENOTCONN depending on implementation */
+		TEST_ASSERT_TRUE(errno == EDESTADDRREQ || errno == ENOTCONN);
+	}
+	close(fd);
+}
+
+
+static void test_sigAlarmHandler(int sig)
+{
+	(void)sig;
+}
+
+
+TEST(socket_api_send, eintr_signal_interrupts)
+{
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1635 issue");
+#endif
+	ssize_t n;
+	struct sigaction sa;
+	int ret;
+	int flags;
+	static char bigBuf[65536];
+
+	/* Fill the send buffer so next send blocks */
+	flags = fcntl(test_common.sv[0], F_GETFL);
+	TEST_ASSERT_TRUE(flags >= 0);
+
+	ret = fcntl(test_common.sv[0], F_SETFL, flags | O_NONBLOCK);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	memset(bigBuf, 'X', sizeof(bigBuf));
+	while (1) {
+		n = send(test_common.sv[0], bigBuf, sizeof(bigBuf), MSG_NOSIGNAL);
+		if (n == -1) {
+			break;
+		}
+	}
+
+	/* Switch back to blocking */
+	ret = fcntl(test_common.sv[0], F_SETFL, flags);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Install SIGALRM handler without SA_RESTART */
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = test_sigAlarmHandler;
+	sigemptyset(&sa.sa_mask);
+	sa.sa_flags = 0;
+
+	ret = sigaction(SIGALRM, &sa, &test_common.oldsa);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	test_common.sigaction_changed = 1;
+
+	/* Schedule alarm in 1 second */
+	alarm(1);
+
+	/* Blocking send should be interrupted */
+	errno = 0;
+	n = send(test_common.sv[0], bigBuf, sizeof(bigBuf), MSG_NOSIGNAL);
+	TEST_ASSERT_EQUAL_INT(-1, (int)n);
+	TEST_ASSERT_EQUAL_INT(EINTR, errno);
+}
+
+
+TEST(socket_api_send, emsgsize_dgram_too_large)
+{
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1644");
+#endif
+	int *sv = test_common.sv;
+	int ret;
+	ssize_t n;
+	int sndbuf = 4096;
+	socklen_t optlen;
+	static char bigBuf[65536];
+
+	close(sv[0]);
+	close(sv[1]);
+
+	ret = socketpair(AF_UNIX, SOCK_DGRAM, 0, sv);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	ret = setsockopt(sv[0], SOL_SOCKET, SO_SNDBUF, &sndbuf, sizeof(sndbuf));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Read back the effective limit (the kernel may round or double it) */
+	optlen = sizeof(sndbuf);
+	ret = getsockopt(sv[0], SOL_SOCKET, SO_SNDBUF, &sndbuf, &optlen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_TRUE((size_t)sndbuf < sizeof(bigBuf));
+
+	/* Single datagram exceeding buffer limit */
+	memset(bigBuf, 'Y', sizeof(bigBuf));
+	errno = 0;
+	n = send(sv[0], bigBuf, (size_t)sndbuf + 1U, 0);
+	TEST_ASSERT_EQUAL_INT(-1, (int)n);
+	TEST_ASSERT_EQUAL_INT(EMSGSIZE, errno);
+}
+
+
+TEST_GROUP_RUNNER(socket_api_send)
+{
+	RUN_TEST_CASE(socket_api_send, basic_success);
+	RUN_TEST_CASE(socket_api_send, returns_bytes_sent);
+	RUN_TEST_CASE(socket_api_send, zero_length_message);
+	RUN_TEST_CASE(socket_api_send, msg_nosignal_flag);
+	RUN_TEST_CASE(socket_api_send, ebadf_invalid_fd);
+	RUN_TEST_CASE(socket_api_send, enotsock_not_socket);
+	RUN_TEST_CASE(socket_api_send, enotconn_unconnected);
+	RUN_TEST_CASE(socket_api_send, epipe_after_shutdown_wr);
+	RUN_TEST_CASE(socket_api_send, ewouldblock_nonblocking);
+	RUN_TEST_CASE(socket_api_send, equivalent_to_write_with_flags_zero);
+	RUN_TEST_CASE(socket_api_send, edestaddrreq_dgram_no_peer);
+	RUN_TEST_CASE(socket_api_send, eintr_signal_interrupts);
+	RUN_TEST_CASE(socket_api_send, emsgsize_dgram_too_large);
+}

--- a/libc/socket/sendmsg.c
+++ b/libc/socket/sendmsg.c
@@ -1,0 +1,730 @@
+/*
+ * Phoenix-RTOS
+ *
+ * POSIX.1-2017 standard library functions tests
+ * HEADER:
+ *    - <sys/socket.h>
+ * TESTED:
+ *    - sendmsg()
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Lukasz Kruszynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/* sendmsg() is declared with a warning attribute on Phoenix-RTOS; suppress it since we are testing this function */
+#pragma GCC diagnostic ignored "-Wattribute-warning"
+
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <sys/uio.h>
+#include <limits.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <fcntl.h>
+#include <signal.h>
+
+#include "unity_fixture.h"
+
+/* IOV_MAX may not be defined as a macro on all systems */
+#ifndef IOV_MAX
+#define IOV_MAX 1024
+#endif
+
+#define SENDMSG_MSG1      "hello"
+#define SENDMSG_MSG1_LEN  5
+#define SENDMSG_MSG2      "world"
+#define SENDMSG_MSG2_LEN  5
+#define SENDMSG_BUF_SZ    64
+#define SENDMSG_SOCK_PATH "/tmp/test_sendmsg_sock"
+
+static struct {
+	int sv[2];
+	struct sigaction oldsa;
+	int sigaction_changed;
+} test_common;
+
+TEST_GROUP(socket_api_sendmsg);
+
+TEST_SETUP(socket_api_sendmsg)
+{
+	int ret;
+	test_common.sv[0] = -1;
+	test_common.sv[1] = -1;
+	test_common.sigaction_changed = 0;
+
+	unlink(SENDMSG_SOCK_PATH);
+	ret = socketpair(AF_UNIX, SOCK_STREAM, 0, test_common.sv);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+TEST_TEAR_DOWN(socket_api_sendmsg)
+{
+	if (test_common.sv[0] >= 0) {
+		close(test_common.sv[0]);
+		test_common.sv[0] = -1;
+	}
+	if (test_common.sv[1] >= 0) {
+		close(test_common.sv[1]);
+		test_common.sv[1] = -1;
+	}
+	if (test_common.sigaction_changed) {
+		alarm(0);
+		sigaction(SIGALRM, &test_common.oldsa, NULL);
+		test_common.sigaction_changed = 0;
+	}
+	unlink(SENDMSG_SOCK_PATH);
+}
+
+
+TEST(socket_api_sendmsg, basic_single_iov)
+{
+	ssize_t n;
+	struct msghdr msg;
+	struct iovec iov;
+	char buf[SENDMSG_BUF_SZ];
+
+	memset(&msg, 0, sizeof(msg));
+	iov.iov_base = (void *)SENDMSG_MSG1;
+	iov.iov_len = SENDMSG_MSG1_LEN;
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	n = sendmsg(test_common.sv[0], &msg, 0);
+	TEST_ASSERT_EQUAL_INT(SENDMSG_MSG1_LEN, (int)n);
+
+	memset(buf, 0, sizeof(buf));
+	n = recv(test_common.sv[1], buf, sizeof(buf), 0);
+	TEST_ASSERT_EQUAL_INT(SENDMSG_MSG1_LEN, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY(SENDMSG_MSG1, buf, SENDMSG_MSG1_LEN);
+}
+
+
+TEST(socket_api_sendmsg, scatter_gather_multiple_iov)
+{
+	ssize_t n;
+	struct msghdr msg;
+	struct iovec iov[2];
+	char buf[SENDMSG_BUF_SZ];
+	const int totalLen = SENDMSG_MSG1_LEN + SENDMSG_MSG2_LEN;
+
+	memset(&msg, 0, sizeof(msg));
+	iov[0].iov_base = (void *)SENDMSG_MSG1;
+	iov[0].iov_len = SENDMSG_MSG1_LEN;
+	iov[1].iov_base = (void *)SENDMSG_MSG2;
+	iov[1].iov_len = SENDMSG_MSG2_LEN;
+	msg.msg_iov = iov;
+	msg.msg_iovlen = 2;
+
+	/* Data from each iov is sent in turn */
+	n = sendmsg(test_common.sv[0], &msg, 0);
+	TEST_ASSERT_EQUAL_INT(totalLen, (int)n);
+
+	memset(buf, 0, sizeof(buf));
+	n = recv(test_common.sv[1], buf, sizeof(buf), 0);
+	TEST_ASSERT_EQUAL_INT(totalLen, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY(SENDMSG_MSG1, buf, SENDMSG_MSG1_LEN);
+	TEST_ASSERT_EQUAL_MEMORY(SENDMSG_MSG2, buf + SENDMSG_MSG1_LEN, SENDMSG_MSG2_LEN);
+}
+
+
+TEST(socket_api_sendmsg, zero_length_iov)
+{
+	ssize_t n;
+	struct msghdr msg;
+	struct iovec iov;
+
+	memset(&msg, 0, sizeof(msg));
+	iov.iov_base = (void *)SENDMSG_MSG1;
+	iov.iov_len = 0;
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	/* Zero-length send should succeed returning 0 */
+	n = sendmsg(test_common.sv[0], &msg, 0);
+	TEST_ASSERT_EQUAL_INT(0, (int)n);
+}
+
+
+TEST(socket_api_sendmsg, returns_bytes_sent)
+{
+	ssize_t n;
+	struct msghdr msg;
+	struct iovec iov;
+
+	memset(&msg, 0, sizeof(msg));
+	iov.iov_base = (void *)SENDMSG_MSG1;
+	iov.iov_len = SENDMSG_MSG1_LEN;
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	n = sendmsg(test_common.sv[0], &msg, 0);
+	TEST_ASSERT_EQUAL_INT(SENDMSG_MSG1_LEN, (int)n);
+}
+
+
+TEST(socket_api_sendmsg, msg_flags_ignored)
+{
+	ssize_t n;
+	struct msghdr msg;
+	struct iovec iov;
+	char buf[SENDMSG_BUF_SZ];
+
+	/* The msg_flags member is ignored on send */
+	memset(&msg, 0, sizeof(msg));
+	iov.iov_base = (void *)SENDMSG_MSG1;
+	iov.iov_len = SENDMSG_MSG1_LEN;
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+	msg.msg_flags = 0x7fff; /* arbitrary value - should be ignored */
+
+	n = sendmsg(test_common.sv[0], &msg, 0);
+	TEST_ASSERT_EQUAL_INT(SENDMSG_MSG1_LEN, (int)n);
+
+	memset(buf, 0, sizeof(buf));
+	n = recv(test_common.sv[1], buf, sizeof(buf), 0);
+	TEST_ASSERT_EQUAL_INT(SENDMSG_MSG1_LEN, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY(SENDMSG_MSG1, buf, SENDMSG_MSG1_LEN);
+}
+
+
+TEST(socket_api_sendmsg, dgram_with_dest_addr)
+{
+	int recvFd = -1;
+	volatile int sendFd = -1;
+	int ret;
+	ssize_t n;
+	struct msghdr msg;
+	struct iovec iov;
+	struct sockaddr_un addr;
+	char buf[SENDMSG_BUF_SZ];
+
+	recvFd = socket(AF_UNIX, SOCK_DGRAM, 0);
+	TEST_ASSERT_TRUE(recvFd >= 0);
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	strncpy(addr.sun_path, SENDMSG_SOCK_PATH, sizeof(addr.sun_path) - 1);
+
+	if (TEST_PROTECT()) {
+		ret = bind(recvFd, (struct sockaddr *)&addr, sizeof(addr));
+		TEST_ASSERT_EQUAL_INT(0, ret);
+
+		sendFd = socket(AF_UNIX, SOCK_DGRAM, 0);
+		TEST_ASSERT_TRUE(sendFd >= 0);
+
+		memset(&msg, 0, sizeof(msg));
+		iov.iov_base = (void *)SENDMSG_MSG1;
+		iov.iov_len = SENDMSG_MSG1_LEN;
+		msg.msg_iov = &iov;
+		msg.msg_iovlen = 1;
+		msg.msg_name = &addr;
+		msg.msg_namelen = sizeof(addr);
+
+		n = sendmsg(sendFd, &msg, 0);
+		TEST_ASSERT_EQUAL_INT(SENDMSG_MSG1_LEN, (int)n);
+
+		memset(buf, 0, sizeof(buf));
+		n = recvfrom(recvFd, buf, sizeof(buf), 0, NULL, NULL);
+		TEST_ASSERT_EQUAL_INT(SENDMSG_MSG1_LEN, (int)n);
+		TEST_ASSERT_EQUAL_MEMORY(SENDMSG_MSG1, buf, SENDMSG_MSG1_LEN);
+	}
+
+	if (recvFd >= 0) {
+		close(recvFd);
+	}
+	if (sendFd >= 0) {
+		close(sendFd);
+	}
+}
+
+
+TEST(socket_api_sendmsg, ebadf_invalid_fd)
+{
+	ssize_t n;
+	struct msghdr msg;
+	struct iovec iov;
+
+	memset(&msg, 0, sizeof(msg));
+	iov.iov_base = (void *)SENDMSG_MSG1;
+	iov.iov_len = SENDMSG_MSG1_LEN;
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	errno = 0;
+	n = sendmsg(-1, &msg, 0);
+	TEST_ASSERT_EQUAL_INT(-1, (int)n);
+	TEST_ASSERT_EQUAL_INT(EBADF, errno);
+}
+
+
+TEST(socket_api_sendmsg, enotsock_not_socket)
+{
+	ssize_t n;
+	struct msghdr msg;
+	struct iovec iov;
+	int pipefd[2] = { -1, -1 };
+	int ret;
+
+	ret = pipe(pipefd);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	if (TEST_PROTECT()) {
+		memset(&msg, 0, sizeof(msg));
+		iov.iov_base = (void *)SENDMSG_MSG1;
+		iov.iov_len = SENDMSG_MSG1_LEN;
+		msg.msg_iov = &iov;
+		msg.msg_iovlen = 1;
+
+		errno = 0;
+		n = sendmsg(pipefd[0], &msg, 0);
+
+		TEST_ASSERT_EQUAL_INT(-1, (int)n);
+		TEST_ASSERT_EQUAL_INT(ENOTSOCK, errno);
+	}
+	if (pipefd[0] >= 0) {
+		close(pipefd[0]);
+	}
+	if (pipefd[1] >= 0) {
+		close(pipefd[1]);
+	}
+}
+
+
+TEST(socket_api_sendmsg, enotconn_unconnected)
+{
+	ssize_t n;
+	struct msghdr msg;
+	struct iovec iov;
+	int fd;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	if (TEST_PROTECT()) {
+		memset(&msg, 0, sizeof(msg));
+		iov.iov_base = (void *)SENDMSG_MSG1;
+		iov.iov_len = SENDMSG_MSG1_LEN;
+		msg.msg_iov = &iov;
+		msg.msg_iovlen = 1;
+
+		errno = 0;
+		n = sendmsg(fd, &msg, 0);
+		TEST_ASSERT_EQUAL_INT(-1, (int)n);
+		TEST_ASSERT_EQUAL_INT(ENOTCONN, errno);
+	}
+	close(fd);
+}
+
+
+TEST(socket_api_sendmsg, epipe_after_shutdown_wr)
+{
+	ssize_t n;
+	struct msghdr msg;
+	struct iovec iov;
+	int ret;
+
+	ret = shutdown(test_common.sv[0], SHUT_WR);
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1634 issue");
+#endif
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	memset(&msg, 0, sizeof(msg));
+	iov.iov_base = (void *)SENDMSG_MSG1;
+	iov.iov_len = SENDMSG_MSG1_LEN;
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	errno = 0;
+	n = sendmsg(test_common.sv[0], &msg, MSG_NOSIGNAL);
+	TEST_ASSERT_EQUAL_INT(-1, (int)n);
+	TEST_ASSERT_EQUAL_INT(EPIPE, errno);
+}
+
+
+TEST(socket_api_sendmsg, ewouldblock_nonblocking)
+{
+	ssize_t n;
+	struct msghdr msg;
+	struct iovec iov;
+	int ret;
+	int flags;
+	static char bigBuf[65536];
+
+	flags = fcntl(test_common.sv[0], F_GETFL);
+	TEST_ASSERT_TRUE(flags >= 0);
+
+	ret = fcntl(test_common.sv[0], F_SETFL, flags | O_NONBLOCK);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	memset(bigBuf, 'C', sizeof(bigBuf));
+	memset(&msg, 0, sizeof(msg));
+	iov.iov_base = bigBuf;
+	iov.iov_len = sizeof(bigBuf);
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	while (1) {
+		errno = 0;
+		n = sendmsg(test_common.sv[0], &msg, MSG_NOSIGNAL);
+		if (n == -1) {
+			TEST_ASSERT_TRUE(errno == EAGAIN || errno == EWOULDBLOCK);
+			break;
+		}
+	}
+}
+
+
+TEST(socket_api_sendmsg, connection_mode_ignores_dest_addr)
+{
+	ssize_t n;
+	struct msghdr msg;
+	struct iovec iov;
+	struct sockaddr_un addr;
+	char buf[SENDMSG_BUF_SZ];
+
+	/* On connection-mode socket, destination address in msghdr shall be ignored */
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	strncpy(addr.sun_path, "/tmp/nonexistent", sizeof(addr.sun_path) - 1);
+
+	memset(&msg, 0, sizeof(msg));
+	iov.iov_base = (void *)SENDMSG_MSG1;
+	iov.iov_len = SENDMSG_MSG1_LEN;
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+	msg.msg_name = &addr;
+	msg.msg_namelen = sizeof(addr);
+
+/* Linux returns EISCONN instead of ignoring dest_addr on connected socket */
+#ifndef __phoenix__
+	TEST_IGNORE();
+#else
+	TEST_IGNORE_MESSAGE("#1640 issue");
+#endif
+	n = sendmsg(test_common.sv[0], &msg, 0);
+	TEST_ASSERT_EQUAL_INT(SENDMSG_MSG1_LEN, (int)n);
+
+	memset(buf, 0, sizeof(buf));
+	n = recv(test_common.sv[1], buf, sizeof(buf), 0);
+	TEST_ASSERT_EQUAL_INT(SENDMSG_MSG1_LEN, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY(SENDMSG_MSG1, buf, SENDMSG_MSG1_LEN);
+}
+
+
+TEST(socket_api_sendmsg, msg_nosignal_flag)
+{
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1635 issue");
+#endif
+	ssize_t n;
+	struct msghdr msg;
+	struct iovec iov;
+
+	close(test_common.sv[1]);
+	test_common.sv[1] = -1;
+
+	memset(&msg, 0, sizeof(msg));
+	iov.iov_base = (void *)SENDMSG_MSG1;
+	iov.iov_len = SENDMSG_MSG1_LEN;
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	/* MSG_NOSIGNAL prevents SIGPIPE, EPIPE error still returned */
+	errno = 0;
+	n = sendmsg(test_common.sv[0], &msg, MSG_NOSIGNAL);
+	TEST_ASSERT_EQUAL_INT(-1, (int)n);
+	TEST_ASSERT_EQUAL_INT(EPIPE, errno);
+}
+
+
+TEST(socket_api_sendmsg, scm_rights_send_fd)
+{
+	/* Send a file descriptor over AF_UNIX socket using SCM_RIGHTS */
+	int ret;
+	int pipefd[2] = { -1, -1 };
+	ssize_t n;
+	struct msghdr msg;
+	struct iovec iov;
+	struct msghdr rmsg;
+	struct iovec riov;
+	char buf[SENDMSG_BUF_SZ];
+	char ctrl[CMSG_SPACE(sizeof(int))] __attribute__((aligned(__alignof__(struct cmsghdr))));
+	char rctrl[CMSG_SPACE(sizeof(int))] __attribute__((aligned(__alignof__(struct cmsghdr))));
+	struct cmsghdr *cmsg;
+	volatile int receivedFd = -1;
+	int tempFd = -1;
+
+	close(test_common.sv[0]);
+	close(test_common.sv[1]);
+	ret = socketpair(AF_UNIX, SOCK_STREAM, 0, test_common.sv);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	ret = pipe(pipefd);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	if (TEST_PROTECT()) {
+		/* Build message with ancillary data carrying pipefd[0] */
+		memset(&msg, 0, sizeof(msg));
+		iov.iov_base = (void *)SENDMSG_MSG1;
+		iov.iov_len = SENDMSG_MSG1_LEN;
+		msg.msg_iov = &iov;
+		msg.msg_iovlen = 1;
+		msg.msg_control = ctrl;
+		msg.msg_controllen = sizeof(ctrl);
+
+		cmsg = CMSG_FIRSTHDR(&msg);
+		cmsg->cmsg_level = SOL_SOCKET;
+		cmsg->cmsg_type = SCM_RIGHTS;
+		cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+		memcpy(CMSG_DATA(cmsg), &pipefd[0], sizeof(int));
+
+		n = sendmsg(test_common.sv[0], &msg, 0);
+		TEST_ASSERT_EQUAL_INT(SENDMSG_MSG1_LEN, (int)n);
+
+		/* Receive on the other end */
+		memset(&rmsg, 0, sizeof(rmsg));
+		memset(buf, 0, sizeof(buf));
+		riov.iov_base = buf;
+		riov.iov_len = sizeof(buf);
+		rmsg.msg_iov = &riov;
+		rmsg.msg_iovlen = 1;
+		rmsg.msg_control = rctrl;
+		rmsg.msg_controllen = sizeof(rctrl);
+
+		n = recvmsg(test_common.sv[1], &rmsg, 0);
+		TEST_ASSERT_EQUAL_INT(SENDMSG_MSG1_LEN, (int)n);
+		TEST_ASSERT_EQUAL_MEMORY(SENDMSG_MSG1, buf, SENDMSG_MSG1_LEN);
+
+		/* Extract the received file descriptor */
+		cmsg = CMSG_FIRSTHDR(&rmsg);
+		TEST_ASSERT_NOT_NULL(cmsg);
+		TEST_ASSERT_EQUAL_INT(SOL_SOCKET, cmsg->cmsg_level);
+		TEST_ASSERT_EQUAL_INT(SCM_RIGHTS, cmsg->cmsg_type);
+		memcpy(&tempFd, CMSG_DATA(cmsg), sizeof(int));
+		receivedFd = tempFd;
+		TEST_ASSERT_TRUE(receivedFd >= 0);
+	}
+
+	if (receivedFd >= 0) {
+		close(receivedFd);
+	}
+	if (pipefd[0] >= 0) {
+		close(pipefd[0]);
+	}
+	if (pipefd[1] >= 0) {
+		close(pipefd[1]);
+	}
+}
+
+
+static void test_sigAlarmHandler(int sig)
+{
+	(void)sig;
+}
+
+
+TEST(socket_api_sendmsg, eintr_signal_interrupts)
+{
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1635 issue");
+#endif
+	ssize_t n;
+	struct msghdr msg;
+	struct iovec iov;
+	struct sigaction sa;
+	int ret;
+	int flags;
+	static char bigBuf[65536];
+
+	/* Fill the send buffer so next sendmsg blocks */
+	flags = fcntl(test_common.sv[0], F_GETFL);
+	TEST_ASSERT_TRUE(flags >= 0);
+
+	ret = fcntl(test_common.sv[0], F_SETFL, flags | O_NONBLOCK);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	memset(bigBuf, 'D', sizeof(bigBuf));
+	while (1) {
+		n = send(test_common.sv[0], bigBuf, sizeof(bigBuf), MSG_NOSIGNAL);
+		if (n == -1) {
+			break;
+		}
+	}
+
+	/* Switch back to blocking */
+	ret = fcntl(test_common.sv[0], F_SETFL, flags);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Install SIGALRM handler */
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = test_sigAlarmHandler;
+	sigemptyset(&sa.sa_mask);
+	sa.sa_flags = 0; /* no SA_RESTART */
+	ret = sigaction(SIGALRM, &sa, &test_common.oldsa);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	test_common.sigaction_changed = 1;
+	if (TEST_PROTECT()) {
+		/* Schedule alarm in 1 second */
+		alarm(1);
+
+		/* Blocking sendmsg should be interrupted by SIGALRM */
+		memset(&msg, 0, sizeof(msg));
+		iov.iov_base = bigBuf;
+		iov.iov_len = sizeof(bigBuf);
+		msg.msg_iov = &iov;
+		msg.msg_iovlen = 1;
+
+		errno = 0;
+		n = sendmsg(test_common.sv[0], &msg, MSG_NOSIGNAL);
+		TEST_ASSERT_EQUAL_INT(-1, (int)n);
+		TEST_ASSERT_EQUAL_INT(EINTR, errno);
+	}
+}
+
+
+TEST(socket_api_sendmsg, emsgsize_dgram_too_large)
+{
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1644");
+#endif
+	int ret;
+	ssize_t n;
+	struct msghdr msg;
+	struct iovec iov;
+	int sndbuf = 4096;
+	socklen_t optlen;
+	static char bigBuf[65536];
+
+	close(test_common.sv[0]);
+	close(test_common.sv[1]);
+
+	ret = socketpair(AF_UNIX, SOCK_DGRAM, 0, test_common.sv);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	ret = setsockopt(test_common.sv[0], SOL_SOCKET, SO_SNDBUF, &sndbuf, sizeof(sndbuf));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	optlen = sizeof(sndbuf);
+	ret = getsockopt(test_common.sv[0], SOL_SOCKET, SO_SNDBUF, &sndbuf, &optlen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_TRUE((size_t)sndbuf < sizeof(bigBuf));
+
+	memset(bigBuf, 'E', sizeof(bigBuf));
+	memset(&msg, 0, sizeof(msg));
+
+	iov.iov_base = bigBuf;
+	iov.iov_len = (size_t)sndbuf + 1U;
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	errno = 0;
+	n = sendmsg(test_common.sv[0], &msg, 0);
+	TEST_ASSERT_EQUAL_INT(-1, (int)n);
+	TEST_ASSERT_EQUAL_INT(EMSGSIZE, errno);
+}
+
+
+TEST(socket_api_sendmsg, iovlen_exceeds_iov_max)
+{
+	ssize_t n;
+	struct msghdr msg;
+	struct iovec iov;
+
+	memset(&msg, 0, sizeof(msg));
+	iov.iov_base = (void *)SENDMSG_MSG1;
+	iov.iov_len = SENDMSG_MSG1_LEN;
+	msg.msg_iov = &iov;
+
+	/* msg_iovlen > IOV_MAX must fail */
+	msg.msg_iovlen = IOV_MAX + 1;
+	errno = 0;
+	n = sendmsg(test_common.sv[0], &msg, 0);
+	TEST_ASSERT_EQUAL_INT(-1, (int)n);
+	TEST_ASSERT_TRUE(errno == EMSGSIZE || errno == EINVAL);
+}
+
+
+TEST(socket_api_sendmsg, iovlen_zero_or_negative)
+{
+	ssize_t n;
+	struct msghdr msg;
+	struct iovec iov;
+
+	memset(&msg, 0, sizeof(msg));
+	iov.iov_base = (void *)SENDMSG_MSG1;
+	iov.iov_len = SENDMSG_MSG1_LEN;
+	msg.msg_iov = &iov;
+
+	/* msg_iovlen of 0: POSIX says send 0 bytes or fail */
+	msg.msg_iovlen = 0;
+	errno = 0;
+	n = sendmsg(test_common.sv[0], &msg, 0);
+	/* Some implementations return 0 (send nothing), others return -1/EINVAL */
+	TEST_ASSERT_TRUE(n == 0 || (n == -1 && errno == EINVAL));
+}
+
+
+TEST(socket_api_sendmsg, invalid_cmsg_len)
+{
+	int ret;
+	ssize_t n;
+	struct msghdr msg;
+	struct iovec iov;
+	char ctrl[CMSG_SPACE(sizeof(int))];
+	struct cmsghdr *cmsg;
+
+	close(test_common.sv[0]);
+	close(test_common.sv[1]);
+	ret = socketpair(AF_UNIX, SOCK_STREAM, 0, test_common.sv);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	memset(&msg, 0, sizeof(msg));
+	iov.iov_base = (void *)SENDMSG_MSG1;
+	iov.iov_len = SENDMSG_MSG1_LEN;
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+	msg.msg_control = ctrl;
+	msg.msg_controllen = sizeof(ctrl);
+
+	/* Set cmsg_len smaller than sizeof(struct cmsghdr) - malformed */
+	cmsg = CMSG_FIRSTHDR(&msg);
+	cmsg->cmsg_level = SOL_SOCKET;
+	cmsg->cmsg_type = SCM_RIGHTS;
+	cmsg->cmsg_len = sizeof(struct cmsghdr) - 1;
+
+	errno = 0;
+	n = sendmsg(test_common.sv[0], &msg, 0);
+	/* POSIX does not mandate a specific errno for malformed ancillary data */
+	TEST_ASSERT_EQUAL_INT(-1, (int)n);
+	TEST_ASSERT_TRUE(errno != 0);
+}
+
+
+TEST_GROUP_RUNNER(socket_api_sendmsg)
+{
+	RUN_TEST_CASE(socket_api_sendmsg, basic_single_iov);
+	RUN_TEST_CASE(socket_api_sendmsg, scatter_gather_multiple_iov);
+	RUN_TEST_CASE(socket_api_sendmsg, zero_length_iov);
+	RUN_TEST_CASE(socket_api_sendmsg, returns_bytes_sent);
+	RUN_TEST_CASE(socket_api_sendmsg, msg_flags_ignored);
+	RUN_TEST_CASE(socket_api_sendmsg, dgram_with_dest_addr);
+	RUN_TEST_CASE(socket_api_sendmsg, ebadf_invalid_fd);
+	RUN_TEST_CASE(socket_api_sendmsg, enotsock_not_socket);
+	RUN_TEST_CASE(socket_api_sendmsg, enotconn_unconnected);
+	RUN_TEST_CASE(socket_api_sendmsg, epipe_after_shutdown_wr);
+	RUN_TEST_CASE(socket_api_sendmsg, ewouldblock_nonblocking);
+	RUN_TEST_CASE(socket_api_sendmsg, connection_mode_ignores_dest_addr);
+	RUN_TEST_CASE(socket_api_sendmsg, msg_nosignal_flag);
+	RUN_TEST_CASE(socket_api_sendmsg, scm_rights_send_fd);
+	RUN_TEST_CASE(socket_api_sendmsg, eintr_signal_interrupts);
+	RUN_TEST_CASE(socket_api_sendmsg, emsgsize_dgram_too_large);
+	RUN_TEST_CASE(socket_api_sendmsg, iovlen_exceeds_iov_max);
+	RUN_TEST_CASE(socket_api_sendmsg, iovlen_zero_or_negative);
+	RUN_TEST_CASE(socket_api_sendmsg, invalid_cmsg_len);
+}

--- a/libc/socket/sendto.c
+++ b/libc/socket/sendto.c
@@ -1,0 +1,356 @@
+/*
+ * Phoenix-RTOS
+ *
+ * POSIX.1-2017 standard library functions tests
+ * HEADER:
+ *    - <sys/socket.h>
+ * TESTED:
+ *    - sendto()
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Lukasz Kruszynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <fcntl.h>
+#include <signal.h>
+
+#include "unity_fixture.h"
+
+#define SENDTO_MSG       "sendto_test"
+#define SENDTO_MSG_LEN   11
+#define SENDTO_BUF_SZ    64
+#define SENDTO_SOCK_PATH "/tmp/test_sendto_sock"
+
+static struct {
+	int sv[2];
+	int fd;
+} test_common;
+
+TEST_GROUP(socket_api_sendto);
+
+TEST_SETUP(socket_api_sendto)
+{
+	int ret;
+
+	test_common.sv[0] = -1;
+	test_common.sv[1] = -1;
+	test_common.fd = -1;
+
+	unlink(SENDTO_SOCK_PATH);
+	ret = socketpair(AF_UNIX, SOCK_STREAM, 0, test_common.sv);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+TEST_TEAR_DOWN(socket_api_sendto)
+{
+	if (test_common.sv[0] >= 0) {
+		close(test_common.sv[0]);
+		test_common.sv[0] = -1;
+	}
+	if (test_common.sv[1] >= 0) {
+		close(test_common.sv[1]);
+		test_common.sv[1] = -1;
+	}
+	if (test_common.fd >= 0) {
+		close(test_common.fd);
+		test_common.fd = -1;
+	}
+	unlink(SENDTO_SOCK_PATH);
+}
+
+
+TEST(socket_api_sendto, basic_connected_stream)
+{
+	ssize_t n;
+	char buf[SENDTO_BUF_SZ];
+
+	/* On connection-mode socket, dest_addr shall be ignored */
+	n = sendto(test_common.sv[0], SENDTO_MSG, SENDTO_MSG_LEN, 0, NULL, 0);
+	TEST_ASSERT_EQUAL_INT(SENDTO_MSG_LEN, (int)n);
+
+	memset(buf, 0, sizeof(buf));
+	n = recv(test_common.sv[1], buf, sizeof(buf), 0);
+	TEST_ASSERT_EQUAL_INT(SENDTO_MSG_LEN, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY(SENDTO_MSG, buf, SENDTO_MSG_LEN);
+}
+
+
+TEST(socket_api_sendto, returns_bytes_sent)
+{
+	ssize_t n;
+
+	n = sendto(test_common.sv[0], SENDTO_MSG, SENDTO_MSG_LEN, 0, NULL, 0);
+	TEST_ASSERT_EQUAL_INT(SENDTO_MSG_LEN, (int)n);
+}
+
+
+TEST(socket_api_sendto, dgram_with_address)
+{
+	int recvFd = -1;
+	volatile int sendFd = -1;
+	int ret;
+	ssize_t n;
+	char buf[SENDTO_BUF_SZ];
+	struct sockaddr_un addr;
+
+	recvFd = socket(AF_UNIX, SOCK_DGRAM, 0);
+	TEST_ASSERT_TRUE(recvFd >= 0);
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	strncpy(addr.sun_path, SENDTO_SOCK_PATH, sizeof(addr.sun_path) - 1);
+
+	if (TEST_PROTECT()) {
+		ret = bind(recvFd, (struct sockaddr *)&addr, sizeof(addr));
+		TEST_ASSERT_EQUAL_INT(0, ret);
+
+		sendFd = socket(AF_UNIX, SOCK_DGRAM, 0);
+		TEST_ASSERT_TRUE(sendFd >= 0);
+
+		/* sendto with explicit destination address */
+		n = sendto(sendFd, SENDTO_MSG, SENDTO_MSG_LEN, 0,
+				(struct sockaddr *)&addr, sizeof(addr));
+		TEST_ASSERT_EQUAL_INT(SENDTO_MSG_LEN, (int)n);
+
+		memset(buf, 0, sizeof(buf));
+		n = recvfrom(recvFd, buf, sizeof(buf), 0, NULL, NULL);
+		TEST_ASSERT_EQUAL_INT(SENDTO_MSG_LEN, (int)n);
+		TEST_ASSERT_EQUAL_MEMORY(SENDTO_MSG, buf, SENDTO_MSG_LEN);
+	}
+	if (recvFd >= 0) {
+		close(recvFd);
+	}
+	if (sendFd >= 0) {
+		close(sendFd);
+	}
+}
+
+
+TEST(socket_api_sendto, connection_mode_ignores_dest_addr)
+{
+	ssize_t n;
+	char buf[SENDTO_BUF_SZ];
+	struct sockaddr_un addr;
+
+	/* For connection-mode socket, dest_addr shall be ignored */
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	strncpy(addr.sun_path, "/tmp/nonexistent_path", sizeof(addr.sun_path) - 1);
+
+/* Linux returns EISCONN instead of ignoring dest_addr on connected socket */
+#ifndef __phoenix__
+	TEST_IGNORE();
+#else
+	TEST_IGNORE_MESSAGE("#1640 issue");
+#endif
+	n = sendto(test_common.sv[0], SENDTO_MSG, SENDTO_MSG_LEN, 0,
+			(struct sockaddr *)&addr, sizeof(addr));
+	TEST_ASSERT_EQUAL_INT(SENDTO_MSG_LEN, (int)n);
+
+	memset(buf, 0, sizeof(buf));
+	n = recv(test_common.sv[1], buf, sizeof(buf), 0);
+	TEST_ASSERT_EQUAL_INT(SENDTO_MSG_LEN, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY(SENDTO_MSG, buf, SENDTO_MSG_LEN);
+}
+
+
+TEST(socket_api_sendto, ebadf_invalid_fd)
+{
+	ssize_t n;
+
+	errno = 0;
+	n = sendto(-1, SENDTO_MSG, SENDTO_MSG_LEN, 0, NULL, 0);
+	TEST_ASSERT_EQUAL_INT(-1, (int)n);
+	TEST_ASSERT_EQUAL_INT(EBADF, errno);
+}
+
+
+TEST(socket_api_sendto, enotsock_not_socket)
+{
+	ssize_t n;
+	int pipefd[2];
+	int ret;
+
+	ret = pipe(pipefd);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	if (TEST_PROTECT()) {
+		errno = 0;
+		n = sendto(pipefd[0], SENDTO_MSG, SENDTO_MSG_LEN, 0, NULL, 0);
+		TEST_ASSERT_EQUAL_INT(-1, (int)n);
+		TEST_ASSERT_EQUAL_INT(ENOTSOCK, errno);
+	}
+
+	close(pipefd[0]);
+	close(pipefd[1]);
+}
+
+
+TEST(socket_api_sendto, enotconn_stream_unconnected)
+{
+	ssize_t n;
+
+	test_common.fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(test_common.fd >= 0);
+
+	errno = 0;
+	n = sendto(test_common.fd, SENDTO_MSG, SENDTO_MSG_LEN, 0, NULL, 0);
+	TEST_ASSERT_EQUAL_INT(-1, (int)n);
+	TEST_ASSERT_EQUAL_INT(ENOTCONN, errno);
+}
+
+
+TEST(socket_api_sendto, epipe_after_shutdown_wr)
+{
+	ssize_t n;
+	int ret;
+
+	ret = shutdown(test_common.sv[0], SHUT_WR);
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1634 issue");
+#endif
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	errno = 0;
+	n = sendto(test_common.sv[0], SENDTO_MSG, SENDTO_MSG_LEN, MSG_NOSIGNAL, NULL, 0);
+	TEST_ASSERT_EQUAL_INT(-1, (int)n);
+	TEST_ASSERT_EQUAL_INT(EPIPE, errno);
+}
+
+
+TEST(socket_api_sendto, epipe_peer_closed)
+{
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1635 issue");
+#endif
+	ssize_t n;
+
+	close(test_common.sv[1]);
+	test_common.sv[1] = -1;
+
+	errno = 0;
+	n = sendto(test_common.sv[0], SENDTO_MSG, SENDTO_MSG_LEN, MSG_NOSIGNAL, NULL, 0);
+	TEST_ASSERT_EQUAL_INT(-1, (int)n);
+	TEST_ASSERT_EQUAL_INT(EPIPE, errno);
+}
+
+
+TEST(socket_api_sendto, ewouldblock_nonblocking)
+{
+	ssize_t n;
+	int ret;
+	int flags;
+	static char bigBuf[65536];
+
+	flags = fcntl(test_common.sv[0], F_GETFL);
+	TEST_ASSERT_TRUE(flags >= 0);
+
+	ret = fcntl(test_common.sv[0], F_SETFL, flags | O_NONBLOCK);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	memset(bigBuf, 'B', sizeof(bigBuf));
+	while (1) {
+		errno = 0;
+		n = sendto(test_common.sv[0], bigBuf, sizeof(bigBuf), MSG_NOSIGNAL, NULL, 0);
+		if (n == -1) {
+			TEST_ASSERT_TRUE(errno == EAGAIN || errno == EWOULDBLOCK);
+			break;
+		}
+	}
+}
+
+
+TEST(socket_api_sendto, enoent_unix_path_missing)
+{
+	ssize_t n;
+	struct sockaddr_un addr;
+
+	test_common.fd = socket(AF_UNIX, SOCK_DGRAM, 0);
+	TEST_ASSERT_TRUE(test_common.fd >= 0);
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	strncpy(addr.sun_path, "/tmp/nonexistent_sendto_path_xyz", sizeof(addr.sun_path) - 1);
+
+	errno = 0;
+	n = sendto(test_common.fd, SENDTO_MSG, SENDTO_MSG_LEN, 0,
+			(struct sockaddr *)&addr, sizeof(addr));
+	TEST_ASSERT_EQUAL_INT(-1, (int)n);
+	/* ENOENT or ECONNREFUSED depending on implementation */
+	TEST_ASSERT_TRUE(errno == ENOENT || errno == ECONNREFUSED);
+}
+
+
+TEST(socket_api_sendto, msg_nosignal_flag)
+{
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1635 issue");
+#endif
+	ssize_t n;
+
+	close(test_common.sv[1]);
+	test_common.sv[1] = -1;
+
+	/* MSG_NOSIGNAL prevents SIGPIPE, but EPIPE error is still returned */
+	errno = 0;
+	n = sendto(test_common.sv[0], SENDTO_MSG, SENDTO_MSG_LEN, MSG_NOSIGNAL, NULL, 0);
+	TEST_ASSERT_EQUAL_INT(-1, (int)n);
+	TEST_ASSERT_EQUAL_INT(EPIPE, errno);
+}
+
+
+TEST(socket_api_sendto, emsgsize_dgram_too_large)
+{
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1644");
+#endif
+	int *sv = test_common.sv;
+	int ret;
+	ssize_t n;
+	int sndbuf;
+	socklen_t optlen;
+	static char bigBuf[262144];
+
+	close(sv[0]);
+	close(sv[1]);
+
+	ret = socketpair(AF_UNIX, SOCK_DGRAM, 0, sv);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	optlen = sizeof(sndbuf);
+	ret = getsockopt(sv[0], SOL_SOCKET, SO_SNDBUF, &sndbuf, &optlen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	memset(bigBuf, 'Z', sizeof(bigBuf));
+	errno = 0;
+	n = sendto(sv[0], bigBuf, (size_t)sndbuf + 1U > sizeof(bigBuf) ? sizeof(bigBuf) : (size_t)sndbuf + 1U, 0, NULL, 0);
+	TEST_ASSERT_EQUAL_INT(-1, (int)n);
+	TEST_ASSERT_EQUAL_INT(EMSGSIZE, errno);
+}
+
+
+TEST_GROUP_RUNNER(socket_api_sendto)
+{
+	RUN_TEST_CASE(socket_api_sendto, basic_connected_stream);
+	RUN_TEST_CASE(socket_api_sendto, returns_bytes_sent);
+	RUN_TEST_CASE(socket_api_sendto, dgram_with_address);
+	RUN_TEST_CASE(socket_api_sendto, connection_mode_ignores_dest_addr);
+	RUN_TEST_CASE(socket_api_sendto, ebadf_invalid_fd);
+	RUN_TEST_CASE(socket_api_sendto, enotsock_not_socket);
+	RUN_TEST_CASE(socket_api_sendto, enotconn_stream_unconnected);
+	RUN_TEST_CASE(socket_api_sendto, epipe_after_shutdown_wr);
+	RUN_TEST_CASE(socket_api_sendto, epipe_peer_closed);
+	RUN_TEST_CASE(socket_api_sendto, ewouldblock_nonblocking);
+	RUN_TEST_CASE(socket_api_sendto, enoent_unix_path_missing);
+	RUN_TEST_CASE(socket_api_sendto, msg_nosignal_flag);
+	RUN_TEST_CASE(socket_api_sendto, emsgsize_dgram_too_large);
+}

--- a/libc/socket/setsockopt.c
+++ b/libc/socket/setsockopt.c
@@ -1,0 +1,563 @@
+/*
+ * Phoenix-RTOS
+ *
+ * POSIX.1-2017 standard library functions tests
+ * HEADER:
+ *    - <sys/socket.h>
+ * TESTED:
+ *    - setsockopt()
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Lukasz Kruszynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <fcntl.h>
+
+#include "unity_fixture.h"
+
+TEST_GROUP(socket_api_setsockopt);
+
+static int fd;
+
+TEST_SETUP(socket_api_setsockopt)
+{
+	fd = -1;
+}
+
+TEST_TEAR_DOWN(socket_api_setsockopt)
+{
+	if (fd >= 0) {
+		close(fd);
+		fd = -1;
+	}
+}
+
+
+TEST(socket_api_setsockopt, so_reuseaddr)
+{
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1644");
+#endif
+	int ret;
+	int optval;
+	socklen_t optlen;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	optval = 1;
+	ret = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Verify the option was set */
+	optval = 0;
+	optlen = sizeof(optval);
+	ret = getsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &optval, &optlen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_NOT_EQUAL_INT(0, optval);
+}
+
+
+TEST(socket_api_setsockopt, so_keepalive)
+{
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1644");
+#endif
+	int ret;
+	int optval;
+	socklen_t optlen;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	optval = 1;
+	ret = setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &optval, sizeof(optval));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	optval = 0;
+	optlen = sizeof(optval);
+	ret = getsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &optval, &optlen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_NOT_EQUAL_INT(0, optval);
+}
+
+
+TEST(socket_api_setsockopt, so_rcvbuf)
+{
+	int ret;
+	int optval;
+	socklen_t optlen;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	optval = 4096;
+	ret = setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &optval, sizeof(optval));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Kernel may double the value, but it should be at least what we set */
+	optval = 0;
+	optlen = sizeof(optval);
+	ret = getsockopt(fd, SOL_SOCKET, SO_RCVBUF, &optval, &optlen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_TRUE(optval >= 4096);
+}
+
+
+TEST(socket_api_setsockopt, so_sndbuf)
+{
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1644");
+#endif
+	int ret;
+	int optval;
+	socklen_t optlen;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	optval = 4096;
+	ret = setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &optval, sizeof(optval));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	optval = 0;
+	optlen = sizeof(optval);
+	ret = getsockopt(fd, SOL_SOCKET, SO_SNDBUF, &optval, &optlen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_TRUE(optval >= 4096);
+}
+
+
+TEST(socket_api_setsockopt, so_rcvtimeo)
+{
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1644");
+#endif
+	int ret;
+	struct timeval tv;
+	struct timeval tvOut;
+	socklen_t optlen;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	tv.tv_sec = 2;
+	tv.tv_usec = 500000;
+	ret = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	memset(&tvOut, 0, sizeof(tvOut));
+	optlen = sizeof(tvOut);
+	ret = getsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tvOut, &optlen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	/* Value may be rounded up but should be at least what was set */
+	TEST_ASSERT_TRUE(tvOut.tv_sec >= 2);
+}
+
+
+TEST(socket_api_setsockopt, so_sndtimeo)
+{
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1644");
+#endif
+	int ret;
+	struct timeval tv;
+	struct timeval tvOut;
+	socklen_t optlen;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	tv.tv_sec = 3;
+	tv.tv_usec = 0;
+	ret = setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	memset(&tvOut, 0, sizeof(tvOut));
+	optlen = sizeof(tvOut);
+	ret = getsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tvOut, &optlen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_TRUE(tvOut.tv_sec >= 3);
+}
+
+
+TEST(socket_api_setsockopt, so_broadcast)
+{
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1644");
+#endif
+	int ret;
+	int optval;
+	socklen_t optlen;
+
+	fd = socket(AF_INET, SOCK_DGRAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	optval = 1;
+	ret = setsockopt(fd, SOL_SOCKET, SO_BROADCAST, &optval, sizeof(optval));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	optval = 0;
+	optlen = sizeof(optval);
+	ret = getsockopt(fd, SOL_SOCKET, SO_BROADCAST, &optval, &optlen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_NOT_EQUAL_INT(0, optval);
+}
+
+
+TEST(socket_api_setsockopt, return_zero_on_success)
+{
+	int ret;
+	int optval;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	optval = 4096;
+	ret = setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &optval, sizeof(optval));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+
+TEST(socket_api_setsockopt, ebadf_invalid_fd)
+{
+	int ret;
+	int optval;
+
+	optval = 1;
+	errno = 0;
+	ret = setsockopt(-1, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_EQUAL_INT(EBADF, errno);
+}
+
+
+TEST(socket_api_setsockopt, enotsock_not_socket)
+{
+	int ret;
+	int optval;
+	int pipefd[2];
+
+	ret = pipe(pipefd);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	optval = 1;
+	errno = 0;
+	if (TEST_PROTECT()) {
+		ret = setsockopt(pipefd[0], SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
+		TEST_ASSERT_EQUAL_INT(-1, ret);
+		TEST_ASSERT_EQUAL_INT(ENOTSOCK, errno);
+	}
+	close(pipefd[0]);
+	close(pipefd[1]);
+}
+
+
+TEST(socket_api_setsockopt, enoprotoopt_invalid_option)
+{
+	int ret;
+	int optval;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	optval = 1;
+	errno = 0;
+	ret = setsockopt(fd, SOL_SOCKET, -1, &optval, sizeof(optval));
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_EQUAL_INT(ENOPROTOOPT, errno);
+}
+
+
+TEST(socket_api_setsockopt, einval_after_shutdown)
+{
+	int sv[2];
+	int ret;
+	int optval;
+
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1634 issue");
+#endif
+
+	if (TEST_PROTECT()) {
+		ret = socketpair(AF_UNIX, SOCK_STREAM, 0, sv);
+		TEST_ASSERT_EQUAL_INT(0, ret);
+
+		ret = shutdown(sv[0], SHUT_RDWR);
+		TEST_ASSERT_EQUAL_INT(0, ret);
+
+		/* Setting option on shut down socket - EINVAL: "the socket has been shut down" */
+		optval = 1;
+		errno = 0;
+		ret = setsockopt(sv[0], SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
+		/* Some implementations allow this; only check if it returns error */
+		if (ret == -1) {
+			TEST_ASSERT_EQUAL_INT(EINVAL, errno);
+		}
+	}
+
+	close(sv[0]);
+	close(sv[1]);
+}
+
+
+TEST(socket_api_setsockopt, disable_option)
+{
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1644");
+#endif
+	int ret;
+	int optval;
+	socklen_t optlen;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	/* Enable */
+	optval = 1;
+	ret = setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &optval, sizeof(optval));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Disable */
+	optval = 0;
+	ret = setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &optval, sizeof(optval));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Verify disabled */
+	optval = 1;
+	optlen = sizeof(optval);
+	ret = getsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &optval, &optlen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_EQUAL_INT(0, optval);
+}
+
+
+TEST(socket_api_setsockopt, so_linger)
+{
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1644");
+#endif
+	int ret;
+	struct linger lin;
+	struct linger linOut;
+	socklen_t optlen;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	lin.l_onoff = 1;
+	lin.l_linger = 5;
+	ret = setsockopt(fd, SOL_SOCKET, SO_LINGER, &lin, sizeof(lin));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	memset(&linOut, 0, sizeof(linOut));
+	optlen = sizeof(linOut);
+	ret = getsockopt(fd, SOL_SOCKET, SO_LINGER, &linOut, &optlen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_NOT_EQUAL_INT(0, linOut.l_onoff);
+	TEST_ASSERT_EQUAL_INT(5, linOut.l_linger);
+}
+
+
+TEST(socket_api_setsockopt, readonly_so_error)
+{
+	int ret;
+	int optval;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	/* SO_ERROR is read-only; setting it should fail */
+	optval = 0;
+	errno = 0;
+	ret = setsockopt(fd, SOL_SOCKET, SO_ERROR, &optval, sizeof(optval));
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_TRUE(errno == ENOPROTOOPT || errno == EINVAL);
+}
+
+
+TEST(socket_api_setsockopt, readonly_so_type)
+{
+	int ret;
+	int optval;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	/* SO_TYPE is read-only; setting it should fail */
+	optval = SOCK_STREAM;
+	errno = 0;
+	ret = setsockopt(fd, SOL_SOCKET, SO_TYPE, &optval, sizeof(optval));
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_TRUE(errno == ENOPROTOOPT || errno == EINVAL);
+}
+
+
+TEST(socket_api_setsockopt, einval_short_optlen)
+{
+	int ret;
+	int optval;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	/* Passing optlen too small for the option */
+	optval = 1;
+	errno = 0;
+	ret = setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &optval, 0);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	/* POSIX does not mandate a specific errno for invalid optlen */
+	TEST_ASSERT_TRUE(errno == EINVAL || errno == ENOENT || errno == ENOPROTOOPT);
+}
+
+
+TEST(socket_api_setsockopt, readonly_so_acceptconn)
+{
+	int ret;
+	int optval;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	/* SO_ACCEPTCONN is read-only; setting it should fail */
+	optval = 1;
+	errno = 0;
+	ret = setsockopt(fd, SOL_SOCKET, SO_ACCEPTCONN, &optval, sizeof(optval));
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_TRUE(errno == ENOPROTOOPT || errno == EINVAL);
+}
+
+
+TEST(socket_api_setsockopt, so_dontroute)
+{
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1644");
+#endif
+	int ret;
+	int optval;
+	socklen_t optlen;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	optval = 1;
+	ret = setsockopt(fd, SOL_SOCKET, SO_DONTROUTE, &optval, sizeof(optval));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	optval = 0;
+	optlen = sizeof(optval);
+	ret = getsockopt(fd, SOL_SOCKET, SO_DONTROUTE, &optval, &optlen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_NOT_EQUAL_INT(0, optval);
+}
+
+
+TEST(socket_api_setsockopt, so_oobinline)
+{
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1644");
+#endif
+	int ret;
+	int optval;
+	socklen_t optlen;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	optval = 1;
+	ret = setsockopt(fd, SOL_SOCKET, SO_OOBINLINE, &optval, sizeof(optval));
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	optval = 0;
+	optlen = sizeof(optval);
+	ret = getsockopt(fd, SOL_SOCKET, SO_OOBINLINE, &optval, &optlen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_NOT_EQUAL_INT(0, optval);
+}
+
+
+TEST(socket_api_setsockopt, so_rcvlowat)
+{
+	int ret;
+	int optval;
+	socklen_t optlen;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	optval = 128;
+	ret = setsockopt(fd, SOL_SOCKET, SO_RCVLOWAT, &optval, sizeof(optval));
+	if (ret == -1) {
+		/* Some implementations don't support setting SO_RCVLOWAT */
+		TEST_ASSERT_TRUE(errno == ENOPROTOOPT || errno == EINVAL);
+	}
+	else {
+		optval = 0;
+		optlen = sizeof(optval);
+		ret = getsockopt(fd, SOL_SOCKET, SO_RCVLOWAT, &optval, &optlen);
+		TEST_ASSERT_EQUAL_INT(0, ret);
+		TEST_ASSERT_TRUE(optval >= 1);
+	}
+}
+
+
+TEST(socket_api_setsockopt, so_sndlowat)
+{
+	int ret;
+	int optval;
+	socklen_t optlen;
+
+	fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	optval = 512;
+	errno = 0;
+	ret = setsockopt(fd, SOL_SOCKET, SO_SNDLOWAT, &optval, sizeof(optval));
+	if (ret == -1) {
+		/* Linux does not allow setting SO_SNDLOWAT (ENOPROTOOPT) */
+		TEST_ASSERT_TRUE(errno == ENOPROTOOPT || errno == EINVAL);
+	}
+	else {
+		optval = 0;
+		optlen = sizeof(optval);
+		ret = getsockopt(fd, SOL_SOCKET, SO_SNDLOWAT, &optval, &optlen);
+		TEST_ASSERT_EQUAL_INT(0, ret);
+		TEST_ASSERT_TRUE(optval >= 1);
+	}
+}
+
+
+TEST_GROUP_RUNNER(socket_api_setsockopt)
+{
+	RUN_TEST_CASE(socket_api_setsockopt, so_reuseaddr);
+	RUN_TEST_CASE(socket_api_setsockopt, so_keepalive);
+	RUN_TEST_CASE(socket_api_setsockopt, so_rcvbuf);
+	RUN_TEST_CASE(socket_api_setsockopt, so_sndbuf);
+	RUN_TEST_CASE(socket_api_setsockopt, so_rcvtimeo);
+	RUN_TEST_CASE(socket_api_setsockopt, so_sndtimeo);
+	RUN_TEST_CASE(socket_api_setsockopt, so_broadcast);
+	RUN_TEST_CASE(socket_api_setsockopt, return_zero_on_success);
+	RUN_TEST_CASE(socket_api_setsockopt, ebadf_invalid_fd);
+	RUN_TEST_CASE(socket_api_setsockopt, enotsock_not_socket);
+	RUN_TEST_CASE(socket_api_setsockopt, enoprotoopt_invalid_option);
+	RUN_TEST_CASE(socket_api_setsockopt, einval_after_shutdown);
+	RUN_TEST_CASE(socket_api_setsockopt, disable_option);
+	RUN_TEST_CASE(socket_api_setsockopt, so_linger);
+	RUN_TEST_CASE(socket_api_setsockopt, readonly_so_error);
+	RUN_TEST_CASE(socket_api_setsockopt, readonly_so_type);
+	RUN_TEST_CASE(socket_api_setsockopt, einval_short_optlen);
+	RUN_TEST_CASE(socket_api_setsockopt, readonly_so_acceptconn);
+	RUN_TEST_CASE(socket_api_setsockopt, so_dontroute);
+	RUN_TEST_CASE(socket_api_setsockopt, so_oobinline);
+	RUN_TEST_CASE(socket_api_setsockopt, so_rcvlowat);
+	RUN_TEST_CASE(socket_api_setsockopt, so_sndlowat);
+}

--- a/libc/socket/shutdown.c
+++ b/libc/socket/shutdown.c
@@ -1,0 +1,346 @@
+/*
+ * Phoenix-RTOS
+ *
+ * POSIX.1-2017 standard library functions tests
+ * HEADER:
+ *    - <sys/socket.h>
+ * TESTED:
+ *    - shutdown()
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Lukasz Kruszynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <sys/socket.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <fcntl.h>
+
+#include "unity_fixture.h"
+
+#define SHUTDOWN_MSG     "test"
+#define SHUTDOWN_MSG_LEN 4
+#define SHUTDOWN_BUF_SZ  32
+
+TEST_GROUP(socket_api_shutdown);
+
+static struct {
+	int sv[2];
+	int fd;
+} test_common;
+
+TEST_SETUP(socket_api_shutdown)
+{
+	test_common.sv[0] = -1;
+	test_common.sv[1] = -1;
+}
+
+TEST_TEAR_DOWN(socket_api_shutdown)
+{
+	if (test_common.sv[0] >= 0) {
+		close(test_common.sv[0]);
+		test_common.sv[0] = -1;
+	}
+	if (test_common.sv[1] >= 0) {
+		close(test_common.sv[1]);
+		test_common.sv[1] = -1;
+	}
+	if (test_common.fd >= 0) {
+		close(test_common.fd);
+		test_common.fd = -1;
+	}
+}
+
+
+TEST(socket_api_shutdown, shut_rd_disables_recv)
+{
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1634 issue");
+#endif
+	int *sv = test_common.sv;
+	int ret;
+	ssize_t n;
+	char buf[SHUTDOWN_BUF_SZ];
+
+	ret = socketpair(AF_UNIX, SOCK_STREAM, 0, sv);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	ret = shutdown(sv[0], SHUT_RD);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Reading from a socket after SHUT_RD should return 0 (EOF) */
+	n = recv(sv[0], buf, sizeof(buf), 0);
+	TEST_ASSERT_EQUAL_INT(0, (int)n);
+}
+
+
+TEST(socket_api_shutdown, shut_wr_disables_send)
+{
+	int *sv = test_common.sv;
+	int ret;
+	ssize_t n;
+
+	ret = socketpair(AF_UNIX, SOCK_STREAM, 0, sv);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	ret = shutdown(sv[0], SHUT_WR);
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1634 issue");
+#endif
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Writing to a socket after SHUT_WR should fail with EPIPE */
+	errno = 0;
+	n = send(sv[0], SHUTDOWN_MSG, SHUTDOWN_MSG_LEN, MSG_NOSIGNAL);
+	TEST_ASSERT_EQUAL_INT(-1, (int)n);
+	TEST_ASSERT_EQUAL_INT(EPIPE, errno);
+}
+
+
+TEST(socket_api_shutdown, shut_rdwr_disables_both)
+{
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1634 issue");
+#endif
+	int *sv = test_common.sv;
+	int ret;
+	ssize_t n;
+	char buf[SHUTDOWN_BUF_SZ];
+
+	ret = socketpair(AF_UNIX, SOCK_STREAM, 0, sv);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	ret = shutdown(sv[0], SHUT_RDWR);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Read should return 0 (EOF) */
+	n = recv(sv[0], buf, sizeof(buf), 0);
+	TEST_ASSERT_EQUAL_INT(0, (int)n);
+
+	/* Write should fail with EPIPE */
+	errno = 0;
+	n = send(sv[0], SHUTDOWN_MSG, SHUTDOWN_MSG_LEN, MSG_NOSIGNAL);
+	TEST_ASSERT_EQUAL_INT(-1, (int)n);
+	TEST_ASSERT_EQUAL_INT(EPIPE, errno);
+}
+
+
+TEST(socket_api_shutdown, shut_wr_peer_reads_eof)
+{
+	int *sv = test_common.sv;
+	int ret;
+	ssize_t n;
+	char buf[SHUTDOWN_BUF_SZ];
+
+	ret = socketpair(AF_UNIX, SOCK_STREAM, 0, sv);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Send data, then shutdown write end */
+	n = send(sv[0], SHUTDOWN_MSG, SHUTDOWN_MSG_LEN, 0);
+	TEST_ASSERT_EQUAL_INT(SHUTDOWN_MSG_LEN, (int)n);
+
+	ret = shutdown(sv[0], SHUT_WR);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Peer should be able to read pending data */
+	memset(buf, 0, sizeof(buf));
+	n = recv(sv[1], buf, sizeof(buf), 0);
+	TEST_ASSERT_EQUAL_INT(SHUTDOWN_MSG_LEN, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY(SHUTDOWN_MSG, buf, SHUTDOWN_MSG_LEN);
+
+	/* Next read should return EOF */
+	n = recv(sv[1], buf, sizeof(buf), 0);
+	TEST_ASSERT_EQUAL_INT(0, (int)n);
+}
+
+
+TEST(socket_api_shutdown, return_zero_on_success)
+{
+	int *sv = test_common.sv;
+	int ret;
+
+	ret = socketpair(AF_UNIX, SOCK_STREAM, 0, sv);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	ret = shutdown(sv[0], SHUT_RD);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+
+TEST(socket_api_shutdown, ebadf_invalid_fd)
+{
+	int ret;
+
+	errno = 0;
+	ret = shutdown(-1, SHUT_RDWR);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_EQUAL_INT(EBADF, errno);
+}
+
+
+TEST(socket_api_shutdown, ebadf_closed_fd)
+{
+	int *sv = test_common.sv;
+	int ret;
+
+	ret = socketpair(AF_UNIX, SOCK_STREAM, 0, sv);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	close(sv[0]);
+
+	errno = 0;
+	ret = shutdown(sv[0], SHUT_RDWR);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_EQUAL_INT(EBADF, errno);
+}
+
+
+TEST(socket_api_shutdown, einval_invalid_how)
+{
+	int *sv = test_common.sv;
+	int ret;
+
+	ret = socketpair(AF_UNIX, SOCK_STREAM, 0, sv);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	errno = 0;
+	ret = shutdown(sv[0], 42);
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1634 issue");
+#endif
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_EQUAL_INT(EINVAL, errno);
+}
+
+
+TEST(socket_api_shutdown, enotsock_not_socket)
+{
+	int fd;
+	int ret;
+	int pipefd[2];
+
+	ret = pipe(pipefd);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	if (TEST_PROTECT()) {
+		fd = pipefd[0];
+
+		errno = 0;
+		ret = shutdown(fd, SHUT_RDWR);
+		TEST_ASSERT_EQUAL_INT(-1, ret);
+		TEST_ASSERT_EQUAL_INT(ENOTSOCK, errno);
+	}
+	close(pipefd[0]);
+	close(pipefd[1]);
+}
+
+
+TEST(socket_api_shutdown, enotconn_unconnected)
+{
+	int ret;
+
+	test_common.fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(test_common.fd >= 0);
+
+	errno = 0;
+	ret = shutdown(test_common.fd, SHUT_RDWR);
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1634 issue");
+#else
+	TEST_IGNORE_MESSAGE("Linux allows shutdown on unconnected AF_UNIX socket");
+#endif
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_EQUAL_INT(ENOTCONN, errno);
+}
+
+
+TEST(socket_api_shutdown, shut_rd_peer_can_still_send)
+{
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1634 issue");
+#endif
+	int *sv = test_common.sv;
+	int ret;
+	ssize_t n;
+	char buf[SHUTDOWN_BUF_SZ];
+
+	ret = socketpair(AF_UNIX, SOCK_STREAM, 0, sv);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Shut down read on sv[0], peer sv[1] should still be able to write
+	 * (the data just won't be delivered to sv[0]) */
+	ret = shutdown(sv[0], SHUT_RD);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* sv[1] can still send (peer write direction is not affected) */
+	n = send(sv[1], SHUTDOWN_MSG, SHUTDOWN_MSG_LEN, MSG_NOSIGNAL);
+	/* On some implementations this may fail with EPIPE since receiver shut down reads,
+	 * but POSIX says SHUT_RD disables receive operations - send may still succeed */
+	(void)n;
+
+	/* sv[1] can still receive from sv[0] if sv[0] hasn't shut down write */
+	n = send(sv[0], SHUTDOWN_MSG, SHUTDOWN_MSG_LEN, MSG_NOSIGNAL);
+	TEST_ASSERT_EQUAL_INT(SHUTDOWN_MSG_LEN, (int)n);
+
+	memset(buf, 0, sizeof(buf));
+	n = recv(sv[1], buf, sizeof(buf), 0);
+	TEST_ASSERT_EQUAL_INT(SHUTDOWN_MSG_LEN, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY(SHUTDOWN_MSG, buf, SHUTDOWN_MSG_LEN);
+}
+
+
+TEST(socket_api_shutdown, dgram_shutdown_rdwr)
+{
+	int *sv = test_common.sv;
+	int ret;
+	ssize_t n;
+	char buf[SHUTDOWN_BUF_SZ];
+
+	close(sv[0]);
+	close(sv[1]);
+	ret = socketpair(AF_UNIX, SOCK_DGRAM, 0, sv);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Verify communication works before shutdown */
+	n = send(sv[0], SHUTDOWN_MSG, SHUTDOWN_MSG_LEN, 0);
+	TEST_ASSERT_EQUAL_INT(SHUTDOWN_MSG_LEN, (int)n);
+
+	memset(buf, 0, sizeof(buf));
+	n = recv(sv[1], buf, sizeof(buf), 0);
+	TEST_ASSERT_EQUAL_INT(SHUTDOWN_MSG_LEN, (int)n);
+
+	/* Shutdown SOCK_DGRAM for both read and write */
+	ret = shutdown(sv[0], SHUT_RDWR);
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1634 issue");
+#endif
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Sending on shutdown socket should fail */
+	errno = 0;
+	n = send(sv[0], SHUTDOWN_MSG, SHUTDOWN_MSG_LEN, MSG_NOSIGNAL);
+	TEST_ASSERT_EQUAL_INT(-1, (int)n);
+	TEST_ASSERT_EQUAL_INT(EPIPE, errno);
+}
+
+
+TEST_GROUP_RUNNER(socket_api_shutdown)
+{
+	RUN_TEST_CASE(socket_api_shutdown, shut_rd_disables_recv);
+	RUN_TEST_CASE(socket_api_shutdown, shut_wr_disables_send);
+	RUN_TEST_CASE(socket_api_shutdown, shut_rdwr_disables_both);
+	RUN_TEST_CASE(socket_api_shutdown, shut_wr_peer_reads_eof);
+	RUN_TEST_CASE(socket_api_shutdown, return_zero_on_success);
+	RUN_TEST_CASE(socket_api_shutdown, ebadf_invalid_fd);
+	RUN_TEST_CASE(socket_api_shutdown, ebadf_closed_fd);
+	RUN_TEST_CASE(socket_api_shutdown, einval_invalid_how);
+	RUN_TEST_CASE(socket_api_shutdown, enotsock_not_socket);
+	RUN_TEST_CASE(socket_api_shutdown, enotconn_unconnected);
+	RUN_TEST_CASE(socket_api_shutdown, shut_rd_peer_can_still_send);
+	RUN_TEST_CASE(socket_api_shutdown, dgram_shutdown_rdwr);
+}

--- a/libc/socket/sockatmark.c
+++ b/libc/socket/sockatmark.c
@@ -1,0 +1,127 @@
+/*
+ * Phoenix-RTOS
+ *
+ * POSIX.1-2017 standard library functions tests
+ * HEADER:
+ *    - <sys/socket.h>
+ * TESTED:
+ *    - sockatmark()
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Damian Loewnau
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+
+#include "unity_fixture.h"
+
+TEST_GROUP(socket_api_sockatmark);
+
+static int testSock;
+
+TEST_SETUP(socket_api_sockatmark)
+{
+	testSock = -1;
+}
+
+TEST_TEAR_DOWN(socket_api_sockatmark)
+{
+	if (testSock >= 0) {
+		close(testSock);
+		testSock = -1;
+	}
+}
+
+
+TEST(socket_api_sockatmark, sockatmark_not_at_mark)
+{
+
+	testSock = socket(AF_INET, SOCK_STREAM, 0);
+	TEST_ASSERT_TRUE(testSock >= 0);
+
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("sockatmark is not implemented");
+#else
+	int ret;
+
+	/* On a freshly created socket with no OOB data, sockatmark should return 0 */
+	ret = sockatmark(testSock);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+#endif
+}
+
+
+TEST(socket_api_sockatmark, sockatmark_ebadf)
+{
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("sockatmark is not implemented");
+#else
+	int ret;
+
+	errno = 0;
+	ret = sockatmark(-1);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_EQUAL_INT(EBADF, errno);
+#endif
+}
+
+
+TEST(socket_api_sockatmark, sockatmark_enotty_not_socket)
+{
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("sockatmark is not implemented");
+#else
+	int ret;
+	int fd;
+
+	fd = open("/dev/null", O_RDONLY);
+	TEST_ASSERT_TRUE(fd >= 0);
+
+	if (TEST_PROTECT()) {
+		errno = 0;
+		ret = sockatmark(fd);
+		TEST_ASSERT_EQUAL_INT(-1, ret);
+		/* POSIX specifies ENOTTY when fd is not a socket */
+		TEST_ASSERT_EQUAL_INT(ENOTTY, errno);
+	}
+	close(fd);
+#endif
+}
+
+
+TEST(socket_api_sockatmark, sockatmark_udp_socket)
+{
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("sockatmark is not implemented");
+#else
+	int ret;
+
+	/* UDP doesn't support OOB; sockatmark should still not crash */
+	testSock = socket(AF_INET, SOCK_DGRAM, 0);
+	TEST_ASSERT_TRUE(testSock >= 0);
+
+	ret = sockatmark(testSock);
+	/* Implementation-defined for non-stream sockets, just verify no crash */
+	TEST_ASSERT_TRUE(ret == 0 || ret == -1);
+#endif
+}
+
+
+TEST_GROUP_RUNNER(socket_api_sockatmark)
+{
+	RUN_TEST_CASE(socket_api_sockatmark, sockatmark_not_at_mark);
+	RUN_TEST_CASE(socket_api_sockatmark, sockatmark_ebadf);
+	RUN_TEST_CASE(socket_api_sockatmark, sockatmark_enotty_not_socket);
+	RUN_TEST_CASE(socket_api_sockatmark, sockatmark_udp_socket);
+}

--- a/libc/socket/socketpair.c
+++ b/libc/socket/socketpair.c
@@ -1,0 +1,348 @@
+/*
+ * Phoenix-RTOS
+ *
+ * POSIX.1-2017 standard library functions tests
+ * HEADER:
+ *    - <sys/socket.h>
+ * TESTED:
+ *    - socketpair()
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Lukasz Kruszynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <sys/socket.h>
+#include <sys/resource.h>
+#include <unistd.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+
+#include "unity_fixture.h"
+
+#define SOCKETPAIR_MSG     "hello"
+#define SOCKETPAIR_MSG_LEN 5
+#define SOCKETPAIR_BUF_SZ  32
+
+TEST_GROUP(socket_api_socketpair);
+
+static struct {
+	struct rlimit oldrl;
+	int rlimit_changed;
+	int sv[2];
+} test_common;
+
+TEST_SETUP(socket_api_socketpair)
+{
+	test_common.rlimit_changed = 0;
+	test_common.sv[0] = -1;
+	test_common.sv[1] = -1;
+}
+
+TEST_TEAR_DOWN(socket_api_socketpair)
+{
+	if (test_common.rlimit_changed) {
+		setrlimit(RLIMIT_NOFILE, &test_common.oldrl);
+		test_common.rlimit_changed = 0;
+	}
+	if (test_common.sv[0] >= 0) {
+		close(test_common.sv[0]);
+		test_common.sv[0] = -1;
+	}
+	if (test_common.sv[1] >= 0) {
+		close(test_common.sv[1]);
+		test_common.sv[1] = -1;
+	}
+}
+
+
+TEST(socket_api_socketpair, stream_success)
+{
+	int *sv = test_common.sv;
+	int ret;
+
+	ret = socketpair(AF_UNIX, SOCK_STREAM, 0, sv);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_TRUE(sv[0] >= 0);
+	TEST_ASSERT_TRUE(sv[1] >= 0);
+	TEST_ASSERT_NOT_EQUAL_INT(sv[0], sv[1]);
+}
+
+
+TEST(socket_api_socketpair, dgram_success)
+{
+	int *sv = test_common.sv;
+	int ret;
+
+	ret = socketpair(AF_UNIX, SOCK_DGRAM, 0, sv);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_TRUE(sv[0] >= 0);
+	TEST_ASSERT_TRUE(sv[1] >= 0);
+	TEST_ASSERT_NOT_EQUAL_INT(sv[0], sv[1]);
+}
+
+
+TEST(socket_api_socketpair, bidirectional_stream)
+{
+	int *sv = test_common.sv;
+	int ret;
+	ssize_t n;
+	char buf[SOCKETPAIR_BUF_SZ];
+
+	ret = socketpair(AF_UNIX, SOCK_STREAM, 0, sv);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* sv[0] -> sv[1] */
+	n = write(sv[0], SOCKETPAIR_MSG, SOCKETPAIR_MSG_LEN);
+	TEST_ASSERT_EQUAL_INT(SOCKETPAIR_MSG_LEN, (int)n);
+
+	memset(buf, 0, sizeof(buf));
+	n = read(sv[1], buf, sizeof(buf));
+	TEST_ASSERT_EQUAL_INT(SOCKETPAIR_MSG_LEN, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY(SOCKETPAIR_MSG, buf, SOCKETPAIR_MSG_LEN);
+
+	/* sv[1] -> sv[0] */
+	n = write(sv[1], SOCKETPAIR_MSG, SOCKETPAIR_MSG_LEN);
+	TEST_ASSERT_EQUAL_INT(SOCKETPAIR_MSG_LEN, (int)n);
+
+	memset(buf, 0, sizeof(buf));
+	n = read(sv[0], buf, sizeof(buf));
+	TEST_ASSERT_EQUAL_INT(SOCKETPAIR_MSG_LEN, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY(SOCKETPAIR_MSG, buf, SOCKETPAIR_MSG_LEN);
+}
+
+
+TEST(socket_api_socketpair, bidirectional_dgram)
+{
+	int *sv = test_common.sv;
+	int ret;
+	ssize_t n;
+	char buf[SOCKETPAIR_BUF_SZ];
+
+	ret = socketpair(AF_UNIX, SOCK_DGRAM, 0, sv);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* sv[0] -> sv[1] */
+	n = write(sv[0], SOCKETPAIR_MSG, SOCKETPAIR_MSG_LEN);
+	TEST_ASSERT_EQUAL_INT(SOCKETPAIR_MSG_LEN, (int)n);
+
+	memset(buf, 0, sizeof(buf));
+	n = read(sv[1], buf, sizeof(buf));
+	TEST_ASSERT_EQUAL_INT(SOCKETPAIR_MSG_LEN, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY(SOCKETPAIR_MSG, buf, SOCKETPAIR_MSG_LEN);
+
+	/* sv[1] -> sv[0] */
+	n = write(sv[1], SOCKETPAIR_MSG, SOCKETPAIR_MSG_LEN);
+	TEST_ASSERT_EQUAL_INT(SOCKETPAIR_MSG_LEN, (int)n);
+
+	memset(buf, 0, sizeof(buf));
+	n = read(sv[0], buf, sizeof(buf));
+	TEST_ASSERT_EQUAL_INT(SOCKETPAIR_MSG_LEN, (int)n);
+	TEST_ASSERT_EQUAL_MEMORY(SOCKETPAIR_MSG, buf, SOCKETPAIR_MSG_LEN);
+}
+
+
+TEST(socket_api_socketpair, fd_allocation)
+{
+	/* File descriptors shall be allocated as described in File Descriptor Allocation
+	 * (lowest available) */
+	int *sv = test_common.sv;
+	int ret;
+	int lowFd;
+
+	/* Create a socket pair, close sv[0], then create again - new fd should reuse freed slot */
+	ret = socketpair(AF_UNIX, SOCK_STREAM, 0, sv);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	lowFd = (sv[0] < sv[1]) ? sv[0] : sv[1];
+	close(sv[0]);
+	close(sv[1]);
+
+	/* After closing both, creating a new pair should allocate fds starting from lowFd or lower */
+	ret = socketpair(AF_UNIX, SOCK_STREAM, 0, sv);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_TRUE(sv[0] <= lowFd || sv[1] <= lowFd);
+}
+
+
+TEST(socket_api_socketpair, eafnosupport_invalid_domain)
+{
+	int *sv = test_common.sv;
+	int ret;
+
+	errno = 0;
+	ret = socketpair(-1, SOCK_STREAM, 0, sv);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_EQUAL_INT(EAFNOSUPPORT, errno);
+}
+
+
+TEST(socket_api_socketpair, eprotonosupport_invalid_protocol)
+{
+	int *sv = test_common.sv;
+	int ret;
+
+	errno = 0;
+	ret = socketpair(AF_UNIX, SOCK_STREAM, 9999, sv);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	TEST_ASSERT_EQUAL_INT(EPROTONOSUPPORT, errno);
+}
+
+
+TEST(socket_api_socketpair, eopnotsupp_inet)
+{
+	int *sv = test_common.sv;
+	int ret;
+
+	/* AF_INET does not support socketpair */
+	errno = 0;
+	ret = socketpair(AF_INET, SOCK_STREAM, 0, sv);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	/* May return EAFNOSUPPORT or EOPNOTSUPP depending on implementation */
+	TEST_ASSERT_TRUE(errno == EOPNOTSUPP || errno == EAFNOSUPPORT);
+}
+
+
+TEST(socket_api_socketpair, eprototype_invalid_type)
+{
+	int *sv = test_common.sv;
+	int ret;
+
+	errno = 0;
+	ret = socketpair(AF_UNIX, -1, 0, sv);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+	/* EPROTOTYPE: socket type not supported by protocol */
+	TEST_ASSERT_TRUE(errno == EPROTOTYPE || errno == EINVAL);
+}
+
+
+TEST(socket_api_socketpair, vector_unmodified_on_error)
+{
+	int *sv = test_common.sv;
+	int ret;
+
+	sv[0] = -42;
+	sv[1] = -42;
+
+	ret = socketpair(-1, SOCK_STREAM, 0, sv);
+	TEST_ASSERT_EQUAL_INT(-1, ret);
+
+/* Linux kernel may modify socket_vector before detecting error */
+#ifndef __phoenix__
+	TEST_IGNORE();
+#endif
+	TEST_ASSERT_EQUAL_INT(-42, sv[0]);
+	TEST_ASSERT_EQUAL_INT(-42, sv[1]);
+}
+
+
+TEST(socket_api_socketpair, seqpacket_success)
+{
+	int *sv = test_common.sv;
+	int ret;
+
+	ret = socketpair(AF_UNIX, SOCK_SEQPACKET, 0, sv);
+	if (ret == -1 && errno == EPROTONOSUPPORT) {
+		TEST_IGNORE_MESSAGE("SOCK_SEQPACKET not supported on this platform");
+	}
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_TRUE(sv[0] >= 0);
+	TEST_ASSERT_TRUE(sv[1] >= 0);
+}
+
+
+TEST(socket_api_socketpair, protocol_zero_default)
+{
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("#1644");
+#endif
+	/* Specifying a protocol of 0 causes socketpair() to use an unspecified default
+	 * protocol appropriate for the requested socket type */
+	int *sv = test_common.sv;
+	int ret;
+	int optval;
+	socklen_t optlen;
+
+	ret = socketpair(AF_UNIX, SOCK_STREAM, 0, sv);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Verify the socket type is correct */
+	optlen = sizeof(optval);
+	ret = getsockopt(sv[0], SOL_SOCKET, SO_TYPE, &optval, &optlen);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+	TEST_ASSERT_EQUAL_INT(SOCK_STREAM, optval);
+}
+
+
+TEST(socket_api_socketpair, emfile_resource_exhaustion)
+{
+#ifdef __phoenix__
+	TEST_IGNORE_MESSAGE("setrlimit(RLIMIT_NOFILE) not enforced");
+#endif
+	int *sv = test_common.sv;
+	int ret;
+	struct rlimit rl;
+	int dupfds[16];
+	int i;
+
+	for (i = 0; i < 16; i++) {
+		dupfds[i] = -1;
+	}
+
+	/* Lower RLIMIT_NOFILE to a small value to exhaust fd table quickly */
+	ret = getrlimit(RLIMIT_NOFILE, &test_common.oldrl);
+	TEST_ASSERT_EQUAL_INT(0, ret);
+
+	/* Set soft limit to current fd count + 1 so no room for a pair */
+	rl.rlim_cur = 4;
+	rl.rlim_max = test_common.oldrl.rlim_max;
+	ret = setrlimit(RLIMIT_NOFILE, &rl);
+	if (ret != 0) {
+		/* If we can't set rlimit, exhaust by duping */
+		TEST_IGNORE_MESSAGE("Cannot set RLIMIT_NOFILE, skipping EMFILE test");
+	}
+	test_common.rlimit_changed = 1;
+
+	if (TEST_PROTECT()) {
+		/* Use up remaining slots by duping */
+		for (i = 0; i < 16; i++) {
+			dupfds[i] = dup(STDIN_FILENO);
+			if (dupfds[i] < 0) {
+				break;
+			}
+		}
+
+		errno = 0;
+		ret = socketpair(AF_UNIX, SOCK_STREAM, 0, sv);
+		TEST_ASSERT_EQUAL_INT(-1, ret);
+		TEST_ASSERT_EQUAL_INT(EMFILE, errno);
+	}
+	/* Cleanup */
+	for (i = 0; i < 16; i++) {
+		if (dupfds[i] >= 0) {
+			close(dupfds[i]);
+		}
+	}
+}
+
+
+TEST_GROUP_RUNNER(socket_api_socketpair)
+{
+	RUN_TEST_CASE(socket_api_socketpair, stream_success);
+	RUN_TEST_CASE(socket_api_socketpair, dgram_success);
+	RUN_TEST_CASE(socket_api_socketpair, bidirectional_stream);
+	RUN_TEST_CASE(socket_api_socketpair, bidirectional_dgram);
+	RUN_TEST_CASE(socket_api_socketpair, fd_allocation);
+	RUN_TEST_CASE(socket_api_socketpair, eafnosupport_invalid_domain);
+	RUN_TEST_CASE(socket_api_socketpair, eprotonosupport_invalid_protocol);
+	RUN_TEST_CASE(socket_api_socketpair, eopnotsupp_inet);
+	RUN_TEST_CASE(socket_api_socketpair, eprototype_invalid_type);
+	RUN_TEST_CASE(socket_api_socketpair, vector_unmodified_on_error);
+	RUN_TEST_CASE(socket_api_socketpair, seqpacket_success);
+	RUN_TEST_CASE(socket_api_socketpair, protocol_zero_default);
+	RUN_TEST_CASE(socket_api_socketpair, emfile_resource_exhaustion);
+}

--- a/libc/test.yaml
+++ b/libc/test.yaml
@@ -113,3 +113,7 @@ test:
       targets:
         include: [host-generic-pc]
 
+    - name: socket
+      execute: test-libc-socket
+      targets:
+        value: [host-generic-pc, ia32-generic-qemu]


### PR DESCRIPTION
Assisted-by:  Claude Opus 4.6
YT: CI-677

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Adding tests to enforce POSIX compliance of the following libc/socket functions:
* accept
* bind
* connect
* getpeername
* getsockname
* getsockopt
* listen
* recv
* recvfrom
* recvmsg
* send
* sendmsg
* sendto
* setsockopt
* shutdown
* sockatmark
* socketpair

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: host-generic-pc.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
