### PR TITLE
libc/socket: fix getsockopt type

### DIFF
--- a/libc/socket/unix-socket.c
+++ b/libc/socket/unix-socket.c
@@ -1458,9 +1458,9 @@ static void unix_accept_connect_liveness_helper(int type)
 		TEST_ASSERT_EQUAL_INT(POLLOUT, fds[0].revents);
 
 		int optval = 0;
-		int optlen = sizeof(optval);
+		socklen_t optlen = sizeof(optval);
 
-		TEST_ASSERT_EQUAL_INT(0, getsockopt(fds[0].fd, SOL_SOCKET, SO_ERROR, &optval, (socklen_t *)&optlen));
+		TEST_ASSERT_EQUAL_INT(0, getsockopt(fds[0].fd, SOL_SOCKET, SO_ERROR, &optval, &optlen));
 
 		fds[0].events = POLLIN;
 		TEST_ASSERT_EQUAL_INT(1, poll(fds, 1, 250));


### PR DESCRIPTION
Type mismatch caused errors due to casting pointer to larger type on 64bit targets.

TASK: RTOS-1365

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
