### PR TITLE
sys: use phMutexLock and phCondWait when checking EINVAL

### DIFF
--- a/sys/cond/cond.c
+++ b/sys/cond/cond.c
@@ -20,6 +20,7 @@
 #include <time.h>
 #include <sys/threads.h>
 #include <sys/time.h>
+#include <phoenix/syscalls.h>
 
 #include <unity_fixture.h>
 
@@ -225,7 +226,8 @@ TEST(condvar_invalid_params, invalid_attr)
 
 TEST(condvar_invalid_params, invalid_cond)
 {
-	TEST_ASSERT_EQUAL_INT(-EINVAL, condWait(-1, -1, 0));
+	/* calling syscall directly here to avoid triggering asserts in libphoenix */
+	TEST_ASSERT_EQUAL_INT(-EINVAL, phCondWait(-1, -1, 0));
 	TEST_ASSERT_EQUAL_INT(-EINVAL, condSignal(-1));
 	TEST_ASSERT_EQUAL_INT(-EINVAL, condBroadcast(-1));
 }

--- a/sys/mutex/mutex.c
+++ b/sys/mutex/mutex.c
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <sys/threads.h>
+#include <phoenix/syscalls.h>
 
 #include <unity_fixture.h>
 
@@ -59,7 +60,8 @@ TEST(mutex_invalid_params, invalid_attr)
 
 TEST(mutex_invalid_params, invalid_mutex)
 {
-	TEST_ASSERT_EQUAL_INT(-EINVAL, mutexLock(-1));
+	/* calling syscall directly here to avoid triggering asserts in libphoenix */
+	TEST_ASSERT_EQUAL_INT(-EINVAL, phMutexLock(-1));
 	TEST_ASSERT_EQUAL_INT(-EINVAL, mutexUnlock(-1));
 	TEST_ASSERT_EQUAL_INT(-EINVAL, resourceDestroy(-1));
 }


### PR DESCRIPTION
libphoenix wrappers assert on invalid handles

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
