### PR TITLE
trunner: add option to filter tests to run based on regex

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -157,6 +157,13 @@ def parse_args(targets: Dict[str, Type[TargetBase]], hosts: Dict[str, Type[Host]
     )
 
     parser.add_argument(
+        "-r",
+        "--regex",
+        default=None,
+        help="Run only the tests that match the regex",
+    )
+
+    parser.add_argument(
         "--nightly",
         default=False,
         action="store_true",
@@ -281,6 +288,7 @@ def main():
         stream_output=args.stream,
         output=args.output,
         kwargs=args.kwargs,
+        regex=args.regex,
     )
 
     host_cls = hosts[args.host]

--- a/trunner/ctx.py
+++ b/trunner/ctx.py
@@ -40,3 +40,4 @@ class TestContext:
     kwargs: dict = field(default_factory=dict)
     target: Optional[TargetBase] = None
     host: Optional[Host] = None
+    regex: Optional[str] = None

--- a/trunner/test_runner.py
+++ b/trunner/test_runner.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import sys
+import re
 import junitparser
 from io import StringIO
 from pathlib import Path
@@ -143,6 +144,10 @@ class TestRunner:
         tests = []
         for path in test_yamls:
             tests.extend(parser.parse(path))
+
+        if self.ctx.regex:
+            regex = re.compile(self.ctx.regex)
+            tests = [t for t in tests if regex.search(t.name)]
 
         return tests
 


### PR DESCRIPTION
Allows to isolate test cases from a given yaml, so that e.g.:
```
./docker-devel.sh ./phoenix-rtos-tests/runner.py -v -T riscv64-generic-qemu -S -r "scanf*"
```
runs only the

```
phoenix-rtos-tests/libc/scanf-basic
phoenix-rtos-tests/libc/scanf-advanced
```
test suites.

TASK: CI-21

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [X] Tested by hand on: host

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
